### PR TITLE
Merging to release-5.10: [DX-2179] docs: fix Content-Type in Swagger for Streams API endpoints (#1118)

### DIFF
--- a/swagger/dashboard-swagger.yml
+++ b/swagger/dashboard-swagger.yml
@@ -1990,7 +1990,7 @@ paths:
             enum: ["application/vnd.tyk.streams.oas"]
       requestBody:
         content:
-          application/json:
+          application/vnd.tyk.streams.oas:
             examples:
               StreamsAPIExample:
                 $ref: "#/components/examples/streamsExample"
@@ -2242,7 +2242,7 @@ paths:
         - $ref: '#/components/parameters/Authentication'
       requestBody:
         content:
-          application/json:
+          application/vnd.tyk.streams.oas:
             examples:
               PatchOASExample:
                 $ref: "#/components/examples/streamsExample"
@@ -2335,7 +2335,7 @@ paths:
             type: string
       requestBody:
         content:
-          application/json:
+          application/vnd.tyk.streams.oas:
             examples:
               StreamsAPIExample:
                 $ref: "#/components/examples/streamsExample"


### PR DESCRIPTION
[DX-2179] docs: fix Content-Type in Swagger for Streams API endpoints (#1118)

[DX-2179]: https://tyktech.atlassian.net/browse/DX-2179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ