### PR TITLE
Release notes wording to align with other Tyk Component Release notes

### DIFF
--- a/developer-support/release-notes/portal.mdx
+++ b/developer-support/release-notes/portal.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Tyk Enterprise Developer Portal Release Notes"
-description: "Release notes documenting updates, enhancements and changes for Tyk Enterprise Developer Portal v1.13.0"
-keywords: "Developer Portal, Release notes, changelog, v1.13.0"
+description: "Release notes documenting updates, enhancements and changes for Tyk Enterprise Developer Portal"
+keywords: "Developer Portal, Release notes, changelog"
 order: 7
 sidebarTitle: "Release Notes"
 canonical: "https://tyk.io/docs/developer-support/release-notes/portal"


### PR DESCRIPTION
### **User description**
Got rid of `v1.13.0` in the description and keywords of the release notes for Portal. v1.13.0 was showing at the beginning of the page and then the release notes would continue to show items for the latest release, i.e v1.15.0....

It not aligns with Gateway release notes wording.


___

### **PR Type**
Documentation


___

### **Description**
- Remove version from portal release notes metadata

- Update description and keywords for consistency

- Align wording with other Tyk components


___

### Diagram Walkthrough


```mermaid
flowchart LR
  portalMeta["Portal release notes metadata"] -- "remove hardcoded version" --> cleanDesc["Generic description/keywords"]
  cleanDesc -- "consistency" --> components["Align with other components"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>portal.mdx</strong><dd><code>Strip version from release notes frontmatter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

developer-support/release-notes/portal.mdx

<ul><li>Remove "v1.13.0" from description<br> <li> Remove "v1.13.0" from keywords<br> <li> Keep remaining frontmatter unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1074/files#diff-307750e7d89398f23197302444997499233512d427b190e1eaa3c8c4464c82e5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

