### PR TITLE
[DX-2128] docs: clarify TYK_GW_USEREDISLOG requires shared Redis instance

### DIFF
--- a/snippets/gateway-config.mdx
+++ b/snippets/gateway-config.mdx
@@ -1960,6 +1960,12 @@ Type: `bool`<br />
 
 Enables the real-time Gateway log view in the Dashboard.
 
+<Note>
+
+For logs to appear in the Tyk Dashboard, both the Gateway and the Dashboard must be configured to use the **same Redis instance**. In deployments where the Data Plane (Gateway) and Control Plane (Dashboard) use separate Redis instances, enabling this option on the Gateway will not make logs available in the Dashboard.
+
+</Note>
+
 ### use_sentry
 ENV: <b>TYK_GW_USESENTRY</b><br />
 Type: `bool`<br />


### PR DESCRIPTION
## Summary

- Added a clarification note to the `use_redis_log` (TYK_GW_USEREDISLOG) configuration documentation
- The note explains that for Gateway logs to appear in the Dashboard, both the Gateway and Dashboard must be configured to use the **same Redis instance**
- Clarifies that in Data Plane/Control Plane deployments with separate Redis instances, enabling this option will not make logs available in the Dashboard

## Test plan

- [ ] Review the rendered documentation in the Mintlify preview
- [ ] Verify the Note component renders correctly

## Related Issues

Fixes: DX-2128

🤖 Generated with [Claude Code](https://claude.com/claude-code)