### PR TITLE
Merging to release-5.8: [DX-2130] Fix Dashboard Swagger Policies API Example Request Body (#899)

### DIFF
--- a/swagger/dashboard-swagger.yml
+++ b/swagger/dashboard-swagger.yml
@@ -7076,7 +7076,7 @@ paths:
           application/json:
             example:
               access_rights:
-                Itachi API:
+                8ddd91f3cda9453442c477b06c4e2da4:
                   allowed_urls:
                   - methods:
                     - GET
@@ -7260,7 +7260,7 @@ paths:
             application/json:
               example:
                 access_rights:
-                  Itachi API:
+                  8ddd91f3cda9453442c477b06c4e2da4:
                     allowed_urls:
                     - methods:
                       - GET
@@ -7365,7 +7365,7 @@ paths:
           application/json:
             example:
               access_rights:
-                Itachi API:
+                8ddd91f3cda9453442c477b06c4e2da4:
                   allowed_urls:
                   - methods:
                     - GET


### PR DESCRIPTION
### **User description**
[DX-2130] Fix Dashboard Swagger Policies API Example Request Body (#899)

[DX-2130]: https://tyktech.atlassian.net/browse/DX-2130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Use API IDs in policy examples

- Replace name keys with UUID keys

- Align POST/GET/PUT examples consistently

- Update dashboard Swagger examples only


___

### Diagram Walkthrough


```mermaid
flowchart LR
  swagger["dashboard-swagger.yml examples"]
  nameKeys["Name-based access_rights keys"]
  idKeys["UUID-based access_rights keys"]

  swagger -- "replace example keys" --> idKeys
  nameKeys -- "deprecated in examples" --> idKeys
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashboard-swagger.yml</strong><dd><code>Switch policy examples to UUID-keyed access_rights</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

swagger/dashboard-swagger.yml

<ul><li>Replace access_rights keys from API name to UUID.<br> <li> Update POST policies request example to use API ID.<br> <li> Update GET policies response example to use API ID.<br> <li> Update PUT policies request example to use API ID.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/902/files#diff-cd11037f1b637fba4caa84f0430c6a346bb50ff05d0b0948ef99b2aad7b8690a">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

