### PR TITLE
Merging to release-5.8: [DX-2171] Fixed Graceful Shutdown env variable (#1067)

### DIFF
--- a/planning-for-production/ensure-high-availability/graceful-shutdown.mdx
+++ b/planning-for-production/ensure-high-availability/graceful-shutdown.mdx
@@ -15,7 +15,7 @@ Tyk Gateway includes a graceful shutdown mechanism that ensures clean terminatio
 
 ### Configuration
 
-Add the [graceful_shutdown_timeout_duration](/tyk-oss-gateway/configuration#graceful_shutdown_timeout_duration) parameter to your Tyk Gateway configuration file (or set the environment variable `TYK_GW_GRACEFUL_SHUTDOWN_TIMEOUT_DURATION`):
+Add the [graceful_shutdown_timeout_duration](/tyk-oss-gateway/configuration#graceful_shutdown_timeout_duration) parameter to your Tyk Gateway configuration file (or set the environment variable `TYK_GW_GRACEFULSHUTDOWNTIMEOUTDURATION`):
 
 ```json
 {


### PR DESCRIPTION
### **User description**
[DX-2171] Fixed Graceful Shutdown env variable (#1067)

[DX-2171]: https://tyktech.atlassian.net/browse/DX-2171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Fix graceful shutdown env var name

- Update docs to correct example


___

### Diagram Walkthrough


```mermaid
flowchart LR
  docs["Graceful shutdown docs"] -- "fix env var name" --> env["Use `TYK_GW_GRACEFULSHUTDOWNTIMEOUTDURATION`"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>graceful-shutdown.mdx</strong><dd><code>Fix graceful shutdown env var reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

planning-for-production/ensure-high-availability/graceful-shutdown.mdx

<ul><li>Replace incorrect env var string<br> <li> Now references <code>TYK_GW_GRACEFULSHUTDOWNTIMEOUTDURATION</code></ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1104/files#diff-95d52b942c7b47a79f29c6c2f4f88fa38df7d642a676905e5d2bd641affcb623">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

