### PR TITLE
[TT-16188] Gateway Config for 5.8

### DIFF
--- a/snippets/gateway-config.mdx
+++ b/snippets/gateway-config.mdx
@@ -297,11 +297,13 @@ https://tyk.io/docs/api-management/traffic-transformation/#request-size-limits
 ENV: <b>TYK_GW_HTTPSERVEROPTIONS_MAXRESPONSEBODYSIZE</b><br />
 Type: `int64`<br />
 
-MaxResponseBodySize sets an upper limit on the response body (payload) size in bytes. It defaults to 0, which means there is no restriction on the response body size.
+MaxResponseBodySize configures an upper limit for the size of the response body (payload) in bytes.
+
+This limit is currently applied only if the Response Body Transform middleware is enabled.
 
 The Gateway will return `HTTP 500 Response Body Too Large` if the response payload exceeds MaxResponseBodySize+1 bytes.
 
-**Note:** The limit is applied only when the [Response Body Transform middleware](/api-management/traffic-transformation/response-body) is enabled.
+A value of zero (default) means that no maximum is set and response bodies will not be limited.
 
 ### version_header
 ENV: <b>TYK_GW_VERSIONHEADER</b><br />
@@ -410,6 +412,8 @@ This is not portable in cases where the data needs to be moved from installation
 If you set this value to `true`, then the id parameter in a stored policy (or imported policy using the Dashboard API), will be used instead of the internal ID.
 
 This option should only be used when moving an installation to a new database.
+
+Deprecated. Is not used in codebase.
 
 ### policies.policy_path
 ENV: <b>TYK_GW_POLICIES_POLICYPATH</b><br />
@@ -726,18 +730,33 @@ Type: `bool`<br />
 
 SynchroniserEnabled enable this config if MDCB has enabled the synchoniser. If disabled then it will ignore signals to synchonise recources
 
+### slave_options.dns_monitor
+DNSMonitor configures background DNS monitoring for proactive detection of MDCB DNS changes
+
+### slave_options.dns_monitor.enabled
+ENV: <b>TYK_GW_SLAVEOPTIONS_DNSMONITOR_ENABLED</b><br />
+Type: `bool`<br />
+
+Enable background DNS monitoring for proactive detection of MDCB DNS changes
+
+### slave_options.dns_monitor.check_interval
+ENV: <b>TYK_GW_SLAVEOPTIONS_DNSMONITOR_CHECKINTERVAL</b><br />
+Type: `int`<br />
+
+Check interval in seconds for DNS monitoring (default: 30)
+
 ### management_node
 ENV: <b>TYK_GW_MANAGEMENTNODE</b><br />
 Type: `bool`<br />
 
 If set to `true`, distributed rate limiter will be disabled for this node, and it will be excluded from any rate limit calculation.
 
+{{< note success >}}
+**Note**
 
-<Note>
 If you set `db_app_conf_options.node_is_segmented` to `true` for multiple Gateway nodes, you should ensure that `management_node` is set to `false`.
 This is to ensure visibility for the management node across all APIs.
-</Note>
-
+{{< /note >}}
 For pro installations, `management_node` is not a valid configuration option.
 Always set `management_node` to `false` in pro environments.
 
@@ -1119,11 +1138,11 @@ Type: `bool`<br />
 
 Tyk is capable of recording every hit to your API to a database with various filtering parameters. Set this value to `true` and fill in the sub-section below to enable logging.
 
+{{< note success >}}
+**Note**
 
-<Note>
 For performance reasons, Tyk will store traffic data to Redis initially and then purge the data from Redis to MongoDB or other data stores on a regular basis as determined by the purge_delay setting in your Tyk Pump configuration.
-</Note>
-
+{{< /note >}}
 
 ### analytics_config
 This section defines options on what analytics data to store.

--- a/snippets/x-tyk-gateway.mdx
+++ b/snippets/x-tyk-gateway.mdx
@@ -204,7 +204,7 @@ Active enables the API so that Tyk will listen for and process requests made to 
 Tyk classic API definition: `active`.
 
 **Field: `internal` (`boolean`)**
-This field controls the exposure of the API on the Gateway. When set to `true`, the API will not be made available for external access and will not be included in API listings returned by the Gateway's management APIs; it will be accessible only via [internal looping](/advanced-configuration/transform-traffic/looping) or as a [child API version](/api-management/api-versioning#base-and-child-apis).
+Internal makes the API accessible only internally.
 
 Tyk classic API definition: `internal`.
 
@@ -592,7 +592,7 @@ Tyk classic API definition: `proxy.listen_path`.
 **Field: `strip` (`boolean`)**
 Strip removes the inbound listen path (as accessed by the client) when generating the outbound request for the upstream service.
 
-For example, consider the scenario where the Tyk base address is `http://acme.com/`, the listen path is `example/` and the upstream URL is `http://httpbin.org/`:
+For example, consider the scenario where the Tyk base address is `http://acme.com/', the listen path is `example/` and the upstream URL is `http://httpbin.org/`:
 
 - If the client application sends a request to `http://acme.com/example/get` then the request will be proxied to `http://httpbin.org/example/get`
 - If stripListenPath is set to `true`, the `example` listen path is removed and the request would be proxied to `http://httpbin.org/get`.
@@ -865,7 +865,7 @@ Tyk classic API definition: `dont_set_quota_on_create`.
 
 ### **Operations**
 
-Operations holds Operation definitions. The string key in this object is the `operationID`, which is a unique identifier for each API operation. 
+Operations holds Operation definitions.
 
 Type defined as object of `Operation` values, see [Operation](#operation) definition.
 
@@ -1693,6 +1693,46 @@ Value is the value of custom plugin config data.
 
 Tyk classic API definition: `config_data`.
 
+### **CustomPlugin**
+
+CustomPlugin configures custom plugin.
+
+**Field: `enabled` (`boolean`)**
+Enabled activates the custom plugin.
+
+
+Tyk classic API definition: `custom_middleware.pre[].disabled`, `custom_middleware.post_key_auth[].disabled`,.
+`custom_middleware.post[].disabled`, `custom_middleware.response[].disabled` (negated).
+
+**Field: `functionName` (`string`)**
+FunctionName is the name of authentication method.
+
+
+Tyk classic API definition: `custom_middleware.pre[].name`, `custom_middleware.post_key_auth[].name`,.
+`custom_middleware.post[].name`, `custom_middleware.response[].name`.
+
+**Field: `path` (`string`)**
+Path is the path to shared object file in case of goplugin mode or path to JS code in case of otto auth plugin.
+
+
+Tyk classic API definition: `custom_middleware.pre[].path`, `custom_middleware.post_key_auth[].path`,.
+`custom_middleware.post[].path`, `custom_middleware.response[].path`.
+
+**Field: `rawBodyOnly` (`boolean`)**
+RawBodyOnly if set to true, do not fill body in request or response object.
+
+
+Tyk classic API definition: `custom_middleware.pre[].raw_body_only`, `custom_middleware.post_key_auth[].raw_body_only`,.
+`custom_middleware.post[].raw_body_only`, `custom_middleware.response[].raw_body_only`.
+
+**Field: `requireSession` (`boolean`)**
+RequireSession if set to true passes down the session information for plugins after authentication.
+RequireSession is used only with JSVM custom middleware.
+
+
+Tyk classic API definition: `custom_middleware.pre[].require_session`, `custom_middleware.post_key_auth[].require_session`,.
+`custom_middleware.post[].require_session`, `custom_middleware.response[].require_session`.
+
 ### **Headers**
 
 Headers is an array of Header.
@@ -1787,46 +1827,6 @@ Name is the name of the header.
 
 **Field: `value` (`string`)**
 Value is the value of the header.
-
-### **CustomPlugin**
-
-CustomPlugin configures custom plugin.
-
-**Field: `enabled` (`boolean`)**
-Enabled activates the custom plugin.
-
-
-Tyk classic API definition: `custom_middleware.pre[].disabled`, `custom_middleware.post_key_auth[].disabled`,.
-`custom_middleware.post[].disabled`, `custom_middleware.response[].disabled` (negated).
-
-**Field: `functionName` (`string`)**
-FunctionName is the name of authentication method.
-
-
-Tyk classic API definition: `custom_middleware.pre[].name`, `custom_middleware.post_key_auth[].name`,.
-`custom_middleware.post[].name`, `custom_middleware.response[].name`.
-
-**Field: `path` (`string`)**
-Path is the path to shared object file in case of goplugin mode or path to JS code in case of otto auth plugin.
-
-
-Tyk classic API definition: `custom_middleware.pre[].path`, `custom_middleware.post_key_auth[].path`,.
-`custom_middleware.post[].path`, `custom_middleware.response[].path`.
-
-**Field: `rawBodyOnly` (`boolean`)**
-RawBodyOnly if set to true, do not fill body in request or response object.
-
-
-Tyk classic API definition: `custom_middleware.pre[].raw_body_only`, `custom_middleware.post_key_auth[].raw_body_only`,.
-`custom_middleware.post[].raw_body_only`, `custom_middleware.response[].raw_body_only`.
-
-**Field: `requireSession` (`boolean`)**
-RequireSession if set to true passes down the session information for plugins after authentication.
-RequireSession is used only with JSVM custom middleware.
-
-
-Tyk classic API definition: `custom_middleware.pre[].require_session`, `custom_middleware.post_key_auth[].require_session`,.
-`custom_middleware.post[].require_session`, `custom_middleware.response[].require_session`.
 
 ### **IDExtractorConfig**
 
@@ -2406,8 +2406,6 @@ Block request by allowance.
 **Field: `ignoreAuthentication` ([Allowance](#allowance))**
 IgnoreAuthentication ignores authentication on request by allowance.
 
-Tyk classic API definition: version_data.versions..extended_paths.ignored[].
-
 **Field: `internal` ([Internal](#internal))**
 Internal makes the endpoint only respond to internal requests.
 
@@ -2497,10 +2495,7 @@ Connect holds plugin configuration for CONNECT requests.
 
 ### **Paths**
 
-Paths is a mapping of API endpoints to Path plugin configurations. This field is part of the [Middleware](#middleware) structure.
-
-
-The string keys in this object represent URL path patterns (e.g. `/users`, `/users/{id}`, `/api/*`) that match API endpoints.
+Paths is a mapping of API endpoints to Path plugin configurations.
 
 Type defined as object of `Path` values, see [Path](#path) definition.
 
@@ -2516,8 +2511,6 @@ Block request by allowance.
 
 **Field: `ignoreAuthentication` ([Allowance](#allowance))**
 IgnoreAuthentication ignores authentication on request by allowance.
-
-Tyk Classic API definition: version_data.versions..extended_paths.ignored[].
 
 **Field: `transformRequestMethod` ([TransformRequestMethod](#transformrequestmethod))**
 TransformRequestMethod allows you to transform the method of a request.
@@ -2824,3 +2817,4 @@ XTykStreaming represents the structure for Tyk streaming configurations.
 
 **Field: `streams` (`any`)**
 Streams contains the configurations related to Tyk Streams.
+

--- a/swagger/gateway-swagger.yml
+++ b/swagger/gateway-swagger.yml
@@ -5,9 +5,6 @@ info:
     name: Tyk Technologies
     url: https://tyk.io/contact
   description: |+
-    <img src="https://tyk.io/docs/img/swagger_gateway_image.png" width="963" height="250">
-    <img src="https://tyk.io/docs/img/swagger_gateway_direction_image.png" width="946" height="392">
-    
     The Tyk Gateway API is the primary means for integrating your application with the Tyk API Gateway system. This API is very small, and has no granular permissions system. It is intended to be used purely for internal automation and integration.
 
     **Warning: Under no circumstances should outside parties be granted access to this API.**
@@ -33,7 +30,7 @@ info:
     name: Mozilla Public License Version 2.0
     url: https://github.com/TykTechnologies/tyk/blob/master/LICENSE.md
   title: Tyk Gateway API
-  version: 5.9.0
+  version: 5.8.9
 servers:
 - url: https://{tenant}
   variables:
@@ -748,7 +745,7 @@ paths:
                 items:
                   allOf:
                   - $ref: '#/components/schemas/OpenAPI3Schema'
-                  - $ref: '#/components/schemas/XTykAPIGateway'
+                  - $ref: '#/components/schemas/TykVendorExtension'
                 type: array
           description: List of API definitions in Tyk OAS format.
         "403":
@@ -849,7 +846,7 @@ paths:
             schema:
               allOf:
               - $ref: '#/components/schemas/OpenAPI3Schema'
-              - $ref: '#/components/schemas/XTykAPIGateway'
+              - $ref: '#/components/schemas/TykVendorExtension'
       responses:
         "200":
           content:
@@ -987,7 +984,7 @@ paths:
               schema:
                 allOf:
                 - $ref: '#/components/schemas/OpenAPI3Schema'
-                - $ref: '#/components/schemas/XTykAPIGateway'
+                - $ref: '#/components/schemas/TykVendorExtension'
           description: OK
           headers:
             x-tyk-base-api-id:
@@ -1210,7 +1207,7 @@ paths:
             schema:
               allOf:
               - $ref: '#/components/schemas/OpenAPI3Schema'
-              - $ref: '#/components/schemas/XTykAPIGateway'
+              - $ref: '#/components/schemas/TykVendorExtension'
       responses:
         "200":
           content:
@@ -1949,9 +1946,6 @@ paths:
         name: hashed
         required: false
         schema:
-          enum:
-          - true
-          - false
           type: boolean
       requestBody:
         content:
@@ -2054,9 +2048,6 @@ paths:
         name: hashed
         required: false
         schema:
-          enum:
-          - true
-          - false
           type: boolean
       - description: The key ID.
         example: 5e9d9544a1dcd60001d0ed20e7f75f9e03534825b7aef9df749582e5
@@ -2117,9 +2108,6 @@ paths:
         name: hashed
         required: false
         schema:
-          enum:
-          - true
-          - false
           type: boolean
       - description: The key ID.
         example: 5e9d9544a1dcd60001d0ed20e7f75f9e03534825b7aef9df749582e5
@@ -2233,9 +2221,6 @@ paths:
         name: hashed
         required: false
         schema:
-          enum:
-          - true
-          - false
           type: boolean
       - description: Name to give the custom key.
         example: customKey
@@ -2360,9 +2345,6 @@ paths:
         name: hashed
         required: false
         schema:
-          enum:
-          - true
-          - false
           type: boolean
       - description: ID of the key you want to update.
         example: 5e9d9544a1dcd60001d0ed20766d9a6ec6b4403b93a554feefef4708
@@ -4401,9 +4383,6 @@ paths:
         name: block
         required: false
         schema:
-          enum:
-          - true
-          - false
           type: boolean
       responses:
         "200":
@@ -5622,9 +5601,6 @@ components:
           type: string
       type: object
     BooleanQueryParam:
-      enum:
-      - true
-      - false
       example: true
       type: boolean
     CORS:
@@ -7777,7 +7753,7 @@ components:
         oas:
           oneOf:
             - $ref: '#/components/schemas/OpenAPI3Schema'
-            - $ref: '#/components/schemas/XTykAPIGateway'
+            - $ref: '#/components/schemas/TykVendorExtension'
       oneOf:
         - required: [oas]
         - required: [spec]
@@ -8193,6 +8169,11 @@ components:
           $ref: '#/components/schemas/Server'
         upstream:
           $ref: '#/components/schemas/Upstream'
+      type: object
+    TykVendorExtension:
+      properties:
+        x-tyk-api-gateway:
+          $ref: '#/components/schemas/XTykAPIGateway'
       type: object
   securitySchemes:
     api_key:


### PR DESCRIPTION
### **User description**
Triggered by: buraksezer

Included:

Tyk Gateway: true
Tyk Dashboard: false
Tyk MDCB false
Tyk Pump false

Intended for: 5.8
Changes sourced from: release-5.8.9
Config info generator branch: main

Note: Docs updates for GW v5.8.9 (branch suffix: docs)

JIRA: https://tyktech.atlassian.net/browse/TT-16188


___

### **PR Type**
Documentation


___

### **Description**
- Clarify max response body size behavior

- Add MDCB DNS monitor config options

- Replace Note tags with Hugo shortcodes

- Adjust OAS schema: vendor extension wrapper


___

### Diagram Walkthrough


```mermaid
flowchart LR
  GWConfig["Gateway config docs"] -- clarify & deprecate notes --> Clarify["Response size, deprecations, notes"]
  MDCB["MDCB settings"] -- add --> DNSMon["DNS monitor options"]
  OASDocs["OAS docs"] -- wording fixes --> Cleanup["Terminology cleanup"]
  Swagger["gateway-swagger.yml"] -- version to 5.8.9 --> Versioning["Version align"]
  Swagger -- schema change --> VendorExt["Add TykVendorExtension wrapper"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gateway-config.mdx</strong><dd><code>Gateway config docs clarified; DNS monitor added</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

snippets/gateway-config.mdx

<ul><li>Clarify <code>max_response_body_size</code> description and default behavior<br> <li> Mark <code>use_db_app_id</code> as deprecated<br> <li> Add <code>slave_options.dns_monitor</code> settings with env vars<br> <li> Replace Note HTML tags with Hugo shortcode notes</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1146/files#diff-94e6408e3fd62de5fa8ddfa92774d3d12f973f9feb257f1a2664fca38cdc8ac4">+27/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>x-tyk-gateway.mdx</strong><dd><code>OAS field descriptions refined; de-dup CustomPlugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

snippets/x-tyk-gateway.mdx

<ul><li>Simplify/clarify field descriptions (e.g., <code>internal</code>, <code>strip</code>)<br> <li> Move <code>CustomPlugin</code> section earlier and remove duplicate<br> <li> Trim verbose explanations for Operations/Paths and classic mappings<br> <li> Minor formatting fixes and trailing newline</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1146/files#diff-32458678320dc9b496ba522552f26638cbe2206e0a69d6bdaaeecf40a060f91f">+45/-51</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gateway-swagger.yml</strong><dd><code>Swagger updated for 5.8.9 and vendor extension</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

swagger/gateway-swagger.yml

<ul><li>Remove header images from description<br> <li> Downgrade API version to 5.8.9<br> <li> Introduce <code>TykVendorExtension</code> and reference it instead of <br><code>XTykAPIGateway</code><br> <li> Remove boolean enum wrappers and add schema oneOf updates</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1146/files#diff-7556595c16b2968c09325441cc3fbdc2d82a1202de4c0e89fb7448fe8332ec92">+11/-30</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

