### PR TITLE
Redis Supported version wording change

### DIFF
--- a/planning-for-production/database-settings.mdx
+++ b/planning-for-production/database-settings.mdx
@@ -19,7 +19,7 @@ Please consult the [data storage configuration](/api-management/dashboard-config
 ## Redis
 
 **Supported Versions**
-- Tyk 5.3 supports Redis 6.2.x, 7.0.x, and 7.2.x
+- Tyk 5.3 and later supports Redis 6.2.x, 7.0.x, and 7.2.x
 - Tyk 5.2.x and earlier supports Redis 6.0.x and Redis 6.2.x only.
 
 


### PR DESCRIPTION
### **User description**
Changed the Redis Supported wording to align for Tyk versions before, and after Tyk v5.3.0.

Previously was confusing for users when a user would go to the latest documentation, i. Tyk v5.10.0 and the wording would only show Tyk 5.3 .........


___

### **PR Type**
Documentation


___

### **Description**
- Clarify Redis support wording for 5.3+

- Preserve guidance for 5.2.x and earlier


___

### Diagram Walkthrough


```mermaid
flowchart LR
  doc["database-settings.mdx Redis section"] -- "update wording" --> clarity["Clarify versions: 5.3+ vs ≤5.2.x"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>database-settings.mdx</strong><dd><code>Clarify Redis version support wording</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

planning-for-production/database-settings.mdx

<ul><li>Update Redis support phrasing to "5.3 and later".<br> <li> Keep earlier line for 5.2.x and earlier unchanged.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/877/files#diff-583d9723cee8407a2b078c6d6dfe6cb1ff8aaef73ef9281f9e15b05862063e7c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

