### PR TITLE
🤖 Auto-merge documentation from branches

### DIFF
--- a/5.8/api-management/troubleshooting-debugging.mdx
+++ b/5.8/api-management/troubleshooting-debugging.mdx
@@ -395,6 +395,24 @@ canonical: "https://tyk.io/docs/api-management/troubleshooting-debugging"
 
     You are able to see a more detailed output in your Gateway log `/var/log` or `/var/log/upstart`.
 
+18. Gateway `proxy_default_timeout` vs `http_server_options.write_timeout`
+
+    **Tyk to Upstream timeout**
+
+    `proxy_default_timeout` specifies the amount of time that Tyk will wait for the upstream service to complete its reply to Tyk
+
+    With gateways prior to release 5.0.7 `proxy_default_timeout` defaulted to zero which would result in the gateway waiting forever. This consumed resources and could lead to depletion of ephemeral sockets.
+
+    Since gateway 5.0.7 `proxy_default_timeout` defaults to 30 seconds.
+
+    When increasing `proxy_default_timeout` beyond 120 seconds it is necessary to consider the client to Tyk timeouts.
+
+    **Client to Tyk timeouts**
+
+    `http_server_options.write_timeout` specifies the number of seconds that Tyk will keep the client connection open for Tyk to write to it. If this is less than `proxy_default_timeout` then the connection to the client will be closed and the upstream reply will not be proxied back to the client if the upstream takes longer than `http_server_options.write_timeout` seconds. To avoid this please make sure that `http_server_options.write_timeout`is at least 1 second longer than `proxy_default_timeout`
+
+    `http_server_options.read_timeout` specifies that number of seconds that Tyk will allow the client to complete sending the request to it. This usually doesn't need to be changed since a lot of data can be sent in the default of 120 seconds, but it can be changed if needed.
+
 ## Gateway Error Response Status Codes
 
 Tyk Gateway responses include HTTP status codes that follow the [HTTP status code standard](https://datatracker.ietf.org/doc/html/rfc9110). They have three digits that describe the result of the request and the semantics of the response. 

--- a/5.8/product-stack/tyk-enterprise-developer-portal/deploy/configuration.mdx
+++ b/5.8/product-stack/tyk-enterprise-developer-portal/deploy/configuration.mdx
@@ -6,8 +6,13 @@ sidebarTitle: "Enterprise Developer Portal"
 canonical: "https://tyk.io/docs/product-stack/tyk-enterprise-developer-portal/deploy/configuration"
 ---
 
+import EnvTypeMapping from '/snippets/5.8/env-type-mapping.mdx';
+
 To configure the Tyk Enterprise Developer Portal, you can use either a config file or environment variables.
 The table below provides a reference to all options available to you when configuring the portal.
+
+<EnvTypeMapping/>
+
 ## Portal settings
 This section explains the general portal settings, including which port it will be listening on, how often it should synchronize API Products and plans with the Tyk Dashboard, and so on.
 Most of these settings are optional, except for the PORTAL_LICENSEKEY. If you don't specify these settings, the default values will be used.

--- a/5.8/tyk-configuration-reference/tyk-identity-broker-configuration.mdx
+++ b/5.8/tyk-configuration-reference/tyk-identity-broker-configuration.mdx
@@ -5,9 +5,11 @@ sidebarTitle: "Tyk Identity Broker"
 canonical: "https://tyk.io/docs/tyk-configuration-reference/tyk-identity-broker-configuration"
 ---
 
+import EnvTypeMapping from '/snippets/5.8/env-type-mapping.mdx';
+
 The Tyk Identity Broker (TIB) is configured through two files: The configuration file `tib.conf` and the profiles file `profiles.json`. TIB can also be managed via the [TIB REST API](/5.8/tyk-identity-broker/tib-rest-api) for automated configurations.
 
-#### The `tib.conf` file
+### The `tib.conf` file
 
 ```{.copyWrapper}
 {
@@ -55,6 +57,8 @@ From TIB v1.3.1, the environment variable `TYK_IB_OMITCONFIGFILE` is provided to
 
 If set to TRUE, then TIB will ignore any provided configuration file and set its parameters according to environment variables. TIB will fall back to the default value for any parameters not set in an environment variable.
 This is particularly useful when using Docker, as this option will ensure that TIB will load the configuration via env vars and not expect a configuration file.
+
+<EnvTypeMapping/>
 
 The various options for `tib.conf` file are:
 

--- a/5.8/tyk-dashboard/configuration.mdx
+++ b/5.8/tyk-dashboard/configuration.mdx
@@ -6,6 +6,7 @@ canonical: "https://tyk.io/docs/tyk-dashboard/configuration"
 ---
 
 import DashboardConfig from '/snippets/5.8/dashboard-config.mdx';
+import EnvTypeMapping from '/snippets/5.8/env-type-mapping.mdx';
 
 You can use environment variables to override the config file for the Tyk Dashboard. The Dashboard configuration file can be found in the `tyk-dashboard` folder and by default is called `tyk_analytics.conf`, though it can be renamed and specified using the `--conf` flag. Environment variables are created from the dot notation versions of the JSON objects contained with the config files.
 To understand how the environment variables notation works, see [Environment Variables](/5.8/tyk-oss-gateway/configuration).
@@ -19,6 +20,8 @@ Please consult the [data storage configuration](/5.8/api-management/dashboard-co
 ### Environment Variables
 
 All the Dashboard environment variables have the prefix `TYK_DB_`. The environment variables will take precedence over the values in the configuration file.
+
+<EnvTypeMapping/>
 
 Environment variables (env var) can be used to override the settings defined in the configuration file. Where an environment variable is specified, its value will take precedence over the value in the configuration file.
 

--- a/5.8/tyk-multi-data-centre/mdcb-configuration-options.mdx
+++ b/5.8/tyk-multi-data-centre/mdcb-configuration-options.mdx
@@ -8,6 +8,7 @@ canonical: "https://tyk.io/docs/tyk-multi-data-centre/mdcb-configuration-options
 ---
 
 import MdcbConfig from '/snippets/5.8/mdcb-config.mdx';
+import EnvTypeMapping from '/snippets/5.8/env-type-mapping.mdx';
 
 ## Tyk MDCB Configuration
 
@@ -16,6 +17,8 @@ The Tyk MDCB server is configured primarily via the `tyk_sink.conf` file, this f
 ### Environment Variables
 
 Environment variables (env var) can be used to override the settings defined in the configuration file. Where an environment variable is specified, its value will take precedence over the value in the configuration file.
+
+<EnvTypeMapping/>
 
 ### Default Ports
 

--- a/5.8/tyk-oss-gateway/configuration.mdx
+++ b/5.8/tyk-oss-gateway/configuration.mdx
@@ -6,11 +6,14 @@ canonical: "https://tyk.io/docs/tyk-oss-gateway/configuration"
 ---
 
 import GatewayConfig from '/snippets/5.8/gateway-config.mdx';
+import EnvTypeMapping from '/snippets/5.8/env-type-mapping.mdx';
 
 You can use environment variables to override the config file for the Tyk Gateway. The Gateway configuration file can be found in the `tyk-gateway` folder and by default is called `tyk.conf`, though it can be renamed and specified using the `--conf` flag. Environment variables are created from the dot notation versions of the JSON objects contained with the config files.
 To understand how the environment variables notation works, see [Environment Variables](/5.8/tyk-oss-gateway/configuration).
 
 All the Gateway environment variables have the prefix `TYK_GW_`. The environment variables will take precedence over the values in the configuration file.
+
+<EnvTypeMapping/>
 
 ### tyk lint
 

--- a/5.8/tyk-pump/tyk-pump-configuration/tyk-pump-environment-variables.mdx
+++ b/5.8/tyk-pump/tyk-pump-configuration/tyk-pump-environment-variables.mdx
@@ -8,10 +8,13 @@ canonical: "https://tyk.io/docs/tyk-pump/tyk-pump-configuration/tyk-pump-environ
 ---
 
 import PumpConfig from '/snippets/5.8/pump-config.mdx';
+import EnvTypeMapping from '/snippets/5.8/env-type-mapping.mdx';
 
 You can use environment variables to override the config file for the Tyk Pump. Environment variables are created from the dot notation versions of the JSON objects contained with the config files.
 To understand how the environment variables notation works, see [Environment Variables](/5.8/tyk-oss-gateway/configuration). 
 
 All the Pump environment variables have the prefix `TYK_PMP_`. The environment variables will take precedence over the values in the configuration file.
+
+<EnvTypeMapping/>
 
 <PumpConfig/>

--- a/api-management/troubleshooting-debugging.mdx
+++ b/api-management/troubleshooting-debugging.mdx
@@ -395,6 +395,24 @@ canonical: "https://tyk.io/docs/api-management/troubleshooting-debugging"
 
     You are able to see a more detailed output in your Gateway log `/var/log` or `/var/log/upstart`.
 
+18. Gateway `proxy_default_timeout` vs `http_server_options.write_timeout`
+
+    **Tyk to Upstream timeout**
+
+    `proxy_default_timeout` specifies the amount of time that Tyk will wait for the upstream service to complete its reply to Tyk
+
+    With gateways prior to release 5.0.7 `proxy_default_timeout` defaulted to zero which would result in the gateway waiting forever. This consumed resources and could lead to depletion of ephemeral sockets.
+
+    Since gateway 5.0.7 `proxy_default_timeout` defaults to 30 seconds.
+
+    When increasing `proxy_default_timeout` beyond 120 seconds it is necessary to consider the client to Tyk timeouts.
+
+    **Client to Tyk timeouts**
+
+    `http_server_options.write_timeout` specifies the number of seconds that Tyk will keep the client connection open for Tyk to write to it. If this is less than `proxy_default_timeout` then the connection to the client will be closed and the upstream reply will not be proxied back to the client if the upstream takes longer than `http_server_options.write_timeout` seconds. To avoid this please make sure that `http_server_options.write_timeout`is at least 1 second longer than `proxy_default_timeout`
+
+    `http_server_options.read_timeout` specifies that number of seconds that Tyk will allow the client to complete sending the request to it. This usually doesn't need to be changed since a lot of data can be sent in the default of 120 seconds, but it can be changed if needed.
+
 ## Gateway Error Response Status Codes
 
 Tyk Gateway responses include HTTP status codes that follow the [HTTP status code standard](https://datatracker.ietf.org/doc/html/rfc9110). They have three digits that describe the result of the request and the semantics of the response. 

--- a/nightly/api-management/troubleshooting-debugging.mdx
+++ b/nightly/api-management/troubleshooting-debugging.mdx
@@ -395,6 +395,24 @@ canonical: "https://tyk.io/docs/api-management/troubleshooting-debugging"
 
     You are able to see a more detailed output in your Gateway log `/var/log` or `/var/log/upstart`.
 
+18. Gateway `proxy_default_timeout` vs `http_server_options.write_timeout`
+
+    **Tyk to Upstream timeout**
+
+    `proxy_default_timeout` specifies the amount of time that Tyk will wait for the upstream service to complete its reply to Tyk
+
+    With gateways prior to release 5.0.7 `proxy_default_timeout` defaulted to zero which would result in the gateway waiting forever. This consumed resources and could lead to depletion of ephemeral sockets.
+
+    Since gateway 5.0.7 `proxy_default_timeout` defaults to 30 seconds.
+
+    When increasing `proxy_default_timeout` beyond 120 seconds it is necessary to consider the client to Tyk timeouts.
+
+    **Client to Tyk timeouts**
+
+    `http_server_options.write_timeout` specifies the number of seconds that Tyk will keep the client connection open for Tyk to write to it. If this is less than `proxy_default_timeout` then the connection to the client will be closed and the upstream reply will not be proxied back to the client if the upstream takes longer than `http_server_options.write_timeout` seconds. To avoid this please make sure that `http_server_options.write_timeout`is at least 1 second longer than `proxy_default_timeout`
+
+    `http_server_options.read_timeout` specifies that number of seconds that Tyk will allow the client to complete sending the request to it. This usually doesn't need to be changed since a lot of data can be sent in the default of 120 seconds, but it can be changed if needed.
+
 ## Gateway Error Response Status Codes
 
 Tyk Gateway responses include HTTP status codes that follow the [HTTP status code standard](https://datatracker.ietf.org/doc/html/rfc9110). They have three digits that describe the result of the request and the semantics of the response. 

--- a/nightly/product-stack/tyk-enterprise-developer-portal/deploy/configuration.mdx
+++ b/nightly/product-stack/tyk-enterprise-developer-portal/deploy/configuration.mdx
@@ -6,8 +6,13 @@ sidebarTitle: "Environment Variables and Configs"
 canonical: "https://tyk.io/docs/product-stack/tyk-enterprise-developer-portal/deploy/configuration"
 ---
 
+import EnvTypeMapping from '/snippets/nightly/env-type-mapping.mdx';
+
 To configure the Tyk Enterprise Developer Portal, you can use either a config file or environment variables.
 The table below provides a reference to all options available to you when configuring the portal.
+
+<EnvTypeMapping/>
+
 ## Portal settings
 This section explains the general portal settings, including which port it will be listening on, how often it should synchronize API Products and plans with the Tyk Dashboard, and so on.
 Most of these settings are optional, except for the PORTAL_LICENSEKEY. If you don't specify these settings, the default values will be used.

--- a/nightly/tyk-configuration-reference/tyk-identity-broker-configuration.mdx
+++ b/nightly/tyk-configuration-reference/tyk-identity-broker-configuration.mdx
@@ -6,9 +6,11 @@ sidebarTitle: "Tyk Identity Broker"
 canonical: "https://tyk.io/docs/tyk-configuration-reference/tyk-identity-broker-configuration"
 ---
 
+import EnvTypeMapping from '/snippets/nightly/env-type-mapping.mdx';
+
 The Tyk Identity Broker (TIB) is configured through two files: The configuration file `tib.conf` and the profiles file `profiles.json`. TIB can also be managed via the [TIB REST API](/nightly/tyk-identity-broker/tib-rest-api) for automated configurations.
 
-#### The `tib.conf` file
+### The `tib.conf` file
 
 ```{.copyWrapper}
 {
@@ -56,6 +58,8 @@ From TIB v1.3.1, the environment variable `TYK_IB_OMITCONFIGFILE` is provided to
 
 If set to TRUE, then TIB will ignore any provided configuration file and set its parameters according to environment variables. TIB will fall back to the default value for any parameters not set in an environment variable.
 This is particularly useful when using Docker, as this option will ensure that TIB will load the configuration via env vars and not expect a configuration file.
+
+<EnvTypeMapping/>
 
 The various options for `tib.conf` file are:
 

--- a/nightly/tyk-dashboard/configuration.mdx
+++ b/nightly/tyk-dashboard/configuration.mdx
@@ -7,6 +7,7 @@ canonical: "https://tyk.io/docs/tyk-dashboard/configuration"
 ---
 
 import DashboardConfig from '/snippets/nightly/dashboard-config.mdx';
+import EnvTypeMapping from '/snippets/nightly/env-type-mapping.mdx';
 
 You can use environment variables to override the config file for the Tyk Dashboard. The Dashboard configuration file can be found in the `tyk-dashboard` folder and by default is called `tyk_analytics.conf`, though it can be renamed and specified using the `--conf` flag. Environment variables are created from the dot notation versions of the JSON objects contained with the config files.
 To understand how the environment variables notation works, see [Environment Variables](/nightly/tyk-oss-gateway/configuration).
@@ -20,6 +21,8 @@ Please consult the [data storage configuration](/nightly/api-management/dashboar
 ### Environment Variables
 
 All the Dashboard environment variables have the prefix `TYK_DB_`. The environment variables will take precedence over the values in the configuration file.
+
+<EnvTypeMapping/>
 
 Environment variables (env var) can be used to override the settings defined in the configuration file. Where an environment variable is specified, its value will take precedence over the value in the configuration file.
 

--- a/nightly/tyk-multi-data-centre/mdcb-configuration-options.mdx
+++ b/nightly/tyk-multi-data-centre/mdcb-configuration-options.mdx
@@ -8,6 +8,7 @@ canonical: "https://tyk.io/docs/tyk-multi-data-centre/mdcb-configuration-options
 ---
 
 import MdcbConfig from '/snippets/nightly/mdcb-config.mdx';
+import EnvTypeMapping from '/snippets/nightly/env-type-mapping.mdx';
 
 ## Tyk MDCB Configuration
 
@@ -16,6 +17,8 @@ The Tyk MDCB server is configured primarily via the `tyk_sink.conf` file, this f
 ### Environment Variables
 
 Environment variables (env var) can be used to override the settings defined in the configuration file. Where an environment variable is specified, its value will take precedence over the value in the configuration file.
+
+<EnvTypeMapping/>
 
 ### Default Ports
 

--- a/nightly/tyk-oss-gateway/configuration.mdx
+++ b/nightly/tyk-oss-gateway/configuration.mdx
@@ -7,11 +7,14 @@ canonical: "https://tyk.io/docs/tyk-oss-gateway/configuration"
 ---
 
 import GatewayConfig from '/snippets/nightly/gateway-config.mdx';
+import EnvTypeMapping from '/snippets/nightly/env-type-mapping.mdx';
 
 You can use environment variables to override the config file for the Tyk Gateway. The Gateway configuration file can be found in the `tyk-gateway` folder and by default is called `tyk.conf`, though it can be renamed and specified using the `--conf` flag. Environment variables are created from the dot notation versions of the JSON objects contained with the config files.
 To understand how the environment variables notation works, see [Environment Variables](/nightly/tyk-oss-gateway/configuration).
 
 All the Gateway environment variables have the prefix `TYK_GW_`. The environment variables will take precedence over the values in the configuration file.
+
+<EnvTypeMapping/>
 
 ### tyk lint
 

--- a/nightly/tyk-pump/tyk-pump-configuration/tyk-pump-environment-variables.mdx
+++ b/nightly/tyk-pump/tyk-pump-configuration/tyk-pump-environment-variables.mdx
@@ -8,10 +8,13 @@ canonical: "https://tyk.io/docs/tyk-pump/tyk-pump-configuration/tyk-pump-environ
 ---
 
 import PumpConfig from '/snippets/nightly/pump-config.mdx';
+import EnvTypeMapping from '/snippets/nightly/env-type-mapping.mdx';
 
 You can use environment variables to override the config file for the Tyk Pump. Environment variables are created from the dot notation versions of the JSON objects contained with the config files.
 To understand how the environment variables notation works, see [Environment Variables](/nightly/tyk-oss-gateway/configuration). 
 
 All the Pump environment variables have the prefix `TYK_PMP_`. The environment variables will take precedence over the values in the configuration file.
+
+<EnvTypeMapping/>
 
 <PumpConfig/>

--- a/product-stack/tyk-enterprise-developer-portal/deploy/configuration.mdx
+++ b/product-stack/tyk-enterprise-developer-portal/deploy/configuration.mdx
@@ -6,8 +6,13 @@ sidebarTitle: "Environment Variables and Configs"
 canonical: "https://tyk.io/docs/product-stack/tyk-enterprise-developer-portal/deploy/configuration"
 ---
 
+import EnvTypeMapping from '/snippets/5.10/env-type-mapping.mdx';
+
 To configure the Tyk Enterprise Developer Portal, you can use either a config file or environment variables.
 The table below provides a reference to all options available to you when configuring the portal.
+
+<EnvTypeMapping/>
+
 ## Portal settings
 This section explains the general portal settings, including which port it will be listening on, how often it should synchronize API Products and plans with the Tyk Dashboard, and so on.
 Most of these settings are optional, except for the PORTAL_LICENSEKEY. If you don't specify these settings, the default values will be used.

--- a/snippets/5.10/env-type-mapping.mdx
+++ b/snippets/5.10/env-type-mapping.mdx
@@ -1,0 +1,16 @@
+### Environment Variable Type Mapping
+
+When configuring Tyk components using environment variables, it's important to understand how different data types are represented. The type of each variable is based on its definition in the Go source code. This section provides a guide on how to format values for common data types.
+
+| Go Type                 | Environment Variable Format        | Example                                                              |
+| ----------------------- | ---------------------------------- | -------------------------------------------------------------------- |
+| `string`                | A regular string of text.          | `TYK_GW_SECRET="mysecret"`                                           |
+| `int`, `int64`          | A whole number.                    | `TYK_GW_LISTENPORT=8080`                                               |
+| `bool`                  | `true` or `false`.                 | `TYK_GW_USEDBAPPCONFIG=true`                                         |
+| `[]string`              | A comma-separated list of strings. | `TYK_PMP_PUMPS_STDOUT_FILTERS_SKIPPEDAPIIDS="api1,api2,api3"`        |
+| `map[string]string`     | A comma-separated list of key:value pairs. | `TYK_GW_GLOBALHEADERS="X-Tyk-Test:true,X-Tyk-Version:1.0"`           |
+| `map[string]interface{}` | A JSON string representing the object. | `TYK_GW_POLICIES_POLICYSOURCE_CONFIG='{"connection_string": "..."}'` |
+
+<Note>
+For complex types like `map[string]interface{}`, the value should be a valid JSON string. For `[]string` and `map[string]string`, ensure there are no spaces around the commas unless they are part of the value itself.
+</Note>

--- a/snippets/5.10/gateway-config.mdx
+++ b/snippets/5.10/gateway-config.mdx
@@ -159,6 +159,12 @@ Type: `int`<br />
 
 API Consumer -> Gateway network write timeout. Not setting this config, or setting this to 0, defaults to 120 seconds
 
+<Note>
+
+If you set `proxy_default_timeout` to a value greater than 120 seconds, you must also increase [http_server_options.write_timeout](#http-server-options-write-timeout) to a value greater than `proxy_default_timeout`. The `write_timeout` setting defaults to 120 seconds and controls how long Tyk waits to write the response back to the client. If not adjusted, the client connection will be closed before the upstream response is received.
+
+</Note>
+
 ### http_server_options.use_ssl
 ENV: <b>TYK_GW_HTTPSERVEROPTIONS_USESSL</b><br />
 Type: `bool`<br />
@@ -1008,6 +1014,12 @@ Type: `float64`<br />
 
 This can specify a default timeout in seconds for upstream API requests.
 Default: 30 seconds
+
+<Note>
+
+If you set `proxy_default_timeout` to a value greater than 120 seconds, you must also increase [http_server_options.write_timeout](#http-server-options-write-timeout) to a value greater than `proxy_default_timeout`. The `write_timeout` setting defaults to 120 seconds and controls how long Tyk waits to write the response back to the client. If not adjusted, the client connection will be closed before the upstream response is received.
+
+</Note>
 
 ### proxy_ssl_disable_renegotiation
 ENV: <b>TYK_GW_PROXYSSLDISABLERENEGOTIATION</b><br />
@@ -1959,6 +1971,12 @@ ENV: <b>TYK_GW_USEREDISLOG</b><br />
 Type: `bool`<br />
 
 Enables the real-time Gateway log view in the Dashboard.
+
+<Note>
+
+For logs to appear in the Tyk Dashboard, both the Gateway and the Dashboard must be configured to use the **same Redis instance**. In deployments where the Data Plane (Gateway) and Control Plane (Dashboard) use separate Redis instances, enabling this option on the Gateway will not make logs available in the Dashboard.
+
+</Note>
 
 ### use_sentry
 ENV: <b>TYK_GW_USESENTRY</b><br />

--- a/snippets/5.8/env-type-mapping.mdx
+++ b/snippets/5.8/env-type-mapping.mdx
@@ -1,0 +1,16 @@
+### Environment Variable Type Mapping
+
+When configuring Tyk components using environment variables, it's important to understand how different data types are represented. The type of each variable is based on its definition in the Go source code. This section provides a guide on how to format values for common data types.
+
+| Go Type                 | Environment Variable Format        | Example                                                              |
+| ----------------------- | ---------------------------------- | -------------------------------------------------------------------- |
+| `string`                | A regular string of text.          | `TYK_GW_SECRET="mysecret"`                                           |
+| `int`, `int64`          | A whole number.                    | `TYK_GW_LISTENPORT=8080`                                               |
+| `bool`                  | `true` or `false`.                 | `TYK_GW_USEDBAPPCONFIG=true`                                         |
+| `[]string`              | A comma-separated list of strings. | `TYK_PMP_PUMPS_STDOUT_FILTERS_SKIPPEDAPIIDS="api1,api2,api3"`        |
+| `map[string]string`     | A comma-separated list of key:value pairs. | `TYK_GW_GLOBALHEADERS="X-Tyk-Test:true,X-Tyk-Version:1.0"`           |
+| `map[string]interface{}` | A JSON string representing the object. | `TYK_GW_POLICIES_POLICYSOURCE_CONFIG='{"connection_string": "..."}'` |
+
+<Note>
+For complex types like `map[string]interface{}`, the value should be a valid JSON string. For `[]string` and `map[string]string`, ensure there are no spaces around the commas unless they are part of the value itself.
+</Note>

--- a/snippets/5.8/gateway-config.mdx
+++ b/snippets/5.8/gateway-config.mdx
@@ -129,6 +129,12 @@ Type: `int`<br />
 
 API Consumer -> Gateway network write timeout. Not setting this config, or setting this to 0, defaults to 120 seconds
 
+<Note>
+
+If you set `proxy_default_timeout` to a value greater than 120 seconds, you must also increase [http_server_options.write_timeout](/5.8/#http-server-options-write-timeout) to a value greater than `proxy_default_timeout`. The `write_timeout` setting defaults to 120 seconds and controls how long Tyk waits to write the response back to the client. If not adjusted, the client connection will be closed before the upstream response is received.
+
+</Note>
+
 ### http_server_options.use_ssl
 ENV: <b>TYK_GW_HTTPSERVEROPTIONS_USESSL</b><br />
 Type: `bool`<br />
@@ -978,6 +984,12 @@ Type: `float64`<br />
 
 This can specify a default timeout in seconds for upstream API requests.
 Default: 30 seconds
+
+<Note>
+
+If you set `proxy_default_timeout` to a value greater than 120 seconds, you must also increase [http_server_options.write_timeout](/5.8/#http-server-options-write-timeout) to a value greater than `proxy_default_timeout`. The `write_timeout` setting defaults to 120 seconds and controls how long Tyk waits to write the response back to the client. If not adjusted, the client connection will be closed before the upstream response is received.
+
+</Note>
 
 ### proxy_ssl_disable_renegotiation
 ENV: <b>TYK_GW_PROXYSSLDISABLERENEGOTIATION</b><br />
@@ -1929,6 +1941,12 @@ ENV: <b>TYK_GW_USEREDISLOG</b><br />
 Type: `bool`<br />
 
 Enables the real-time Gateway log view in the Dashboard.
+
+<Note>
+
+For logs to appear in the Tyk Dashboard, both the Gateway and the Dashboard must be configured to use the **same Redis instance**. In deployments where the Data Plane (Gateway) and Control Plane (Dashboard) use separate Redis instances, enabling this option on the Gateway will not make logs available in the Dashboard.
+
+</Note>
 
 ### use_sentry
 ENV: <b>TYK_GW_USESENTRY</b><br />

--- a/snippets/nightly/env-type-mapping.mdx
+++ b/snippets/nightly/env-type-mapping.mdx
@@ -1,0 +1,16 @@
+### Environment Variable Type Mapping
+
+When configuring Tyk components using environment variables, it's important to understand how different data types are represented. The type of each variable is based on its definition in the Go source code. This section provides a guide on how to format values for common data types.
+
+| Go Type                 | Environment Variable Format        | Example                                                              |
+| ----------------------- | ---------------------------------- | -------------------------------------------------------------------- |
+| `string`                | A regular string of text.          | `TYK_GW_SECRET="mysecret"`                                           |
+| `int`, `int64`          | A whole number.                    | `TYK_GW_LISTENPORT=8080`                                               |
+| `bool`                  | `true` or `false`.                 | `TYK_GW_USEDBAPPCONFIG=true`                                         |
+| `[]string`              | A comma-separated list of strings. | `TYK_PMP_PUMPS_STDOUT_FILTERS_SKIPPEDAPIIDS="api1,api2,api3"`        |
+| `map[string]string`     | A comma-separated list of key:value pairs. | `TYK_GW_GLOBALHEADERS="X-Tyk-Test:true,X-Tyk-Version:1.0"`           |
+| `map[string]interface{}` | A JSON string representing the object. | `TYK_GW_POLICIES_POLICYSOURCE_CONFIG='{"connection_string": "..."}'` |
+
+<Note>
+For complex types like `map[string]interface{}`, the value should be a valid JSON string. For `[]string` and `map[string]string`, ensure there are no spaces around the commas unless they are part of the value itself.
+</Note>

--- a/snippets/nightly/gateway-config.mdx
+++ b/snippets/nightly/gateway-config.mdx
@@ -159,6 +159,12 @@ Type: `int`<br />
 
 API Consumer -> Gateway network write timeout. Not setting this config, or setting this to 0, defaults to 120 seconds
 
+<Note>
+
+If you set `proxy_default_timeout` to a value greater than 120 seconds, you must also increase [http_server_options.write_timeout](/nightly/#http-server-options-write-timeout) to a value greater than `proxy_default_timeout`. The `write_timeout` setting defaults to 120 seconds and controls how long Tyk waits to write the response back to the client. If not adjusted, the client connection will be closed before the upstream response is received.
+
+</Note>
+
 ### http_server_options.use_ssl
 ENV: <b>TYK_GW_HTTPSERVEROPTIONS_USESSL</b><br />
 Type: `bool`<br />
@@ -1008,6 +1014,12 @@ Type: `float64`<br />
 
 This can specify a default timeout in seconds for upstream API requests.
 Default: 30 seconds
+
+<Note>
+
+If you set `proxy_default_timeout` to a value greater than 120 seconds, you must also increase [http_server_options.write_timeout](/nightly/#http-server-options-write-timeout) to a value greater than `proxy_default_timeout`. The `write_timeout` setting defaults to 120 seconds and controls how long Tyk waits to write the response back to the client. If not adjusted, the client connection will be closed before the upstream response is received.
+
+</Note>
 
 ### proxy_ssl_disable_renegotiation
 ENV: <b>TYK_GW_PROXYSSLDISABLERENEGOTIATION</b><br />
@@ -1959,6 +1971,12 @@ ENV: <b>TYK_GW_USEREDISLOG</b><br />
 Type: `bool`<br />
 
 Enables the real-time Gateway log view in the Dashboard.
+
+<Note>
+
+For logs to appear in the Tyk Dashboard, both the Gateway and the Dashboard must be configured to use the **same Redis instance**. In deployments where the Data Plane (Gateway) and Control Plane (Dashboard) use separate Redis instances, enabling this option on the Gateway will not make logs available in the Dashboard.
+
+</Note>
 
 ### use_sentry
 ENV: <b>TYK_GW_USESENTRY</b><br />

--- a/tyk-configuration-reference/tyk-identity-broker-configuration.mdx
+++ b/tyk-configuration-reference/tyk-identity-broker-configuration.mdx
@@ -6,9 +6,11 @@ sidebarTitle: "Tyk Identity Broker"
 canonical: "https://tyk.io/docs/tyk-configuration-reference/tyk-identity-broker-configuration"
 ---
 
+import EnvTypeMapping from '/snippets/5.10/env-type-mapping.mdx';
+
 The Tyk Identity Broker (TIB) is configured through two files: The configuration file `tib.conf` and the profiles file `profiles.json`. TIB can also be managed via the [TIB REST API](/tyk-identity-broker/tib-rest-api) for automated configurations.
 
-#### The `tib.conf` file
+### The `tib.conf` file
 
 ```{.copyWrapper}
 {
@@ -56,6 +58,8 @@ From TIB v1.3.1, the environment variable `TYK_IB_OMITCONFIGFILE` is provided to
 
 If set to TRUE, then TIB will ignore any provided configuration file and set its parameters according to environment variables. TIB will fall back to the default value for any parameters not set in an environment variable.
 This is particularly useful when using Docker, as this option will ensure that TIB will load the configuration via env vars and not expect a configuration file.
+
+<EnvTypeMapping/>
 
 The various options for `tib.conf` file are:
 

--- a/tyk-dashboard/configuration.mdx
+++ b/tyk-dashboard/configuration.mdx
@@ -7,6 +7,7 @@ canonical: "https://tyk.io/docs/tyk-dashboard/configuration"
 ---
 
 import DashboardConfig from '/snippets/5.10/dashboard-config.mdx';
+import EnvTypeMapping from '/snippets/5.10/env-type-mapping.mdx';
 
 You can use environment variables to override the config file for the Tyk Dashboard. The Dashboard configuration file can be found in the `tyk-dashboard` folder and by default is called `tyk_analytics.conf`, though it can be renamed and specified using the `--conf` flag. Environment variables are created from the dot notation versions of the JSON objects contained with the config files.
 To understand how the environment variables notation works, see [Environment Variables](/tyk-oss-gateway/configuration).
@@ -20,6 +21,8 @@ Please consult the [data storage configuration](/api-management/dashboard-config
 ### Environment Variables
 
 All the Dashboard environment variables have the prefix `TYK_DB_`. The environment variables will take precedence over the values in the configuration file.
+
+<EnvTypeMapping/>
 
 Environment variables (env var) can be used to override the settings defined in the configuration file. Where an environment variable is specified, its value will take precedence over the value in the configuration file.
 

--- a/tyk-multi-data-centre/mdcb-configuration-options.mdx
+++ b/tyk-multi-data-centre/mdcb-configuration-options.mdx
@@ -8,6 +8,7 @@ canonical: "https://tyk.io/docs/tyk-multi-data-centre/mdcb-configuration-options
 ---
 
 import MdcbConfig from '/snippets/5.10/mdcb-config.mdx';
+import EnvTypeMapping from '/snippets/5.10/env-type-mapping.mdx';
 
 ## Tyk MDCB Configuration
 
@@ -16,6 +17,8 @@ The Tyk MDCB server is configured primarily via the `tyk_sink.conf` file, this f
 ### Environment Variables
 
 Environment variables (env var) can be used to override the settings defined in the configuration file. Where an environment variable is specified, its value will take precedence over the value in the configuration file.
+
+<EnvTypeMapping/>
 
 ### Default Ports
 

--- a/tyk-oss-gateway/configuration.mdx
+++ b/tyk-oss-gateway/configuration.mdx
@@ -7,11 +7,14 @@ canonical: "https://tyk.io/docs/tyk-oss-gateway/configuration"
 ---
 
 import GatewayConfig from '/snippets/5.10/gateway-config.mdx';
+import EnvTypeMapping from '/snippets/5.10/env-type-mapping.mdx';
 
 You can use environment variables to override the config file for the Tyk Gateway. The Gateway configuration file can be found in the `tyk-gateway` folder and by default is called `tyk.conf`, though it can be renamed and specified using the `--conf` flag. Environment variables are created from the dot notation versions of the JSON objects contained with the config files.
 To understand how the environment variables notation works, see [Environment Variables](/tyk-oss-gateway/configuration).
 
 All the Gateway environment variables have the prefix `TYK_GW_`. The environment variables will take precedence over the values in the configuration file.
+
+<EnvTypeMapping/>
 
 ### tyk lint
 

--- a/tyk-pump/tyk-pump-configuration/tyk-pump-environment-variables.mdx
+++ b/tyk-pump/tyk-pump-configuration/tyk-pump-environment-variables.mdx
@@ -8,10 +8,13 @@ canonical: "https://tyk.io/docs/tyk-pump/tyk-pump-configuration/tyk-pump-environ
 ---
 
 import PumpConfig from '/snippets/5.10/pump-config.mdx';
+import EnvTypeMapping from '/snippets/5.10/env-type-mapping.mdx';
 
 You can use environment variables to override the config file for the Tyk Pump. Environment variables are created from the dot notation versions of the JSON objects contained with the config files.
 To understand how the environment variables notation works, see [Environment Variables](/tyk-oss-gateway/configuration). 
 
 All the Pump environment variables have the prefix `TYK_PMP_`. The environment variables will take precedence over the values in the configuration file.
+
+<EnvTypeMapping/>
 
 <PumpConfig/>


### PR DESCRIPTION
### **User description**
## 📚 Documentation Merge Summary

This PR contains automatically merged documentation from multiple branches.

**Triggered by:**
- **Branch:** N/A
- **Commit:** N/A
- **PR:** N/A (direct push)

**Deployment Details:**
- **Generated from:** `branches-config.json`  
- **Run ID:** 20053830547
- **Subfolder:** `(root deployment)`
- **Timestamp:** $(date)

### Changes Include:
- ✅ Merged documentation from multiple branches
- ✅ Generated unified `docs.json` configuration
- ✅ Updated assets and content structure
- ✅ Cleaned up outdated version folders

---

🚦 **This PR will be processed by merge queue to ensure proper validation and ordering.**

Previous deployment PRs have been automatically closed to prevent conflicts.


___

### **PR Type**
Documentation


___

### **Description**
- Add env type mapping snippets

- Insert mapping into config docs

- Clarify gateway timeout interactions

- Note Redis requirement for dashboard logs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Snippets["Add Env Type Mapping snippets"] -- "import & embed" --> ConfigDocs["Gateway/Dashboard/MDCB/Pump/Portal docs"]
  GatewayDocs["Gateway config & troubleshooting"] -- "add timeout notes" --> TimeoutClarifications["proxy_default_timeout vs write_timeout"]
  GatewayDocs -- "add logging note" --> RedisLoggingNote["Dashboard logs require same Redis"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>27 files</summary><table>
<tr>
  <td><strong>troubleshooting-debugging.mdx</strong><dd><code>Add section on proxy vs write timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1178/files#diff-1dbd82aeebae6527aced0012796e79160fbfec9c7e41d6b827950b47d3b6ccdc">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>configuration.mdx</strong><dd><code>Import and render env type mapping snippet</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1178/files#diff-8e9e35c37ba2fcc89a8e417bbebf6765529a5494bc434954bce3a3385ae17c00">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tyk-identity-broker-configuration.mdx</strong><dd><code>Normalize heading and include env type mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1178/files#diff-00610ef10afeb8126c609f0d49bc0b8bb958ef08273985df9d6f99609f5f9601">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>configuration.mdx</strong><dd><code>Include env type mapping in dashboard config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1178/files#diff-ae18c26f4858b996845be0ade289ca6e8f277c952ce7a3d9ca48a1220d039d20">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mdcb-configuration-options.mdx</strong><dd><code>Add env type mapping reference to MDCB</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1178/files#diff-e58c847fde80e1bcc1ddb01487230d66ffd8e7d422be674157c98078696057c7">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>configuration.mdx</strong><dd><code>Embed env type mapping in gateway config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1178/files#diff-d0154a56d70f9314150a724d1d207a5f7672afe70b5ddf43d1322ef9fe15c644">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tyk-pump-environment-variables.mdx</strong><dd><code>Add env type mapping to pump config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1178/files#diff-e6279d76f1dd7d9f3664db452a9c559a552d655080e4f4f3ea59ad42d3d37e79">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>troubleshooting-debugging.mdx</strong><dd><code>Add proxy vs write timeout guidance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1178/files#diff-b5aa5b66f145539f436126fd67aeb58eb108b515b4bfdb30cd47d59f58ce7b59">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>troubleshooting-debugging.mdx</strong><dd><code>Nightly: add proxy vs write timeout notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1178/files#diff-dc3eb84e80a7e94dc7187bc1bee19953f298fef9cbdc8628a1752bf1d2835ea1">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>configuration.mdx</strong><dd><code>Nightly: include env type mapping snippet</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1178/files#diff-bec4c92f3d3646db38e5e1b40be47cf4228a3da5074c3b7a57ebd670addff17c">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tyk-identity-broker-configuration.mdx</strong><dd><code>Nightly: heading fix and env mapping include</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1178/files#diff-e947259f3e870fe93455a0b4852bfdd69f20d1c79831c83f7ca85d0fea4f7c48">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>configuration.mdx</strong><dd><code>Nightly: add env type mapping to dashboard doc</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1178/files#diff-0b6e7eaa002e30f472582920d6dff0c36239651b1bde646492f07fd2e94d3122">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mdcb-configuration-options.mdx</strong><dd><code>Nightly: include env type mapping in MDCB doc</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1178/files#diff-025372a986a95709b18916af468c6d92145caf037baeab0b300bdc51aafd396b">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>configuration.mdx</strong><dd><code>Nightly: embed env type mapping in gateway doc</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1178/files#diff-8f1044ee98c2e3a83e151ea2a067f99004e86c5ca97fdbe86982544b6afa6413">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tyk-pump-environment-variables.mdx</strong><dd><code>Nightly: add env type mapping to pump doc</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1178/files#diff-97e9cc73ef1c38629ccecec761a85abe3880c6666a9b0e2450a4da7c9406fb04">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>configuration.mdx</strong><dd><code>Latest: include env type mapping snippet</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1178/files#diff-99e43dfea88c4257cd7245cf500d72ba7ffda9170f97dbd41cb3a1a8d11ad8ad">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>env-type-mapping.mdx</strong><dd><code>New snippet documenting env var types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1178/files#diff-6d847e470ffdfde4731000a3da20e0aa855a3694d71f53276939c9ed27ff59b9">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>gateway-config.mdx</strong><dd><code>Add timeout and Redis logging notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1178/files#diff-70282ae533c4e9cac1780d2bc879cd3fba4da658b5c3703ad4ee04254a8c2e8c">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>env-type-mapping.mdx</strong><dd><code>New snippet for 5.8 env var types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1178/files#diff-7d0cbc9c28d3e01e7479a68003cc1cbf3ec8c525c31ab248b927663bf4703f99">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>gateway-config.mdx</strong><dd><code>Add timeout cross-reference and Redis note</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1178/files#diff-6a2c05175f25667d7b5588b48367248f0d5fc5ea49d3c87f7adc045c587123b7">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>env-type-mapping.mdx</strong><dd><code>New nightly snippet for env var types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1178/files#diff-19525c66c78013f7ecf2c3b1d61ff4a5a1b55648c50d3107575899d2abcddf84">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>gateway-config.mdx</strong><dd><code>Nightly: add timeout and Redis logging notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1178/files#diff-596c5fdf1e0630d301e65130addcc2840e286e4476711ad922eee8e54e0673cf">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tyk-identity-broker-configuration.mdx</strong><dd><code>Latest: heading fix and env mapping include</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1178/files#diff-f60c93bd9894baf0a34b5f118b10f6809a2591e7d145ff05b1ef4361325424b2">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>configuration.mdx</strong><dd><code>Latest: include env type mapping in dashboard doc</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1178/files#diff-6f842fc27a19418ff86a8a9a5381873547c26d36754d11ee0995b0a035252bca">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mdcb-configuration-options.mdx</strong><dd><code>Latest: add env type mapping to MDCB doc</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1178/files#diff-0eccb01bb821e41fa556bde80d7fc16143c87f6668629ab96e143162fab882ca">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>configuration.mdx</strong><dd><code>Latest: embed env type mapping in gateway doc</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1178/files#diff-266b6843d3b658657bfb6bb235e2fdb95df65144d3301f3bda7c6ef8fefcaa55">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tyk-pump-environment-variables.mdx</strong><dd><code>Latest: add env type mapping to pump doc</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1178/files#diff-5ac3df8b6cc14c2fd8805fba214011f60a097b57f68aae017f7eef0269abec16">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

