### PR TITLE
docs(DX-2061): add environment variable type mapping documentation

### DIFF
--- a/product-stack/tyk-enterprise-developer-portal/deploy/configuration.mdx
+++ b/product-stack/tyk-enterprise-developer-portal/deploy/configuration.mdx
@@ -5,8 +5,13 @@ keywords: "Configure Tyk Enterprise Developer Portal, Tyk Enterprise Developer P
 sidebarTitle: "Environment Variables and Configs"
 ---
 
+import EnvTypeMapping from '/snippets/env-type-mapping.mdx';
+
 To configure the Tyk Enterprise Developer Portal, you can use either a config file or environment variables.
 The table below provides a reference to all options available to you when configuring the portal.
+
+<EnvTypeMapping/>
+
 ## Portal settings
 This section explains the general portal settings, including which port it will be listening on, how often it should synchronize API Products and plans with the Tyk Dashboard, and so on.
 Most of these settings are optional, except for the PORTAL_LICENSEKEY. If you don't specify these settings, the default values will be used.

--- a/snippets/env-type-mapping.mdx
+++ b/snippets/env-type-mapping.mdx
@@ -1,0 +1,16 @@
+## Environment Variable Type Mapping
+
+When configuring Tyk components using environment variables, it's important to understand how different data types are represented. The type of each variable is based on its definition in the Go source code. This section provides a guide on how to format values for common data types.
+
+| Go Type                 | Environment Variable Format        | Example                                                              |
+| ----------------------- | ---------------------------------- | -------------------------------------------------------------------- |
+| `string`                | A regular string of text.          | `TYK_GW_SECRET="mysecret"`                                           |
+| `int`, `int64`          | A whole number.                    | `TYK_GW_LISTENPORT=8080`                                               |
+| `bool`                  | `true` or `false`.                 | `TYK_GW_USEDBAPPCONFIG=true`                                         |
+| `[]string`              | A comma-separated list of strings. | `TYK_PMP_PUMPS_STDOUT_FILTERS_SKIPPEDAPIIDS="api1,api2,api3"`        |
+| `map[string]string`     | A comma-separated list of key:value pairs. | `TYK_GW_GLOBALHEADERS="X-Tyk-Test:true,X-Tyk-Version:1.0"`           |
+| `map[string]interface{}` | A JSON string representing the object. | `TYK_GW_POLICIES_POLICYSOURCE_CONFIG='{"connection_string": "..."}'` |
+
+<Note>
+For complex types like `map[string]interface{}`, the value should be a valid JSON string. For `[]string` and `map[string]string`, ensure there are no spaces around the commas unless they are part of the value itself.
+</Note>

--- a/snippets/env-type-mapping.mdx
+++ b/snippets/env-type-mapping.mdx
@@ -1,4 +1,4 @@
-## Environment Variable Type Mapping
+### Environment Variable Type Mapping
 
 When configuring Tyk components using environment variables, it's important to understand how different data types are represented. The type of each variable is based on its definition in the Go source code. This section provides a guide on how to format values for common data types.
 

--- a/tyk-configuration-reference/tyk-identity-broker-configuration.mdx
+++ b/tyk-configuration-reference/tyk-identity-broker-configuration.mdx
@@ -5,6 +5,8 @@ order: 3
 sidebarTitle: "Tyk Identity Broker"
 ---
 
+import EnvTypeMapping from '/snippets/env-type-mapping.mdx';
+
 The Tyk Identity Broker (TIB) is configured through two files: The configuration file `tib.conf` and the profiles file `profiles.json`. TIB can also be managed via the [TIB REST API](/tyk-identity-broker/tib-rest-api) for automated configurations.
 
 #### The `tib.conf` file
@@ -55,6 +57,8 @@ From TIB v1.3.1, the environment variable `TYK_IB_OMITCONFIGFILE` is provided to
 
 If set to TRUE, then TIB will ignore any provided configuration file and set its parameters according to environment variables. TIB will fall back to the default value for any parameters not set in an environment variable.
 This is particularly useful when using Docker, as this option will ensure that TIB will load the configuration via env vars and not expect a configuration file.
+
+<EnvTypeMapping/>
 
 The various options for `tib.conf` file are:
 

--- a/tyk-configuration-reference/tyk-identity-broker-configuration.mdx
+++ b/tyk-configuration-reference/tyk-identity-broker-configuration.mdx
@@ -9,7 +9,7 @@ import EnvTypeMapping from '/snippets/env-type-mapping.mdx';
 
 The Tyk Identity Broker (TIB) is configured through two files: The configuration file `tib.conf` and the profiles file `profiles.json`. TIB can also be managed via the [TIB REST API](/tyk-identity-broker/tib-rest-api) for automated configurations.
 
-#### The `tib.conf` file
+### The `tib.conf` file
 
 ```{.copyWrapper}
 {

--- a/tyk-dashboard/configuration.mdx
+++ b/tyk-dashboard/configuration.mdx
@@ -6,6 +6,7 @@ sidebarTitle: "Dashboard"
 ---
 
 import DashboardConfig from '/snippets/dashboard-config.mdx';
+import EnvTypeMapping from '/snippets/env-type-mapping.mdx';
 
 You can use environment variables to override the config file for the Tyk Dashboard. The Dashboard configuration file can be found in the `tyk-dashboard` folder and by default is called `tyk_analytics.conf`, though it can be renamed and specified using the `--conf` flag. Environment variables are created from the dot notation versions of the JSON objects contained with the config files.
 To understand how the environment variables notation works, see [Environment Variables](/tyk-oss-gateway/configuration).
@@ -19,6 +20,8 @@ Please consult the [data storage configuration](/api-management/dashboard-config
 ### Environment Variables
 
 All the Dashboard environment variables have the prefix `TYK_DB_`. The environment variables will take precedence over the values in the configuration file.
+
+<EnvTypeMapping/>
 
 Environment variables (env var) can be used to override the settings defined in the configuration file. Where an environment variable is specified, its value will take precedence over the value in the configuration file.
 

--- a/tyk-multi-data-centre/mdcb-configuration-options.mdx
+++ b/tyk-multi-data-centre/mdcb-configuration-options.mdx
@@ -7,6 +7,7 @@ sidebarTitle: "Multi Data Center Bridge"
 ---
 
 import MdcbConfig from '/snippets/mdcb-config.mdx';
+import EnvTypeMapping from '/snippets/env-type-mapping.mdx';
 
 ## Tyk MDCB Configuration
 
@@ -15,6 +16,8 @@ The Tyk MDCB server is configured primarily via the `tyk_sink.conf` file, this f
 ### Environment Variables
 
 Environment variables (env var) can be used to override the settings defined in the configuration file. Where an environment variable is specified, its value will take precedence over the value in the configuration file.
+
+<EnvTypeMapping/>
 
 ### Default Ports
 

--- a/tyk-oss-gateway/configuration.mdx
+++ b/tyk-oss-gateway/configuration.mdx
@@ -6,11 +6,14 @@ sidebarTitle: "Gateway"
 ---
 
 import GatewayConfig from '/snippets/gateway-config.mdx';
+import EnvTypeMapping from '/snippets/env-type-mapping.mdx';
 
 You can use environment variables to override the config file for the Tyk Gateway. The Gateway configuration file can be found in the `tyk-gateway` folder and by default is called `tyk.conf`, though it can be renamed and specified using the `--conf` flag. Environment variables are created from the dot notation versions of the JSON objects contained with the config files.
 To understand how the environment variables notation works, see [Environment Variables](/tyk-oss-gateway/configuration).
 
 All the Gateway environment variables have the prefix `TYK_GW_`. The environment variables will take precedence over the values in the configuration file.
+
+<EnvTypeMapping/>
 
 ### tyk lint
 

--- a/tyk-pump/tyk-pump-configuration/tyk-pump-environment-variables.mdx
+++ b/tyk-pump/tyk-pump-configuration/tyk-pump-environment-variables.mdx
@@ -7,10 +7,13 @@ sidebarTitle: "Pump"
 ---
 
 import PumpConfig from '/snippets/pump-config.mdx';
+import EnvTypeMapping from '/snippets/env-type-mapping.mdx';
 
 You can use environment variables to override the config file for the Tyk Pump. Environment variables are created from the dot notation versions of the JSON objects contained with the config files.
 To understand how the environment variables notation works, see [Environment Variables](/tyk-oss-gateway/configuration). 
 
 All the Pump environment variables have the prefix `TYK_PMP_`. The environment variables will take precedence over the values in the configuration file.
+
+<EnvTypeMapping/>
 
 <PumpConfig/>


### PR DESCRIPTION
### **User description**
## Summary

- Add a centralized snippet (`snippets/env-type-mapping.mdx`) explaining how Go types map to environment variable formats
- This clarifies the expected format for array types like `[]string`, which should be comma-separated values rather than JSON arrays
- The snippet is included in all configuration documentation pages for consistency

## Context

This PR addresses the confusion reported in DX-2061, where the documentation for `TYK_PMP_PUMPS_STDOUT_FILTERS_SKIPPEDAPIIDS` (type `[]string`) was unclear, potentially leading users to incorrectly use JSON array format when a comma-separated string is expected.

## Changes

### New Files
- `snippets/env-type-mapping.mdx` - A reusable snippet with a type mapping table

### Modified Files
- `tyk-oss-gateway/configuration.mdx`
- `tyk-dashboard/configuration.mdx`
- `tyk-pump/tyk-pump-configuration/tyk-pump-environment-variables.mdx`
- `tyk-multi-data-centre/mdcb-configuration-options.mdx`
- `tyk-configuration-reference/tyk-identity-broker-configuration.mdx`
- `product-stack/tyk-enterprise-developer-portal/deploy/configuration.mdx`

## Test Plan

- [ ] Verify the snippet renders correctly on each documentation page
- [ ] Confirm the type mapping table is clear and accurate
- [ ] Test that the documentation builds without errors

Closes DX-2061

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Documentation


___

### **Description**
- Add reusable env type mapping snippet

- Include snippet across config docs

- Clarify []string uses comma-separated values

- Document map and JSON formatting rules


___

### Diagram Walkthrough


```mermaid
flowchart LR
  SNIPPET["New snippet: env-type-mapping.mdx"]
  GW["Gateway configuration docs"]
  DB["Dashboard configuration docs"]
  PUMP["Pump configuration docs"]
  MDCB["MDCB configuration docs"]
  TIB["Identity Broker configuration docs"]
  PORTAL["Enterprise Developer Portal configuration docs"]

  SNIPPET -- "import + <EnvTypeMapping/>" --> GW
  SNIPPET -- "import + <EnvTypeMapping/>" --> DB
  SNIPPET -- "import + <EnvTypeMapping/>" --> PUMP
  SNIPPET -- "import + <EnvTypeMapping/>" --> MDCB
  SNIPPET -- "import + <EnvTypeMapping/>" --> TIB
  SNIPPET -- "import + <EnvTypeMapping/>" --> PORTAL
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>env-type-mapping.mdx</strong><dd><code>Add reusable environment variable type mapping table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1134/files#diff-b1a8da9371ed141092da52b8c22eb1bc2503e45d94ea06c3777bd4264c2f6791">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>configuration.mdx</strong><dd><code>Import and render env type mapping snippet</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1134/files#diff-266b6843d3b658657bfb6bb235e2fdb95df65144d3301f3bda7c6ef8fefcaa55">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>configuration.mdx</strong><dd><code>Import and insert env type mapping guidance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1134/files#diff-6f842fc27a19418ff86a8a9a5381873547c26d36754d11ee0995b0a035252bca">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tyk-pump-environment-variables.mdx</strong><dd><code>Add env type mapping to Pump config docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1134/files#diff-5ac3df8b6cc14c2fd8805fba214011f60a097b57f68aae017f7eef0269abec16">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mdcb-configuration-options.mdx</strong><dd><code>Include env type mapping in MDCB docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1134/files#diff-0eccb01bb821e41fa556bde80d7fc16143c87f6668629ab96e143162fab882ca">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tyk-identity-broker-configuration.mdx</strong><dd><code>Insert env type mapping into TIB config page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1134/files#diff-f60c93bd9894baf0a34b5f118b10f6809a2591e7d145ff05b1ef4361325424b2">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>configuration.mdx</strong><dd><code>Import and display env type mapping in Portal docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1134/files#diff-99e43dfea88c4257cd7245cf500d72ba7ffda9170f97dbd41cb3a1a8d11ad8ad">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

