### PR TITLE
Merging to release-5.8: [DX-2128] docs: clarify TYK_GW_USEREDISLOG requires shared Redis instance (#1126)

### DIFF
--- a/snippets/gateway-config.mdx
+++ b/snippets/gateway-config.mdx
@@ -1942,6 +1942,12 @@ Type: `bool`<br />
 
 Enables the real-time Gateway log view in the Dashboard.
 
+<Note>
+
+For logs to appear in the Tyk Dashboard, both the Gateway and the Dashboard must be configured to use the **same Redis instance**. In deployments where the Data Plane (Gateway) and Control Plane (Dashboard) use separate Redis instances, enabling this option on the Gateway will not make logs available in the Dashboard.
+
+</Note>
+
 ### use_sentry
 ENV: <b>TYK_GW_USESENTRY</b><br />
 Type: `bool`<br />


### PR DESCRIPTION
### **User description**
[DX-2128] docs: clarify TYK_GW_USEREDISLOG requires shared Redis instance (#1126)

[DX-2128]: https://tyktech.atlassian.net/browse/DX-2128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Clarify `use_redis_log` shared Redis requirement

- Add Note explaining Dashboard log visibility

- Specify limitation for split DP/CP Redis setups


___

### Diagram Walkthrough


```mermaid
flowchart LR
  config["Gateway config docs"]
  note["Add Note: shared Redis required"]
  impact["Dashboard log visibility clarified"]

  config -- "update section: use_redis_log" --> note
  note -- "affects DP/CP split deployments" --> impact
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gateway-config.mdx</strong><dd><code>Note: shared Redis required for Dashboard logs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

snippets/gateway-config.mdx

<ul><li>Add Note under <code>use_redis_log</code> section.<br> <li> Explain Gateway and Dashboard need same Redis.<br> <li> Clarify no logs in Dashboard with separate Redis.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1175/files#diff-94e6408e3fd62de5fa8ddfa92774d3d12f973f9feb257f1a2664fca38cdc8ac4">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

