### PR TITLE
[DX-2179] docs: fix Content-Type in Swagger for Streams API endpoints

### DIFF
--- a/swagger/dashboard-swagger.yml
+++ b/swagger/dashboard-swagger.yml
@@ -1990,7 +1990,7 @@ paths:
             enum: ["application/vnd.tyk.streams.oas"]
       requestBody:
         content:
-          application/json:
+          application/vnd.tyk.streams.oas:
             examples:
               StreamsAPIExample:
                 $ref: "#/components/examples/streamsExample"
@@ -2242,7 +2242,7 @@ paths:
         - $ref: '#/components/parameters/Authentication'
       requestBody:
         content:
-          application/json:
+          application/vnd.tyk.streams.oas:
             examples:
               PatchOASExample:
                 $ref: "#/components/examples/streamsExample"
@@ -2335,7 +2335,7 @@ paths:
             type: string
       requestBody:
         content:
-          application/json:
+          application/vnd.tyk.streams.oas:
             examples:
               StreamsAPIExample:
                 $ref: "#/components/examples/streamsExample"


### PR DESCRIPTION
### **User description**
## Summary
- Fixed the OpenAPI `requestBody` content type for Streams API endpoints to use `application/vnd.tyk.streams.oas` instead of `application/json`
- Affected endpoints: POST `/api/apis/streams`, PATCH `/api/apis/streams/{apiId}`, PUT `/api/apis/streams/{apiId}`
- The Content-Type was already documented as a required header parameter but the requestBody section incorrectly used `application/json`

## Related Jira
DX-2179 - Incorrect Content-Type for Streams API Not Documented

## Related PRs
- TykTechnologies/tyk-analytics#5129 (same fix in the source swagger.yml)

## Test plan
- [ ] Verify Swagger documentation correctly shows `application/vnd.tyk.streams.oas` as the expected Content-Type for request bodies
- [ ] Verify existing curl examples in documentation still work with the documented Content-Type

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Documentation


___

### **Description**
- Fix Streams requestBody content type

- Use `application/vnd.tyk.streams.oas`

- Align requestBody with header parameter


___

### Diagram Walkthrough


```mermaid
flowchart LR
  HeaderParam["Streams header parameter: vnd.tyk.streams.oas"] -- "align content type" --> RequestBody["requestBody content: vnd.tyk.streams.oas"]
  Endpoints["POST/PATCH/PUT /api/apis/streams"] -- "update media type keys" --> RequestBody
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashboard-swagger.yml</strong><dd><code>Align Streams requestBody media type with required header</code></dd></summary>
<hr>

swagger/dashboard-swagger.yml

<ul><li>Replace <code>application/json</code> with <code>application/vnd.tyk.streams.oas</code> in <br>requestBody.<br> <li> Update for POST, PATCH, PUT Streams endpoints.<br> <li> Keep examples and schemas unchanged.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1118/files#diff-cd11037f1b637fba4caa84f0430c6a346bb50ff05d0b0948ef99b2aad7b8690a">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

