### PR TITLE
Merging to release-5.8: Remove Docker From FIPS Page (#1147)

### DIFF
--- a/developer-support/release-types/fips-release.mdx
+++ b/developer-support/release-types/fips-release.mdx
@@ -30,7 +30,7 @@ For API management, FIPS matters because it ensures:
 
 Tyk provides a **FIPS-compliant package** of the Tyk Gateway (Enterprise Edition) and Tyk Pump (together, the *FIPS Tyk Product*). Please note that the FIPS Tyk Product has not been submitted to a [NIST](https://www.nist.gov/federal-information-processing-standards-fips) testing lab for validation and Tyk is not FIPS certified.. 
 
-**FIPS-compliant** means that the FIPS Tyk Product only uses FIPS 140-2 approved cryptographic algorithms (see below) when running in FIPS mode. This is only available to specific Tyk-built packages or Docker images of the FIPS Tyk Product. These packages and images are not publicly accessible.
+**FIPS-compliant** means that the FIPS Tyk Product only uses FIPS 140-2 approved cryptographic algorithms (see below) when running in FIPS mode. This is only available to specific Tyk-built RPM and DEB packages FIPS Tyk Product. These packages and images are not publicly accessible.
 
 * The FIPS Tyk Product uses the **[BoringCrypto module](https://boringssl.googlesource.com/boringssl/+/master/crypto/fipsmodule/FIPS.md#fips-140_2)**, enabling only FIPS 140-2 approved algorithms when run in FIPS mode.
 


### PR DESCRIPTION
### **User description**
Remove Docker From FIPS Page (#1147)


___

### **PR Type**
Documentation


___

### **Description**
- Replace Docker references with RPM/DEB

- Clarify limited package availability

- Retain BoringCrypto usage note

- Keep '-fips' package suffix info


___

### Diagram Walkthrough


```mermaid
flowchart LR
  doc["FIPS release docs"] -- "remove reference" --> docker["Docker images"]
  doc -- "state packaging" --> packages["RPM/DEB packages"]
  packages -- "availability" --> access["Not publicly accessible"]
  doc -- "retain notes" --> crypto["BoringCrypto & -fips suffix"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fips-release.mdx</strong><dd><code>Switch FIPS packaging text to RPM/DEB</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

developer-support/release-types/fips-release.mdx

<ul><li>Replace Docker images with RPM/DEB wording.<br> <li> Clarify restricted access to FIPS packages.<br> <li> Preserve BoringCrypto and '-fips' suffix notes.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1149/files#diff-c0336861e42dc15798b6b97689ec813a7a70e6d3f3b001a04a11a18c930d796b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

