### PR TITLE
Merging to release-5.10: [DX-2045] docs: clarify TYK_GW_MAXIDLECONNSPERHOST default value and recommendation (#1136)

### DIFF
--- a/snippets/gateway-config.mdx
+++ b/snippets/gateway-config.mdx
@@ -938,7 +938,7 @@ Maximum idle connections, per API, between Tyk and Upstream. By default not limi
 ENV: <b>TYK_GW_MAXIDLECONNSPERHOST</b><br />
 Type: `int`<br />
 
-Maximum idle connections, per API, per upstream, between Tyk and Upstream. Default:100
+Maximum idle connections, per API, per upstream, between Tyk and Upstream. A value of `0` will use the default from the Go standard library, which is 2 connections. Tyk recommends setting this value to `500` for production environments.
 
 ### max_conn_time
 ENV: <b>TYK_GW_MAXCONNTIME</b><br />


### PR DESCRIPTION
[DX-2045] docs: clarify TYK_GW_MAXIDLECONNSPERHOST default value and recommendation (#1136)

[DX-2045]: https://tyktech.atlassian.net/browse/DX-2045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ