### PR TITLE
docs: Add RHEL 9 to supported distributions

### DIFF
--- a/apim/open-source/installation.mdx
+++ b/apim/open-source/installation.mdx
@@ -354,6 +354,7 @@ You can choose to not install Redis by removing the `-t redis`. However, Redis i
 | CentOS | 7 | ✅ |
 | Debian | 10 | ✅ |
 | Debian | 9 | ✅ |
+| RHEL | 9 | ✅ |
 | RHEL | 8 | ✅ |
 | RHEL | 7 | ✅ |
 | Ubuntu | 21 | ✅ |
@@ -562,6 +563,7 @@ The Tyk Gateway can be installed following different installation methods includ
 | --------- | :---------: | :---------: |
 | CentOS | 8 | ✅ |
 | CentOS | 7 | ✅ |
+| RHEL | 9 | ✅ |
 | RHEL | 8 | ✅ |
 | RHEL | 7 | ✅ |
 
@@ -663,6 +665,7 @@ sudo service tyk-gateway start
 | --------- | :---------: | :---------: |
 | CentOS | 8 | ✅ |
 | CentOS | 7 | ✅ |
+| RHEL | 9 | ✅ |
 | RHEL | 8 | ✅ |
 | RHEL | 7 | ✅ |
 

--- a/tyk-self-managed/install.mdx
+++ b/tyk-self-managed/install.mdx
@@ -946,6 +946,7 @@ wget https://raw.githubusercontent.com/sedkis/tyk/master/scripts/bootstrap-ssl.s
 | CentOS | 7 | ✅ |
 | Debian | 10 | ✅ |
 | Debian | 9 | ✅ |
+| RHEL | 9 | ✅ |
 | RHEL | 8 | ✅ |
 | RHEL | 7 | ✅ |
 | Ubuntu | 21 | ✅ |
@@ -1583,6 +1584,7 @@ There are 4 components which needs to be installed. Each can be installed via sh
 | --------- | :---------: | :---------: |
 | CentOS | 7 | ✅ |
 | RHEL | 9 | ✅ |
+| RHEL | 9 | ✅ |
 | RHEL | 8 | ✅ |
 | RHEL | 7 | ✅ |
 
@@ -1665,6 +1667,7 @@ The order is to install Tyk Dashboard, then Tyk Pump and then Tyk Gateway for a 
 | Distribution | Version | Supported |
 | --------- | :---------: | :---------: |
 | CentOS | 7 | ✅ |
+| RHEL | 9 | ✅ |
 | RHEL | 8 | ✅ |
 | RHEL | 7 | ✅ |
 
@@ -2034,6 +2037,7 @@ $ ansible-playbook playbook.yaml -t tyk-dashboard
 | Amazon Linux | 2 | ✅ |
 | CentOS | 8 | ✅ |
 | CentOS | 7 | ✅ |
+| RHEL | 9 | ✅ |
 | RHEL | 8 | ✅ |
 | RHEL | 7 | ✅ |
 
@@ -2189,6 +2193,7 @@ $ ansible-playbook playbook.yaml -t tyk-pump
 | Amazon Linux | 2 | ✅ |
 | CentOS | 8 | ✅ |
 | CentOS | 7 | ✅ |
+| RHEL | 9 | ✅ |
 | RHEL | 8 | ✅ |
 | RHEL | 7 | ✅ |
 
@@ -2297,6 +2302,7 @@ $ ansible-playbook playbook.yaml -t `tyk-gateway-pro` or `tyk-gateway-hybrid`
 | Amazon Linux | 2 | ✅ |
 | CentOS | 8 | ✅ |
 | CentOS | 7 | ✅ |
+| RHEL | 9 | ✅ |
 | RHEL | 8 | ✅ |
 | RHEL | 7 | ✅ |
 


### PR DESCRIPTION
## Summary

Add RHEL 9 to the supported distributions tables in installation documentation.

### Changes

Updated the following files to include RHEL 9:

| File | Tables Updated |
|------|----------------|
| `apim/open-source/installation.mdx` | 3 tables |
| `tyk-self-managed/install.mdx` | 6 tables |

### Related PR

This documentation update corresponds to the RHEL 9 support added in tyk-ansible:
- https://github.com/TykTechnologies/tyk-ansible/pull/9

### Notes

RHEL 9 support requires a workaround for the packagecloud GPG key issue (SHA-1 deprecation in RHEL 9). See the tyk-ansible PR for technical details.

🤖 Generated with [Claude Code](https://claude.ai/code)