### PR TITLE
🤖 Auto-merge documentation from branches

### DIFF
--- a/developer-support/release-notes/sync.mdx
+++ b/developer-support/release-notes/sync.mdx
@@ -32,7 +32,7 @@ Tyk Sync 2.1.1 was accidentally also released to [DockerHub](https://hub.docker.
 #### Release Date 18 December 2025
 
 #### Release Highlights
-Tyk Sync 2.1.5 is a version alignment release that ensures compatibility with the most recent Tyk LTS release [5.8.9](/developer-support/release-notes/dashboard#589-release-notes). It contains one bug fix.
+Tyk Sync 2.1.5 is a version alignment release that ensures compatibility with the most recent Tyk LTS release [5.8.9](/developer-support/release-notes/dashboard#589-release-notes). No functional changes have been implemented in this release.
 
 #### Breaking Changes
 This release has no breaking changes.
@@ -54,12 +54,7 @@ Go to the [Upgrading Tyk](#upgrading-tyk) section for detailed upgrade Instructi
 #### Changelog
 <a id="Changelog-v2.1.5"></a>
 
-##### Fixed
-
-<Expandable title='Fixed error when deleting policies'>
-Fixed an issue introduced in v2.1.0 where Tyk Sync would not successfully delete a policy that has been removed from `.tyk.json`. The Dashboard would return an error reporting `invalid doc id` when the `sync` operation was triggered. Now Tyk Sync identifies the policy to be deleted and correctly deletes it from the Dashboard.
-</Expandable>
-
+No changes this release
 
 ### 2.1.4 Release Notes
 

--- a/snippets/5.10/gateway-config.mdx
+++ b/snippets/5.10/gateway-config.mdx
@@ -162,7 +162,6 @@ API Consumer -> Gateway network write timeout. Not setting this config, or setti
 <Note>
 
 If you set `proxy_default_timeout` to a value greater than 120 seconds, you must also increase [http_server_options.write_timeout](#http-server-options-write-timeout) to a value greater than `proxy_default_timeout`. The `write_timeout` setting defaults to 120 seconds and controls how long Tyk waits to write the response back to the client. If not adjusted, the client connection will be closed before the upstream response is received.
-
 </Note>
 
 ### http_server_options.use_ssl
@@ -329,6 +328,17 @@ A value of zero (default) means that no maximum is set and API requests will not
 See more information about setting request size limits here:
 https://tyk.io/docs/api-management/traffic-transformation/#request-size-limits
 
+### http_server_options.xff_depth
+ENV: <b>TYK_GW_HTTPSERVEROPTIONS_XFFDEPTH</b><br />
+Type: `int`<br />
+
+XFFDepth controls which position in the X-Forwarded-For chain to use for determining client IP address.
+A value of 0 means using the first IP (default). this is way the Gateway has calculated the client IP historically,
+the most common case, and will be used when this config is not set.
+However, any non-zero value will use that position from the right in the X-Forwarded-For chain.
+This is a security feature to prevent against IP spoofing attacks, and is recommended to be set to a non-zero value.
+A value of 1 means using the last IP, 2 means second to last, and so on.
+
 ### http_server_options.max_response_body_size
 ENV: <b>TYK_GW_HTTPSERVEROPTIONS_MAXRESPONSEBODYSIZE</b><br />
 Type: `int64`<br />
@@ -338,6 +348,7 @@ MaxResponseBodySize sets an upper limit on the response body (payload) size in b
 The Gateway will return `HTTP 500 Response Body Too Large` if the response payload exceeds MaxResponseBodySize+1 bytes.
 
 **Note:** The limit is applied only when the [Response Body Transform middleware](/api-management/traffic-transformation/response-body) is enabled.
+
 
 ### version_header
 ENV: <b>TYK_GW_VERSIONHEADER</b><br />
@@ -446,6 +457,8 @@ This is not portable in cases where the data needs to be moved from installation
 If you set this value to `true`, then the id parameter in a stored policy (or imported policy using the Dashboard API), will be used instead of the internal ID.
 
 This option should only be used when moving an installation to a new database.
+
+Deprecated. Is not used in codebase.
 
 ### policies.policy_path
 ENV: <b>TYK_GW_POLICIES_POLICYPATH</b><br />
@@ -762,18 +775,32 @@ Type: `bool`<br />
 
 SynchroniserEnabled enable this config if MDCB has enabled the synchoniser. If disabled then it will ignore signals to synchonise recources
 
+### slave_options.dns_monitor
+DNSMonitor configures background DNS monitoring for proactive detection of MDCB DNS changes
+
+### slave_options.dns_monitor.enabled
+ENV: <b>TYK_GW_SLAVEOPTIONS_DNSMONITOR_ENABLED</b><br />
+Type: `bool`<br />
+
+Enable background DNS monitoring for proactive detection of MDCB DNS changes
+
+### slave_options.dns_monitor.check_interval
+ENV: <b>TYK_GW_SLAVEOPTIONS_DNSMONITOR_CHECKINTERVAL</b><br />
+Type: `int`<br />
+
+Check interval in seconds for DNS monitoring (default: 30)
+
 ### management_node
 ENV: <b>TYK_GW_MANAGEMENTNODE</b><br />
 Type: `bool`<br />
 
 If set to `true`, distributed rate limiter will be disabled for this node, and it will be excluded from any rate limit calculation.
 
-
 <Note>
+
 If you set `db_app_conf_options.node_is_segmented` to `true` for multiple Gateway nodes, you should ensure that `management_node` is set to `false`.
 This is to ensure visibility for the management node across all APIs.
 </Note>
-
 For pro installations, `management_node` is not a valid configuration option.
 Always set `management_node` to `false` in pro environments.
 
@@ -944,7 +971,8 @@ Maximum idle connections, per API, between Tyk and Upstream. By default not limi
 ENV: <b>TYK_GW_MAXIDLECONNSPERHOST</b><br />
 Type: `int`<br />
 
-Maximum idle connections, per API, per upstream, between Tyk and Upstream. A value of `0` will use the default from the Go standard library, which is 2 connections. Tyk recommends setting this value to `500` for production environments.
+Maximum idle connections, per API, per upstream, between Tyk and Upstream.
+A value of `0` will use the default from the Go standard library, which is 2 connections. Tyk recommends setting this value to `500` for production environments.
 
 ### max_conn_time
 ENV: <b>TYK_GW_MAXCONNTIME</b><br />
@@ -1018,7 +1046,6 @@ Default: 30 seconds
 <Note>
 
 If you set `proxy_default_timeout` to a value greater than 120 seconds, you must also increase [http_server_options.write_timeout](#http-server-options-write-timeout) to a value greater than `proxy_default_timeout`. The `write_timeout` setting defaults to 120 seconds and controls how long Tyk waits to write the response back to the client. If not adjusted, the client connection will be closed before the upstream response is received.
-
 </Note>
 
 ### proxy_ssl_disable_renegotiation
@@ -1161,11 +1188,10 @@ Type: `bool`<br />
 
 Tyk is capable of recording every hit to your API to a database with various filtering parameters. Set this value to `true` and fill in the sub-section below to enable logging.
 
-
 <Note>
+
 For performance reasons, Tyk will store traffic data to Redis initially and then purge the data from Redis to MongoDB or other data stores on a regular basis as determined by the purge_delay setting in your Tyk Pump configuration.
 </Note>
-
 
 ### analytics_config
 This section defines options on what analytics data to store.
@@ -1974,8 +2000,9 @@ Enables the real-time Gateway log view in the Dashboard.
 
 <Note>
 
-For logs to appear in the Tyk Dashboard, both the Gateway and the Dashboard must be configured to use the **same Redis instance**. In deployments where the Data Plane (Gateway) and Control Plane (Dashboard) use separate Redis instances, enabling this option on the Gateway will not make logs available in the Dashboard.
-
+For logs to appear in the Tyk Dashboard, both the Gateway and the Dashboard must be configured to use the **same Redis instance**.
+In deployments where the Data Plane (Gateway) and Control Plane (Dashboard) use separate Redis instances,
+enabling this option on the Gateway will not make logs available in the Dashboard.
 </Note>
 
 ### use_sentry

--- a/snippets/5.10/x-tyk-gateway.mdx
+++ b/snippets/5.10/x-tyk-gateway.mdx
@@ -208,6 +208,7 @@ Internal controls the exposure of the API on the Gateway.
 When set to `true`, the API will not be made available for external access and will not be included in API listings returned by the Gateway's management APIs;
 it will be accessible only via [internal looping](/advanced-configuration/transform-traffic/looping) or as a [child API version](/api-management/api-versioning#base-and-child-apis).
 
+
 Tyk classic API definition: `internal`.
 
 ### **Versioning**
@@ -876,7 +877,7 @@ Tyk classic API definition: `dont_set_quota_on_create`.
 
 ### **Operations**
 
-Operations holds Operation definitions. The string key in this object is the `operationID`, which is a unique identifier for each API operation. 
+Operations holds Operation definitions. The string key in this object is the `operationID`, which is a unique identifier for each API operation.
 
 Type defined as object of `Operation` values, see [Operation](#operation) definition.
 
@@ -1708,6 +1709,46 @@ Value is the value of custom plugin config data.
 
 Tyk classic API definition: `config_data`.
 
+### **CustomPlugin**
+
+CustomPlugin configures custom plugin.
+
+**Field: `enabled` (`boolean`)**
+Enabled activates the custom plugin.
+
+
+Tyk classic API definition: `custom_middleware.pre[].disabled`, `custom_middleware.post_key_auth[].disabled`,.
+`custom_middleware.post[].disabled`, `custom_middleware.response[].disabled` (negated).
+
+**Field: `functionName` (`string`)**
+FunctionName is the name of authentication method.
+
+
+Tyk classic API definition: `custom_middleware.pre[].name`, `custom_middleware.post_key_auth[].name`,.
+`custom_middleware.post[].name`, `custom_middleware.response[].name`.
+
+**Field: `path` (`string`)**
+Path is the path to shared object file in case of goplugin mode or path to JS code in case of otto auth plugin.
+
+
+Tyk classic API definition: `custom_middleware.pre[].path`, `custom_middleware.post_key_auth[].path`,.
+`custom_middleware.post[].path`, `custom_middleware.response[].path`.
+
+**Field: `rawBodyOnly` (`boolean`)**
+RawBodyOnly if set to true, do not fill body in request or response object.
+
+
+Tyk classic API definition: `custom_middleware.pre[].raw_body_only`, `custom_middleware.post_key_auth[].raw_body_only`,.
+`custom_middleware.post[].raw_body_only`, `custom_middleware.response[].raw_body_only`.
+
+**Field: `requireSession` (`boolean`)**
+RequireSession if set to true passes down the session information for plugins after authentication.
+RequireSession is used only with JSVM custom middleware.
+
+
+Tyk classic API definition: `custom_middleware.pre[].require_session`, `custom_middleware.post_key_auth[].require_session`,.
+`custom_middleware.post[].require_session`, `custom_middleware.response[].require_session`.
+
 ### **Headers**
 
 Headers is an array of Header.
@@ -1802,46 +1843,6 @@ Name is the name of the header.
 
 **Field: `value` (`string`)**
 Value is the value of the header.
-
-### **CustomPlugin**
-
-CustomPlugin configures custom plugin.
-
-**Field: `enabled` (`boolean`)**
-Enabled activates the custom plugin.
-
-
-Tyk classic API definition: `custom_middleware.pre[].disabled`, `custom_middleware.post_key_auth[].disabled`,.
-`custom_middleware.post[].disabled`, `custom_middleware.response[].disabled` (negated).
-
-**Field: `functionName` (`string`)**
-FunctionName is the name of authentication method.
-
-
-Tyk classic API definition: `custom_middleware.pre[].name`, `custom_middleware.post_key_auth[].name`,.
-`custom_middleware.post[].name`, `custom_middleware.response[].name`.
-
-**Field: `path` (`string`)**
-Path is the path to shared object file in case of goplugin mode or path to JS code in case of otto auth plugin.
-
-
-Tyk classic API definition: `custom_middleware.pre[].path`, `custom_middleware.post_key_auth[].path`,.
-`custom_middleware.post[].path`, `custom_middleware.response[].path`.
-
-**Field: `rawBodyOnly` (`boolean`)**
-RawBodyOnly if set to true, do not fill body in request or response object.
-
-
-Tyk classic API definition: `custom_middleware.pre[].raw_body_only`, `custom_middleware.post_key_auth[].raw_body_only`,.
-`custom_middleware.post[].raw_body_only`, `custom_middleware.response[].raw_body_only`.
-
-**Field: `requireSession` (`boolean`)**
-RequireSession if set to true passes down the session information for plugins after authentication.
-RequireSession is used only with JSVM custom middleware.
-
-
-Tyk classic API definition: `custom_middleware.pre[].require_session`, `custom_middleware.post_key_auth[].require_session`,.
-`custom_middleware.post[].require_session`, `custom_middleware.response[].require_session`.
 
 ### **IDExtractorConfig**
 
@@ -2046,6 +2047,16 @@ Multiple rules can be mixed, some blocking and others non-blocking.
 CustomClaimValidationType represents how a JWT claim should be validated.
 This determines the validation logic used to check the claim value.
 The validation behavior varies based on both the type selected and the claim's data type.
+
+### **EdgeEndpoint**
+
+EdgeEndpoint represents an edge gateway endpoint configuration.
+
+**Field: `Endpoint` (`string`)**
+Endpoint is the edge gateway URL (e.g., "http://edge1.example.com").
+
+**Field: `Tags` (`[]string`)**
+Tags are the tags associated with this edge gateway.
 
 ### **EndpointPostPlugin**
 
@@ -2509,6 +2520,7 @@ Block request by allowance.
 **Field: `ignoreAuthentication` ([Allowance](#allowance))**
 IgnoreAuthentication ignores authentication on request by allowance.
 
+
 Tyk classic API definition: version_data.versions..extended_paths.ignored[].
 
 **Field: `internal` ([Internal](#internal))**
@@ -2601,7 +2613,6 @@ Connect holds plugin configuration for CONNECT requests.
 ### **Paths**
 
 Paths is a mapping of API endpoints to Path plugin configurations. This field is part of the [Middleware](#middleware) structure.
-
 The string keys in this object represent URL path patterns (e.g. `/users`, `/users/{id}`, `/api/*`) that match API endpoints.
 
 Type defined as object of `Path` values, see [Path](#path) definition.
@@ -2618,6 +2629,7 @@ Block request by allowance.
 
 **Field: `ignoreAuthentication` ([Allowance](#allowance))**
 IgnoreAuthentication ignores authentication on request by allowance.
+
 
 Tyk classic API definition: version_data.versions..extended_paths.ignored[].
 

--- a/swagger/5.10/gateway-swagger.yml
+++ b/swagger/5.10/gateway-swagger.yml
@@ -33,7 +33,7 @@ info:
     name: Mozilla Public License Version 2.0
     url: https://github.com/TykTechnologies/tyk/blob/master/LICENSE.md
   title: Tyk Gateway API
-  version: 5.10.1
+  version: 5.11.0
 servers:
 - url: https://{tenant}
   variables:
@@ -748,7 +748,7 @@ paths:
                 items:
                   allOf:
                   - $ref: '#/components/schemas/OpenAPI3Schema'
-                  - $ref: '#/components/schemas/XTykAPIGateway'
+                  - $ref: '#/components/schemas/TykVendorExtension'
                 type: array
           description: List of API definitions in Tyk OAS format.
         "403":
@@ -849,7 +849,7 @@ paths:
             schema:
               allOf:
               - $ref: '#/components/schemas/OpenAPI3Schema'
-              - $ref: '#/components/schemas/XTykAPIGateway'
+              - $ref: '#/components/schemas/TykVendorExtension'
       responses:
         "200":
           content:
@@ -987,7 +987,7 @@ paths:
               schema:
                 allOf:
                 - $ref: '#/components/schemas/OpenAPI3Schema'
-                - $ref: '#/components/schemas/XTykAPIGateway'
+                - $ref: '#/components/schemas/TykVendorExtension'
           description: OK
           headers:
             x-tyk-base-api-id:
@@ -1210,7 +1210,7 @@ paths:
             schema:
               allOf:
               - $ref: '#/components/schemas/OpenAPI3Schema'
-              - $ref: '#/components/schemas/XTykAPIGateway'
+              - $ref: '#/components/schemas/TykVendorExtension'
       responses:
         "200":
           content:
@@ -2009,9 +2009,6 @@ paths:
         name: hashed
         required: false
         schema:
-          enum:
-          - true
-          - false
           type: boolean
       requestBody:
         content:
@@ -2114,9 +2111,6 @@ paths:
         name: hashed
         required: false
         schema:
-          enum:
-          - true
-          - false
           type: boolean
       - description: The key ID.
         example: 5e9d9544a1dcd60001d0ed20e7f75f9e03534825b7aef9df749582e5
@@ -2177,9 +2171,6 @@ paths:
         name: hashed
         required: false
         schema:
-          enum:
-          - true
-          - false
           type: boolean
       - description: The key ID.
         example: 5e9d9544a1dcd60001d0ed20e7f75f9e03534825b7aef9df749582e5
@@ -2293,9 +2284,6 @@ paths:
         name: hashed
         required: false
         schema:
-          enum:
-          - true
-          - false
           type: boolean
       - description: Name to give the custom key.
         example: customKey
@@ -2420,9 +2408,6 @@ paths:
         name: hashed
         required: false
         schema:
-          enum:
-          - true
-          - false
           type: boolean
       - description: ID of the key you want to update.
         example: 5e9d9544a1dcd60001d0ed20766d9a6ec6b4403b93a554feefef4708
@@ -4461,9 +4446,6 @@ paths:
         name: block
         required: false
         schema:
-          enum:
-          - true
-          - false
           type: boolean
       responses:
         "200":
@@ -5682,9 +5664,6 @@ components:
           type: string
       type: object
     BooleanQueryParam:
-      enum:
-      - true
-      - false
       example: true
       type: boolean
     CORS:
@@ -7837,7 +7816,7 @@ components:
         oas:
           oneOf:
             - $ref: '#/components/schemas/OpenAPI3Schema'
-            - $ref: '#/components/schemas/XTykAPIGateway'
+            - $ref: '#/components/schemas/TykVendorExtension'
       oneOf:
         - required: [oas]
         - required: [spec]
@@ -8253,6 +8232,11 @@ components:
           $ref: '#/components/schemas/Server'
         upstream:
           $ref: '#/components/schemas/Upstream'
+      type: object
+    TykVendorExtension:
+      properties:
+        x-tyk-api-gateway:
+          $ref: '#/components/schemas/XTykAPIGateway'
       type: object
   securitySchemes:
     api_key:


### PR DESCRIPTION
### **User description**
## 📚 Documentation Merge Summary

This PR contains automatically merged documentation from multiple branches.

**Triggered by:**
- **Branch:** N/A
- **Commit:** N/A
- **PR:** N/A (direct push)

**Deployment Details:**
- **Generated from:** `branches-config.json`  
- **Run ID:** 20777654291
- **Subfolder:** `(root deployment)`
- **Timestamp:** $(date)

### Changes Include:
- ✅ Merged documentation from multiple branches
- ✅ Generated unified `docs.json` configuration
- ✅ Updated assets and content structure
- ✅ Cleaned up outdated version folders

---

🚦 **This PR will be processed by merge queue to ensure proper validation and ordering.**

Previous deployment PRs have been automatically closed to prevent conflicts.


___

### **PR Type**
Documentation


___

### **Description**
- Update Sync 2.1.5 notes: no changes

- Expand 5.10 gateway config docs

- Add vendor extension schema to Swagger

- Text cleanups and clarifications


___

### Diagram Walkthrough


```mermaid
flowchart LR
  sync["Sync 2.1.5 notes"] -- clarify --> rn["Release notes"]
  gwcfg["Gateway 5.10 config"] -- add new options --> docs["Documentation"]
  xtyk["x-tyk-gateway spec"] -- reorganize/add types --> docs
  swagger["Gateway Swagger 5.10"] -- add TykVendorExtension + version bump --> apiSpec["API schema"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sync.mdx</strong><dd><code>Clarify Sync 2.1.5 release content</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

developer-support/release-notes/sync.mdx

<ul><li>Clarify 2.1.5 has no functional changes<br> <li> Replace fixed item with "No changes this release"</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1263/files#diff-cac9d708983eaefd5fd0b06ac25b0f3934804430ff37b7fb7d12c44c4d46e799">+2/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gateway-config.mdx</strong><dd><code>New gateway config options and deprecations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

snippets/5.10/gateway-config.mdx

<ul><li>Add http_server_options.xff_depth configuration<br> <li> Document slave_options.dns_monitor settings<br> <li> Mark policies.allow_explicit_policy_id deprecated<br> <li> Minor note formatting and copy edits</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1263/files#diff-70282ae533c4e9cac1780d2bc879cd3fba4da658b5c3703ad4ee04254a8c2e8c">+36/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>x-tyk-gateway.mdx</strong><dd><code>Reorganize and extend x-tyk-gateway types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

snippets/5.10/x-tyk-gateway.mdx

<ul><li>Add CustomPlugin section earlier; remove duplicate later<br> <li> Introduce EdgeEndpoint type<br> <li> Minor spacing and copy fixes</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1263/files#diff-193de276359697aaa7dd5c358055e56061e9f6fb9a98163b03ea54c655187f29">+54/-42</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gateway-swagger.yml</strong><dd><code>Swagger vendor extension and version update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

swagger/5.10/gateway-swagger.yml

<ul><li>Bump API version to 5.11.0<br> <li> Replace XTykAPIGateway refs with TykVendorExtension<br> <li> Add TykVendorExtension schema wrapper<br> <li> Simplify boolean query param schemas</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1263/files#diff-18930da035b134240b7444560357a19040eac3a17b966c2cc1f8929592c181fc">+11/-27</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

