### PR TITLE
🤖 Auto-merge documentation from branches

### DIFF
--- a/5.8/planning-for-production/ensure-high-availability/graceful-shutdown.mdx
+++ b/5.8/planning-for-production/ensure-high-availability/graceful-shutdown.mdx
@@ -16,7 +16,7 @@ Tyk Gateway includes a graceful shutdown mechanism that ensures clean terminatio
 
 ### Configuration
 
-Add the [graceful_shutdown_timeout_duration](/5.8/tyk-oss-gateway/configuration#graceful_shutdown_timeout_duration) parameter to your Tyk Gateway configuration file (or set the environment variable `TYK_GW_GRACEFUL_SHUTDOWN_TIMEOUT_DURATION`):
+Add the [graceful_shutdown_timeout_duration](/5.8/tyk-oss-gateway/configuration#graceful_shutdown_timeout_duration) parameter to your Tyk Gateway configuration file (or set the environment variable `TYK_GW_GRACEFULSHUTDOWNTIMEOUTDURATION`):
 
 ```json
 {

--- a/nightly/planning-for-production/ensure-high-availability/graceful-shutdown.mdx
+++ b/nightly/planning-for-production/ensure-high-availability/graceful-shutdown.mdx
@@ -16,7 +16,7 @@ Tyk Gateway includes a graceful shutdown mechanism that ensures clean terminatio
 
 ### Configuration
 
-Add the [graceful_shutdown_timeout_duration](/nightly/tyk-oss-gateway/configuration#graceful_shutdown_timeout_duration) parameter to your Tyk Gateway configuration file (or set the environment variable `TYK_GW_GRACEFUL_SHUTDOWN_TIMEOUT_DURATION`):
+Add the [graceful_shutdown_timeout_duration](/nightly/tyk-oss-gateway/configuration#graceful_shutdown_timeout_duration) parameter to your Tyk Gateway configuration file (or set the environment variable `TYK_GW_GRACEFULSHUTDOWNTIMEOUTDURATION`):
 
 ```json
 {

--- a/planning-for-production/ensure-high-availability/graceful-shutdown.mdx
+++ b/planning-for-production/ensure-high-availability/graceful-shutdown.mdx
@@ -16,7 +16,7 @@ Tyk Gateway includes a graceful shutdown mechanism that ensures clean terminatio
 
 ### Configuration
 
-Add the [graceful_shutdown_timeout_duration](/tyk-oss-gateway/configuration#graceful_shutdown_timeout_duration) parameter to your Tyk Gateway configuration file (or set the environment variable `TYK_GW_GRACEFUL_SHUTDOWN_TIMEOUT_DURATION`):
+Add the [graceful_shutdown_timeout_duration](/tyk-oss-gateway/configuration#graceful_shutdown_timeout_duration) parameter to your Tyk Gateway configuration file (or set the environment variable `TYK_GW_GRACEFULSHUTDOWNTIMEOUTDURATION`):
 
 ```json
 {


### PR DESCRIPTION
### **User description**
## 📚 Documentation Merge Summary

This PR contains automatically merged documentation from multiple branches.

**Triggered by:**
- **Branch:** release-5.8
- **Commit:** faed4b986c07f5375815727c0b96e376198a86fb
- **PR:** #1104 - Merging to release-5.8: [DX-2171] Fixed Graceful Shutdown env variable (#1067) (cherry-pick of #1067)

**Deployment Details:**
- **Generated from:** `branches-config.json`  
- **Run ID:** 19918757525
- **Subfolder:** `(root deployment)`
- **Timestamp:** $(date)

### Changes Include:
- ✅ Merged documentation from multiple branches
- ✅ Generated unified `docs.json` configuration
- ✅ Updated assets and content structure
- ✅ Cleaned up outdated version folders

---

🚦 **This PR will be processed by merge queue to ensure proper validation and ordering.**

Previous deployment PRs have been automatically closed to prevent conflicts.

[DX-2171]: https://tyktech.atlassian.net/browse/DX-2171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Correct graceful shutdown env variable

- Update docs across versions

- Align examples with config key


___

### Diagram Walkthrough


```mermaid
flowchart LR
  docs58["5.8 graceful-shutdown docs"] -- "fix env var" --> env58["Use `TYK_GW_GRACEFULSHUTDOWNTIMEOUTDURATION`"]
  docsNightly["nightly graceful-shutdown docs"] -- "fix env var" --> envNightly["Use `TYK_GW_GRACEFULSHUTDOWNTIMEOUTDURATION`"]
  docsRoot["root graceful-shutdown docs"] -- "fix env var" --> envRoot["Use `TYK_GW_GRACEFULSHUTDOWNTIMEOUTDURATION`"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>graceful-shutdown.mdx</strong><dd><code>Fix env var in 5.8 graceful shutdown docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

5.8/planning-for-production/ensure-high-availability/graceful-shutdown.mdx

<ul><li>Replace incorrect env var string<br> <li> Now uses <code>TYK_GW_GRACEFULSHUTDOWNTIMEOUTDURATION</code></ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1106/files#diff-d67d9eac702aef660bff070dcc761f62110f4113ecc0c8482c7c792a7b977007">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>graceful-shutdown.mdx</strong><dd><code>Fix env var in nightly graceful shutdown docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nightly/planning-for-production/ensure-high-availability/graceful-shutdown.mdx

<ul><li>Replace incorrect env var string<br> <li> Now uses <code>TYK_GW_GRACEFULSHUTDOWNTIMEOUTDURATION</code></ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1106/files#diff-9ba39a6fe881833f052a05e8891b91b3fc12dff0207b7933dab59df356e5c78d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>graceful-shutdown.mdx</strong><dd><code>Fix env var in root graceful shutdown docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

planning-for-production/ensure-high-availability/graceful-shutdown.mdx

<ul><li>Replace incorrect env var string<br> <li> Now uses <code>TYK_GW_GRACEFULSHUTDOWNTIMEOUTDURATION</code></ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1106/files#diff-95d52b942c7b47a79f29c6c2f4f88fa38df7d642a676905e5d2bd641affcb623">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

