### PR TITLE
🤖 Auto-merge documentation from branches

### DIFF
--- a/swagger/5.10/dashboard-swagger.yml
+++ b/swagger/5.10/dashboard-swagger.yml
@@ -1990,7 +1990,7 @@ paths:
             enum: ["application/vnd.tyk.streams.oas"]
       requestBody:
         content:
-          application/json:
+          application/vnd.tyk.streams.oas:
             examples:
               StreamsAPIExample:
                 $ref: "#/components/examples/streamsExample"
@@ -2242,7 +2242,7 @@ paths:
         - $ref: '#/components/parameters/Authentication'
       requestBody:
         content:
-          application/json:
+          application/vnd.tyk.streams.oas:
             examples:
               PatchOASExample:
                 $ref: "#/components/examples/streamsExample"
@@ -2335,7 +2335,7 @@ paths:
             type: string
       requestBody:
         content:
-          application/json:
+          application/vnd.tyk.streams.oas:
             examples:
               StreamsAPIExample:
                 $ref: "#/components/examples/streamsExample"

--- a/swagger/5.8/dashboard-swagger.yml
+++ b/swagger/5.8/dashboard-swagger.yml
@@ -1988,7 +1988,7 @@ paths:
             enum: ["application/vnd.tyk.streams.oas"]
       requestBody:
         content:
-          application/json:
+          application/vnd.tyk.streams.oas:
             examples:
               StreamsAPIExample:
                 $ref: "#/components/examples/streamsExample"
@@ -2240,7 +2240,7 @@ paths:
         - $ref: '#/components/parameters/Authentication'
       requestBody:
         content:
-          application/json:
+          application/vnd.tyk.streams.oas:
             examples:
               PatchOASExample:
                 $ref: "#/components/examples/streamsExample"
@@ -2333,7 +2333,7 @@ paths:
             type: string
       requestBody:
         content:
-          application/json:
+          application/vnd.tyk.streams.oas:
             examples:
               StreamsAPIExample:
                 $ref: "#/components/examples/streamsExample"

--- a/swagger/nightly/dashboard-swagger.yml
+++ b/swagger/nightly/dashboard-swagger.yml
@@ -1990,7 +1990,7 @@ paths:
             enum: ["application/vnd.tyk.streams.oas"]
       requestBody:
         content:
-          application/json:
+          application/vnd.tyk.streams.oas:
             examples:
               StreamsAPIExample:
                 $ref: "#/components/examples/streamsExample"
@@ -2242,7 +2242,7 @@ paths:
         - $ref: '#/components/parameters/Authentication'
       requestBody:
         content:
-          application/json:
+          application/vnd.tyk.streams.oas:
             examples:
               PatchOASExample:
                 $ref: "#/components/examples/streamsExample"
@@ -2335,7 +2335,7 @@ paths:
             type: string
       requestBody:
         content:
-          application/json:
+          application/vnd.tyk.streams.oas:
             examples:
               StreamsAPIExample:
                 $ref: "#/components/examples/streamsExample"


### PR DESCRIPTION
### **User description**
## 📚 Documentation Merge Summary

This PR contains automatically merged documentation from multiple branches.

**Triggered by:**
- **Branch:** release-5.8
- **Commit:** 0550f5070ea5079dba750c9b7de8be477719e127
- **PR:** #1121 - Merging to release-5.8: [DX-2179] docs: fix Content-Type in Swagger for Streams API endpoints (#1118) (cherry-pick of #1118)

**Deployment Details:**
- **Generated from:** `branches-config.json`  
- **Run ID:** 19955944235
- **Subfolder:** `(root deployment)`
- **Timestamp:** $(date)

### Changes Include:
- ✅ Merged documentation from multiple branches
- ✅ Generated unified `docs.json` configuration
- ✅ Updated assets and content structure
- ✅ Cleaned up outdated version folders

---

🚦 **This PR will be processed by merge queue to ensure proper validation and ordering.**

Previous deployment PRs have been automatically closed to prevent conflicts.

[DX-2179]: https://tyktech.atlassian.net/browse/DX-2179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Set Streams requestBody media type correctly

- Use application/vnd.tyk.streams.oas instead of JSON

- Update POST/PATCH/PUT Streams endpoints

- Align requestBody with required header enum


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Header["Header enum: application/vnd.tyk.streams.oas"]
  Body["requestBody: application/vnd.tyk.streams.oas"]
  Endpoints["Streams endpoints: POST/PATCH/PUT"]
  Header -- "already required" --> Endpoints
  Endpoints -- "update media type" --> Body
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashboard-swagger.yml</strong><dd><code>Use Streams OAS content type for bodies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

swagger/5.10/dashboard-swagger.yml

<ul><li>Replace requestBody media type to Streams OAS.<br> <li> Apply to POST/PATCH/PUT Streams endpoints.<br> <li> Keep examples and schemas unchanged.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1123/files#diff-1ea547ff47a8fb6adf1364eb42da93d81b6f935e1fe1f05b528732e3901a2b18">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dashboard-swagger.yml</strong><dd><code>Align Streams requestBody media type (5.8)</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

swagger/5.8/dashboard-swagger.yml

<ul><li>Switch requestBody media type from JSON.<br> <li> Set to application/vnd.tyk.streams.oas.<br> <li> Applied across Streams POST/PATCH/PUT.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1123/files#diff-5d93f1375c48b9f29d087d74b3b571adffd58eb10acce4b20dba26de978f918f">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dashboard-swagger.yml</strong><dd><code>Nightly: correct Streams requestBody media type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

swagger/nightly/dashboard-swagger.yml

<ul><li>Update requestBody media type to Streams OAS.<br> <li> Change for POST/PATCH/PUT endpoints.<br> <li> Preserve examples/schemas references.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1123/files#diff-556d37086daf0b5a459da7de8862efe90791f8b6e68e31d6d8fdaa83e6a1b2be">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

