### PR TITLE
[DX-2045] docs: clarify TYK_GW_MAXIDLECONNSPERHOST default value and recommendation

### DIFF
--- a/snippets/gateway-config.mdx
+++ b/snippets/gateway-config.mdx
@@ -938,7 +938,7 @@ Maximum idle connections, per API, between Tyk and Upstream. By default not limi
 ENV: <b>TYK_GW_MAXIDLECONNSPERHOST</b><br />
 Type: `int`<br />
 
-Maximum idle connections, per API, per upstream, between Tyk and Upstream. Default:100
+Maximum idle connections, per API, per upstream, between Tyk and Upstream. A value of `0` will use the default from the Go standard library, which is 2 connections. Tyk recommends setting this value to `500` for production environments.
 
 ### max_conn_time
 ENV: <b>TYK_GW_MAXCONNTIME</b><br />


### PR DESCRIPTION
### **User description**
## Summary

- Clarify that a value of `0` for `TYK_GW_MAXIDLECONNSPERHOST` will use the Go standard library default of 2 connections
- Add recommendation to use `500` for production environments

## Context

The documentation previously stated "Default:100" which was inconsistent with the Helm chart default values. This update addresses the confusion by clearly explaining the behavior when set to `0` and providing a production recommendation.

## Test plan

- [x] Verify the updated documentation renders correctly
- [x] Confirm the description accurately reflects the Go standard library behavior

Refs: DX-2045

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Documentation


___

### **Description**
- Clarify `max_idle_connections_per_host` default behavior

- Note Go stdlib default when set to `0`

- Recommend `500` for production environments

- Align docs with Helm defaults


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Doc["Gateway config docs"] -- "update setting description" --> MaxIdle["max_idle_connections_per_host"]
  MaxIdle -- "document 0 => Go default (2)" --> Default["Default behavior clarified"]
  MaxIdle -- "recommend 500 in production" --> Reco["Production guidance added"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gateway-config.mdx</strong><dd><code>Clarify max idle connections per host defaults</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

snippets/gateway-config.mdx

<ul><li>Replace ambiguous default text.<br> <li> Explain <code>0</code> uses Go default of 2.<br> <li> Add recommendation to set <code>500</code> in production.<br> <li> Align description with Helm chart defaults.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1136/files#diff-94e6408e3fd62de5fa8ddfa92774d3d12f973f9feb257f1a2664fca38cdc8ac4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

