### PR TITLE
[TT-16188] Update documentation for master

### DIFF
--- a/snippets/gateway-config.mdx
+++ b/snippets/gateway-config.mdx
@@ -159,12 +159,6 @@ Type: `int`<br />
 
 API Consumer -> Gateway network write timeout. Not setting this config, or setting this to 0, defaults to 120 seconds
 
-<Note>
-
-If you set `proxy_default_timeout` to a value greater than 120 seconds, you must also increase [http_server_options.write_timeout](#http-server-options-write-timeout) to a value greater than `proxy_default_timeout`. The `write_timeout` setting defaults to 120 seconds and controls how long Tyk waits to write the response back to the client. If not adjusted, the client connection will be closed before the upstream response is received.
-
-</Note>
-
 ### http_server_options.use_ssl
 ENV: <b>TYK_GW_HTTPSERVEROPTIONS_USESSL</b><br />
 Type: `bool`<br />
@@ -329,15 +323,28 @@ A value of zero (default) means that no maximum is set and API requests will not
 See more information about setting request size limits here:
 https://tyk.io/docs/api-management/traffic-transformation/#request-size-limits
 
+### http_server_options.xff_depth
+ENV: <b>TYK_GW_HTTPSERVEROPTIONS_XFFDEPTH</b><br />
+Type: `int`<br />
+
+XFFDepth controls which position in the X-Forwarded-For chain to use for determining client IP address.
+A value of 0 means using the first IP (default). this is way the Gateway has calculated the client IP historically,
+the most common case, and will be used when this config is not set.
+However, any non-zero value will use that position from the right in the X-Forwarded-For chain.
+This is a security feature to prevent against IP spoofing attacks, and is recommended to be set to a non-zero value.
+A value of 1 means using the last IP, 2 means second to last, and so on.
+
 ### http_server_options.max_response_body_size
 ENV: <b>TYK_GW_HTTPSERVEROPTIONS_MAXRESPONSEBODYSIZE</b><br />
 Type: `int64`<br />
 
-MaxResponseBodySize sets an upper limit on the response body (payload) size in bytes. It defaults to 0, which means there is no restriction on the response body size.
+MaxResponseBodySize configures an upper limit for the size of the response body (payload) in bytes.
+
+This limit is currently applied only if the Response Body Transform middleware is enabled.
 
 The Gateway will return `HTTP 500 Response Body Too Large` if the response payload exceeds MaxResponseBodySize+1 bytes.
 
-**Note:** The limit is applied only when the [Response Body Transform middleware](/api-management/traffic-transformation/response-body) is enabled.
+A value of zero (default) means that no maximum is set and response bodies will not be limited.
 
 ### version_header
 ENV: <b>TYK_GW_VERSIONHEADER</b><br />
@@ -446,6 +453,8 @@ This is not portable in cases where the data needs to be moved from installation
 If you set this value to `true`, then the id parameter in a stored policy (or imported policy using the Dashboard API), will be used instead of the internal ID.
 
 This option should only be used when moving an installation to a new database.
+
+Deprecated. Is not used in codebase.
 
 ### policies.policy_path
 ENV: <b>TYK_GW_POLICIES_POLICYPATH</b><br />
@@ -762,18 +771,32 @@ Type: `bool`<br />
 
 SynchroniserEnabled enable this config if MDCB has enabled the synchoniser. If disabled then it will ignore signals to synchonise recources
 
+### slave_options.dns_monitor
+DNSMonitor configures background DNS monitoring for proactive detection of MDCB DNS changes
+
+### slave_options.dns_monitor.enabled
+ENV: <b>TYK_GW_SLAVEOPTIONS_DNSMONITOR_ENABLED</b><br />
+Type: `bool`<br />
+
+Enable background DNS monitoring for proactive detection of MDCB DNS changes
+
+### slave_options.dns_monitor.check_interval
+ENV: <b>TYK_GW_SLAVEOPTIONS_DNSMONITOR_CHECKINTERVAL</b><br />
+Type: `int`<br />
+
+Check interval in seconds for DNS monitoring (default: 30)
+
 ### management_node
 ENV: <b>TYK_GW_MANAGEMENTNODE</b><br />
 Type: `bool`<br />
 
 If set to `true`, distributed rate limiter will be disabled for this node, and it will be excluded from any rate limit calculation.
 
-
 <Note>
+
 If you set `db_app_conf_options.node_is_segmented` to `true` for multiple Gateway nodes, you should ensure that `management_node` is set to `false`.
 This is to ensure visibility for the management node across all APIs.
 </Note>
-
 For pro installations, `management_node` is not a valid configuration option.
 Always set `management_node` to `false` in pro environments.
 
@@ -944,7 +967,8 @@ Maximum idle connections, per API, between Tyk and Upstream. By default not limi
 ENV: <b>TYK_GW_MAXIDLECONNSPERHOST</b><br />
 Type: `int`<br />
 
-Maximum idle connections, per API, per upstream, between Tyk and Upstream. A value of `0` will use the default from the Go standard library, which is 2 connections. Tyk recommends setting this value to `500` for production environments.
+Maximum idle connections, per API, per upstream, between Tyk and Upstream.
+A value of `0` will use the default from the Go standard library, which is 2 connections. Tyk recommends setting this value to `500` for production environments.
 
 ### max_conn_time
 ENV: <b>TYK_GW_MAXCONNTIME</b><br />
@@ -1014,12 +1038,6 @@ Type: `float64`<br />
 
 This can specify a default timeout in seconds for upstream API requests.
 Default: 30 seconds
-
-<Note>
-
-If you set `proxy_default_timeout` to a value greater than 120 seconds, you must also increase [http_server_options.write_timeout](#http-server-options-write-timeout) to a value greater than `proxy_default_timeout`. The `write_timeout` setting defaults to 120 seconds and controls how long Tyk waits to write the response back to the client. If not adjusted, the client connection will be closed before the upstream response is received.
-
-</Note>
 
 ### proxy_ssl_disable_renegotiation
 ENV: <b>TYK_GW_PROXYSSLDISABLERENEGOTIATION</b><br />
@@ -1161,11 +1179,10 @@ Type: `bool`<br />
 
 Tyk is capable of recording every hit to your API to a database with various filtering parameters. Set this value to `true` and fill in the sub-section below to enable logging.
 
-
 <Note>
-For performance reasons, Tyk will store traffic data to Redis initially and then purge the data from Redis to MongoDB or other data stores on a regular basis as determined by the purge_delay setting in your Tyk Pump configuration.
-</Note>
 
+For performance reasons, Tyk will store traffic data to Redis initially and then purge the data from Redis to MongoDB or other data stores on a regular basis as determined by the purge_delay setting in your Tyk Pump configuration.
+{{< /note >}}
 
 ### analytics_config
 This section defines options on what analytics data to store.
@@ -1974,9 +1991,10 @@ Enables the real-time Gateway log view in the Dashboard.
 
 <Note>
 
-For logs to appear in the Tyk Dashboard, both the Gateway and the Dashboard must be configured to use the **same Redis instance**. In deployments where the Data Plane (Gateway) and Control Plane (Dashboard) use separate Redis instances, enabling this option on the Gateway will not make logs available in the Dashboard.
-
-</Note>
+For logs to appear in the Tyk Dashboard, both the Gateway and the Dashboard must be configured to use the **same Redis instance**.
+In deployments where the Data Plane (Gateway) and Control Plane (Dashboard) use separate Redis instances,
+enabling this option on the Gateway will not make logs available in the Dashboard.
+{{< /note >}}
 
 ### use_sentry
 ENV: <b>TYK_GW_USESENTRY</b><br />

--- a/snippets/x-tyk-gateway.mdx
+++ b/snippets/x-tyk-gateway.mdx
@@ -206,7 +206,8 @@ Tyk classic API definition: `active`.
 **Field: `internal` (`boolean`)**
 Internal controls the exposure of the API on the Gateway.
 When set to `true`, the API will not be made available for external access and will not be included in API listings returned by the Gateway's management APIs;
-it will be accessible only via [internal looping](/advanced-configuration/transform-traffic/looping) or as a [child API version](/api-management/api-versioning#base-and-child-apis).
+it will be accessible only via [internal looping]({{< ref "advanced-configuration/transform-traffic/looping" >}}) or as a [child API version]({{< ref "api-management/api-versioning#base-and-child-apis" >}}).
+
 
 Tyk classic API definition: `internal`.
 
@@ -876,7 +877,7 @@ Tyk classic API definition: `dont_set_quota_on_create`.
 
 ### **Operations**
 
-Operations holds Operation definitions. The string key in this object is the `operationID`, which is a unique identifier for each API operation. 
+Operations holds Operation definitions. The string key in this object is the `operationID`, which is a unique identifier for each API operation.
 
 Type defined as object of `Operation` values, see [Operation](#operation) definition.
 
@@ -1708,6 +1709,46 @@ Value is the value of custom plugin config data.
 
 Tyk classic API definition: `config_data`.
 
+### **CustomPlugin**
+
+CustomPlugin configures custom plugin.
+
+**Field: `enabled` (`boolean`)**
+Enabled activates the custom plugin.
+
+
+Tyk classic API definition: `custom_middleware.pre[].disabled`, `custom_middleware.post_key_auth[].disabled`,.
+`custom_middleware.post[].disabled`, `custom_middleware.response[].disabled` (negated).
+
+**Field: `functionName` (`string`)**
+FunctionName is the name of authentication method.
+
+
+Tyk classic API definition: `custom_middleware.pre[].name`, `custom_middleware.post_key_auth[].name`,.
+`custom_middleware.post[].name`, `custom_middleware.response[].name`.
+
+**Field: `path` (`string`)**
+Path is the path to shared object file in case of goplugin mode or path to JS code in case of otto auth plugin.
+
+
+Tyk classic API definition: `custom_middleware.pre[].path`, `custom_middleware.post_key_auth[].path`,.
+`custom_middleware.post[].path`, `custom_middleware.response[].path`.
+
+**Field: `rawBodyOnly` (`boolean`)**
+RawBodyOnly if set to true, do not fill body in request or response object.
+
+
+Tyk classic API definition: `custom_middleware.pre[].raw_body_only`, `custom_middleware.post_key_auth[].raw_body_only`,.
+`custom_middleware.post[].raw_body_only`, `custom_middleware.response[].raw_body_only`.
+
+**Field: `requireSession` (`boolean`)**
+RequireSession if set to true passes down the session information for plugins after authentication.
+RequireSession is used only with JSVM custom middleware.
+
+
+Tyk classic API definition: `custom_middleware.pre[].require_session`, `custom_middleware.post_key_auth[].require_session`,.
+`custom_middleware.post[].require_session`, `custom_middleware.response[].require_session`.
+
 ### **Headers**
 
 Headers is an array of Header.
@@ -1802,46 +1843,6 @@ Name is the name of the header.
 
 **Field: `value` (`string`)**
 Value is the value of the header.
-
-### **CustomPlugin**
-
-CustomPlugin configures custom plugin.
-
-**Field: `enabled` (`boolean`)**
-Enabled activates the custom plugin.
-
-
-Tyk classic API definition: `custom_middleware.pre[].disabled`, `custom_middleware.post_key_auth[].disabled`,.
-`custom_middleware.post[].disabled`, `custom_middleware.response[].disabled` (negated).
-
-**Field: `functionName` (`string`)**
-FunctionName is the name of authentication method.
-
-
-Tyk classic API definition: `custom_middleware.pre[].name`, `custom_middleware.post_key_auth[].name`,.
-`custom_middleware.post[].name`, `custom_middleware.response[].name`.
-
-**Field: `path` (`string`)**
-Path is the path to shared object file in case of goplugin mode or path to JS code in case of otto auth plugin.
-
-
-Tyk classic API definition: `custom_middleware.pre[].path`, `custom_middleware.post_key_auth[].path`,.
-`custom_middleware.post[].path`, `custom_middleware.response[].path`.
-
-**Field: `rawBodyOnly` (`boolean`)**
-RawBodyOnly if set to true, do not fill body in request or response object.
-
-
-Tyk classic API definition: `custom_middleware.pre[].raw_body_only`, `custom_middleware.post_key_auth[].raw_body_only`,.
-`custom_middleware.post[].raw_body_only`, `custom_middleware.response[].raw_body_only`.
-
-**Field: `requireSession` (`boolean`)**
-RequireSession if set to true passes down the session information for plugins after authentication.
-RequireSession is used only with JSVM custom middleware.
-
-
-Tyk classic API definition: `custom_middleware.pre[].require_session`, `custom_middleware.post_key_auth[].require_session`,.
-`custom_middleware.post[].require_session`, `custom_middleware.response[].require_session`.
 
 ### **IDExtractorConfig**
 
@@ -2046,6 +2047,16 @@ Multiple rules can be mixed, some blocking and others non-blocking.
 CustomClaimValidationType represents how a JWT claim should be validated.
 This determines the validation logic used to check the claim value.
 The validation behavior varies based on both the type selected and the claim's data type.
+
+### **EdgeEndpoint**
+
+EdgeEndpoint represents an edge gateway endpoint configuration.
+
+**Field: `Endpoint` (`string`)**
+Endpoint is the edge gateway URL (e.g., "http://edge1.example.com").
+
+**Field: `Tags` (`[]string`)**
+Tags are the tags associated with this edge gateway.
 
 ### **EndpointPostPlugin**
 
@@ -2353,9 +2364,9 @@ The validation can be one of three types:
 - "contains": for strings, must contain one of the values as substring; for arrays, must contain one of the values as element
 
 Examples:
-Basic validation: `{"role": {"type": "exact_match", "allowedValues": ["admin", "user"]}}`
-Nested claim: `{"user.metadata.level": {"type": "contains", "allowedValues": ["gold", "silver"]}}`
-Multiple rules: `{"permissions": {"type": "contains", "allowedValues": ["read", "write"], "nonBlocking": true}}`
+Basic validation: {"role": {"type": "exact_match", "allowedValues": ["admin", "user"]}}
+Nested claim: {"user.metadata.level": {"type": "contains", "allowedValues": ["gold", "silver"]}}
+Multiple rules: {"permissions": {"type": "contains", "allowedValues": ["read", "write"], "nonBlocking": true}}
 
 Claims can be of type string, number, boolean, or array. For arrays, the contains validation
 checks if any of the array elements exactly match any of the allowed values.
@@ -2509,6 +2520,7 @@ Block request by allowance.
 **Field: `ignoreAuthentication` ([Allowance](#allowance))**
 IgnoreAuthentication ignores authentication on request by allowance.
 
+
 Tyk classic API definition: version_data.versions..extended_paths.ignored[].
 
 **Field: `internal` ([Internal](#internal))**
@@ -2601,7 +2613,6 @@ Connect holds plugin configuration for CONNECT requests.
 ### **Paths**
 
 Paths is a mapping of API endpoints to Path plugin configurations. This field is part of the [Middleware](#middleware) structure.
-
 The string keys in this object represent URL path patterns (e.g. `/users`, `/users/{id}`, `/api/*`) that match API endpoints.
 
 Type defined as object of `Path` values, see [Path](#path) definition.
@@ -2618,6 +2629,7 @@ Block request by allowance.
 
 **Field: `ignoreAuthentication` ([Allowance](#allowance))**
 IgnoreAuthentication ignores authentication on request by allowance.
+
 
 Tyk classic API definition: version_data.versions..extended_paths.ignored[].
 
@@ -2655,6 +2667,22 @@ Tyk classic API definition: `version_data.versions..extended_paths.size_limits[]
 ### **SecurityScheme**
 
 SecurityScheme defines an Importer interface for security schemes.
+
+### **ServerRegenerationConfig**
+
+ServerRegenerationConfig holds the configuration required for server URL regeneration.
+
+**Field: `Protocol` (`string`)**
+Protocol is the URL scheme (http:// or https://).
+
+**Field: `DefaultHost` (`string`)**
+DefaultHost is the default gateway host (e.g., "localhost:8080").
+
+**Field: `EdgeEndpoints` ([[]EdgeEndpoint](#edgeendpoint))**
+EdgeEndpoints contains edge gateway configurations.
+
+**Field: `HybridEnabled` (`boolean`)**
+HybridEnabled indicates if the gateway is in MDCB/hybrid mode.
 
 ### **Signature**
 

--- a/swagger/gateway-swagger.yml
+++ b/swagger/gateway-swagger.yml
@@ -33,7 +33,7 @@ info:
     name: Mozilla Public License Version 2.0
     url: https://github.com/TykTechnologies/tyk/blob/master/LICENSE.md
   title: Tyk Gateway API
-  version: 5.10.1
+  version: 5.11.0
 servers:
 - url: https://{tenant}
   variables:
@@ -748,7 +748,7 @@ paths:
                 items:
                   allOf:
                   - $ref: '#/components/schemas/OpenAPI3Schema'
-                  - $ref: '#/components/schemas/XTykAPIGateway'
+                  - $ref: '#/components/schemas/TykVendorExtension'
                 type: array
           description: List of API definitions in Tyk OAS format.
         "403":
@@ -849,7 +849,7 @@ paths:
             schema:
               allOf:
               - $ref: '#/components/schemas/OpenAPI3Schema'
-              - $ref: '#/components/schemas/XTykAPIGateway'
+              - $ref: '#/components/schemas/TykVendorExtension'
       responses:
         "200":
           content:
@@ -987,7 +987,7 @@ paths:
               schema:
                 allOf:
                 - $ref: '#/components/schemas/OpenAPI3Schema'
-                - $ref: '#/components/schemas/XTykAPIGateway'
+                - $ref: '#/components/schemas/TykVendorExtension'
           description: OK
           headers:
             x-tyk-base-api-id:
@@ -1210,7 +1210,7 @@ paths:
             schema:
               allOf:
               - $ref: '#/components/schemas/OpenAPI3Schema'
-              - $ref: '#/components/schemas/XTykAPIGateway'
+              - $ref: '#/components/schemas/TykVendorExtension'
       responses:
         "200":
           content:
@@ -2009,9 +2009,6 @@ paths:
         name: hashed
         required: false
         schema:
-          enum:
-          - true
-          - false
           type: boolean
       requestBody:
         content:
@@ -2114,9 +2111,6 @@ paths:
         name: hashed
         required: false
         schema:
-          enum:
-          - true
-          - false
           type: boolean
       - description: The key ID.
         example: 5e9d9544a1dcd60001d0ed20e7f75f9e03534825b7aef9df749582e5
@@ -2177,9 +2171,6 @@ paths:
         name: hashed
         required: false
         schema:
-          enum:
-          - true
-          - false
           type: boolean
       - description: The key ID.
         example: 5e9d9544a1dcd60001d0ed20e7f75f9e03534825b7aef9df749582e5
@@ -2293,9 +2284,6 @@ paths:
         name: hashed
         required: false
         schema:
-          enum:
-          - true
-          - false
           type: boolean
       - description: Name to give the custom key.
         example: customKey
@@ -2420,9 +2408,6 @@ paths:
         name: hashed
         required: false
         schema:
-          enum:
-          - true
-          - false
           type: boolean
       - description: ID of the key you want to update.
         example: 5e9d9544a1dcd60001d0ed20766d9a6ec6b4403b93a554feefef4708
@@ -4461,9 +4446,6 @@ paths:
         name: block
         required: false
         schema:
-          enum:
-          - true
-          - false
           type: boolean
       responses:
         "200":
@@ -5682,9 +5664,6 @@ components:
           type: string
       type: object
     BooleanQueryParam:
-      enum:
-      - true
-      - false
       example: true
       type: boolean
     CORS:
@@ -7837,7 +7816,7 @@ components:
         oas:
           oneOf:
             - $ref: '#/components/schemas/OpenAPI3Schema'
-            - $ref: '#/components/schemas/XTykAPIGateway'
+            - $ref: '#/components/schemas/TykVendorExtension'
       oneOf:
         - required: [oas]
         - required: [spec]
@@ -8253,6 +8232,11 @@ components:
           $ref: '#/components/schemas/Server'
         upstream:
           $ref: '#/components/schemas/Upstream'
+      type: object
+    TykVendorExtension:
+      properties:
+        x-tyk-api-gateway:
+          $ref: '#/components/schemas/XTykAPIGateway'
       type: object
   securitySchemes:
     api_key:


### PR DESCRIPTION
### **User description**
Triggered by: sharadregoti

Included:

Tyk Gateway: true
Tyk Dashboard: false
Tyk MDCB false
Tyk Pump false

Intended for: master
Changes sourced from: release-5.11.0
Config info generator branch: main

Note: <none> (branch suffix: docs)

JIRA: https://tyktech.atlassian.net/browse/TT-16188


___

### **PR Type**
Documentation


___

### **Description**
- Add new Gateway config docs, XFF depth

- Clarify response body size behavior

- Document MDCB DNS monitor options

- Update OpenAPI to 5.11; vendor extension schema


___

### Diagram Walkthrough


```mermaid
flowchart LR
  cfg["Gateway config docs"] -- add/clarify --> http["HTTP server options"]
  cfg -- add --> mdcb["MDCB DNS monitor options"]
  oas["Swagger 5.11.0"] -- update --> ver["Version bump"]
  oas -- schema change --> vendor["TykVendorExtension replaces inline XTyk"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gateway-config.mdx</strong><dd><code>New configs and clarifications in Gateway settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

snippets/gateway-config.mdx

<ul><li>Remove outdated write_timeout cross-note.<br> <li> Add <code>http_server_options.xff_depth</code> config.<br> <li> Clarify <code>max_response_body_size</code> applicability and defaults.<br> <li> Mark <code>policies.allowExplicitPolicyId</code> deprecated.<br> <li> Add MDCB <code>slave_options.dns_monitor</code> options.<br> <li> Fix/standardize Note blocks and wording.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1190/files#diff-94e6408e3fd62de5fa8ddfa92774d3d12f973f9feb257f1a2664fca38cdc8ac4">+41/-23</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>x-tyk-gateway.mdx</strong><dd><code>OAS vendor docs: plugins and edge/server configs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

snippets/x-tyk-gateway.mdx

<ul><li>Fix internal links using Hugo ref.<br> <li> Add <code>CustomPlugin</code> section earlier; remove duplicate later.<br> <li> Add <code>EdgeEndpoint</code> and <code>ServerRegenerationConfig</code> docs.<br> <li> Minor wording/whitespace and example formatting fixes.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1190/files#diff-32458678320dc9b496ba522552f26638cbe2206e0a69d6bdaaeecf40a060f91f">+74/-46</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gateway-swagger.yml</strong><dd><code>Swagger 5.11.0 with vendor extension schema updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

swagger/gateway-swagger.yml

<ul><li>Bump API version to 5.11.0.<br> <li> Introduce <code>TykVendorExtension</code> wrapper schema.<br> <li> Replace inline <code>XTykAPIGateway</code> refs with <code>TykVendorExtension</code>.<br> <li> Simplify boolean query param schemas (remove enums).</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1190/files#diff-7556595c16b2968c09325441cc3fbdc2d82a1202de4c0e89fb7448fe8332ec92">+11/-27</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

