### PR TITLE
Merging to release-5.8: [DX-2045] docs: clarify TYK_GW_MAXIDLECONNSPERHOST default value and recommendation (#1136)

### DIFF
--- a/snippets/gateway-config.mdx
+++ b/snippets/gateway-config.mdx
@@ -908,7 +908,7 @@ Maximum idle connections, per API, between Tyk and Upstream. By default not limi
 ENV: <b>TYK_GW_MAXIDLECONNSPERHOST</b><br />
 Type: `int`<br />
 
-Maximum idle connections, per API, per upstream, between Tyk and Upstream. Default:100
+Maximum idle connections, per API, per upstream, between Tyk and Upstream. A value of `0` will use the default from the Go standard library, which is 2 connections. Tyk recommends setting this value to `500` for production environments.
 
 ### max_conn_time
 ENV: <b>TYK_GW_MAXCONNTIME</b><br />


### PR DESCRIPTION
### **User description**
[DX-2045] docs: clarify TYK_GW_MAXIDLECONNSPERHOST default value and recommendation (#1136)

[DX-2045]: https://tyktech.atlassian.net/browse/DX-2045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Clarify `max_idle_connections_per_host` default behavior

- Document Go default when set to `0` (2)

- Recommend `500` for production environments

- Align wording with Helm defaults


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Docs["Gateway config docs"] --> Field["max_idle_connections_per_host setting"]
  Field -- "0 uses Go default (2)" --> Default["Default behavior clarified"]
  Field -- "set 500 in production" --> Reco["Production guidance added"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gateway-config.mdx</strong><dd><code>Clarify max idle connections defaults and guidance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

snippets/gateway-config.mdx

<ul><li>Update <code>max_idle_connections_per_host</code> description.<br> <li> Note 0 -> Go default of 2 connections.<br> <li> Recommend 500 for production environments.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1164/files#diff-94e6408e3fd62de5fa8ddfa92774d3d12f973f9feb257f1a2664fca38cdc8ac4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

