### PR TITLE
Merging to release-5.8: [DX-2179] docs: fix Content-Type in Swagger for Streams API endpoints (#1118)

### DIFF
--- a/swagger/dashboard-swagger.yml
+++ b/swagger/dashboard-swagger.yml
@@ -1988,7 +1988,7 @@ paths:
             enum: ["application/vnd.tyk.streams.oas"]
       requestBody:
         content:
-          application/json:
+          application/vnd.tyk.streams.oas:
             examples:
               StreamsAPIExample:
                 $ref: "#/components/examples/streamsExample"
@@ -2240,7 +2240,7 @@ paths:
         - $ref: '#/components/parameters/Authentication'
       requestBody:
         content:
-          application/json:
+          application/vnd.tyk.streams.oas:
             examples:
               PatchOASExample:
                 $ref: "#/components/examples/streamsExample"
@@ -2333,7 +2333,7 @@ paths:
             type: string
       requestBody:
         content:
-          application/json:
+          application/vnd.tyk.streams.oas:
             examples:
               StreamsAPIExample:
                 $ref: "#/components/examples/streamsExample"


### PR DESCRIPTION
### **User description**
[DX-2179] docs: fix Content-Type in Swagger for Streams API endpoints (#1118)

[DX-2179]: https://tyktech.atlassian.net/browse/DX-2179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Fix Streams requestBody content type

- Use application/vnd.tyk.streams.oas

- Update POST/PATCH/PUT Streams endpoints

- Align requestBody with header enum


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Header["Header param enum: vnd.tyk.streams.oas"]
  Body["requestBody media type: vnd.tyk.streams.oas"]
  Endpoints["POST/PATCH/PUT /api/apis/streams"]

  Header -- "already correct" --> Endpoints
  Endpoints -- "update media type" --> Body
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashboard-swagger.yml</strong><dd><code>Align Streams requestBody media type with header</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

swagger/dashboard-swagger.yml

<ul><li>Replace requestBody media type keys.<br> <li> Use <code>application/vnd.tyk.streams.oas</code> instead of JSON.<br> <li> Apply to POST, PATCH, PUT Streams endpoints.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1121/files#diff-cd11037f1b637fba4caa84f0430c6a346bb50ff05d0b0948ef99b2aad7b8690a">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

