### PR TITLE
Merging to release-5.10: [TT-16278] docs: add PORTAL_SSO_CUSTOM_LOGIN_URL configuration (#1234)

### DIFF
--- a/product-stack/tyk-enterprise-developer-portal/deploy/configuration.mdx
+++ b/product-stack/tyk-enterprise-developer-portal/deploy/configuration.mdx
@@ -30,6 +30,7 @@ However, you can leverage the settings below to customize the deployment of your
   "ProductDocRenderer": "stoplight",
   "LogLevel": "debug",
   "LogFormat": "dev",
+  "SSOCustomLoginURL": "https://your-idp.example.com/login",
   "TLSConfig": {
     "Enable": true,
     "InsecureSkipVerify": true,
@@ -56,6 +57,7 @@ PORTAL_THEMING_PATH=./themes
 PORTAL_DOCRENDERER=stoplight
 PORTAL_LOG_LEVEL=debug
 PORTAL_LOG_FORMAT=dev
+PORTAL_SSO_CUSTOM_LOGIN_URL=https://your-idp.example.com/login
 PORTAL_TLS_ENABLE=true
 PORTAL_TLS_INSECURE_SKIP_VERIFY=true
 PORTAL_TLS_CERTIFICATES = '[{"Name": "localhost","CertFile": "portal.crt","KeyFile": "portal.key"}]'
@@ -276,7 +278,12 @@ Values for TLS Versions:
 **Config file:** PortalAPISecret <br/>
 **Type:** `string` <br/>
 **Description**: API secret for enabling [Single Sign-on (SSO) flow](/tyk-stack/tyk-developer-portal/enterprise-developer-portal/managing-access/enable-sso) with the Tyk Identity Broker.
-You can specify any string value in this setting. Omit this setting if you don't require SSO. 
+You can specify any string value in this setting. Omit this setting if you don't require SSO.
+
+### PORTAL_SSO_CUSTOM_LOGIN_URL
+**Config file:** SSOCustomLoginURL <br/>
+**Type:** `string` <br/>
+**Description**: Redirects the portal login page to a custom SSO login URL. When set, GET requests to `/auth/password/login` are automatically redirected to this URL, and the portal's "Log in" button points to it. This is useful when using an Identity Provider (IDP) based login/SSO profile, as it allows you to bypass the default portal password login page and direct users to your external IDP login page instead. This setting only affects the login page redirect; user registration and password reset pages remain unchanged.
 
 ## Response Headers Configuration
 This section explains how to configure custom HTTP response headers that will be added to all responses from the Portal.
@@ -605,6 +612,7 @@ PORTAL_CORS_ALLOWED_METHODS=GET,POST,HEAD
   "ProductDocRenderer": "stoplight",
   "LogLevel": "debug",
   "LogFormat": "dev",
+  "SSOCustomLoginURL": "https://your-idp.example.com/login",
   "TLSConfig": {
     "Enable": true,
     "InsecureSkipVerify": true,
@@ -649,6 +657,7 @@ PORTAL_THEMING_PATH=./themes
 PORTAL_DOCRENDERER=stoplight
 PORTAL_LOG_LEVEL=debug
 PORTAL_LOG_FORMAT=dev
+PORTAL_SSO_CUSTOM_LOGIN_URL=https://your-idp.example.com/login
 PORTAL_TLS_ENABLE=true
 PORTAL_TLS_INSECURE_SKIP_VERIFY=true
 PORTAL_TLS_CERTIFICATES = '[{"Name": "localhost","CertFile": "portal.crt","KeyFile": "portal.key"}]'


### PR DESCRIPTION
[TT-16278] docs: add PORTAL_SSO_CUSTOM_LOGIN_URL configuration (#1234)

Add documentation for the new PORTAL_SSO_CUSTOM_LOGIN_URL environment
variable introduced in portal PR #1715 (TT-15340).

This setting allows redirecting the portal login page to a custom SSO
login URL, enabling seamless integration with external Identity Providers.

Changes:
- Add PORTAL_SSO_CUSTOM_LOGIN_URL configuration entry
- Update sample config files (JSON and environment variables)
- Place documentation next to PORTAL_API_SECRET (related SSO setting)

Co-authored-by: Leonid Bugaev <leonsbox@gmail.com>

[TT-16278]: https://tyktech.atlassian.net/browse/TT-16278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ