### PR TITLE
Merging to release-5.10: [DX-2128] docs: clarify TYK_GW_USEREDISLOG requires shared Redis instance (#1126)

### DIFF
--- a/snippets/gateway-config.mdx
+++ b/snippets/gateway-config.mdx
@@ -1972,6 +1972,12 @@ Type: `bool`<br />
 
 Enables the real-time Gateway log view in the Dashboard.
 
+<Note>
+
+For logs to appear in the Tyk Dashboard, both the Gateway and the Dashboard must be configured to use the **same Redis instance**. In deployments where the Data Plane (Gateway) and Control Plane (Dashboard) use separate Redis instances, enabling this option on the Gateway will not make logs available in the Dashboard.
+
+</Note>
+
 ### use_sentry
 ENV: <b>TYK_GW_USESENTRY</b><br />
 Type: `bool`<br />


### PR DESCRIPTION
[DX-2128] docs: clarify TYK_GW_USEREDISLOG requires shared Redis instance (#1126)

[DX-2128]: https://tyktech.atlassian.net/browse/DX-2128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ