### PR TITLE
docs: Add cache_hit field to access logs documentation

### DIFF
--- a/api-management/logs-metrics.mdx
+++ b/api-management/logs-metrics.mdx
@@ -308,7 +308,7 @@ As of Tyk Gateway `v5.8.0`, you can configure the Gateway to log individual API 
 You can specify which fields are logged by configuring the `TYK_GW_ACCESSLOGS_TEMPLATE` environment variable. Below are the available values you can include:
 
 - `api_key`: Obfuscated or hashed API key used in the request.
-- `cache_hit`: A boolean (`true`/`false`) indicating whether the response was served from the API Response Cache. This field is `false` when the response is fetched from the upstream service or when caching is not enabled for the API.
+- `cache_hit`: A boolean indicating whether the response was served from the API Response Cache. This field is `false` when the response is fetched from the upstream service or when caching is not enabled for the API.
 - `client_ip`: IP address of the client making the request.
 - `host`: Hostname of the request.
 - `method`: HTTP method used in the request (e.g., GET, POST).

--- a/api-management/logs-metrics.mdx
+++ b/api-management/logs-metrics.mdx
@@ -308,6 +308,7 @@ As of Tyk Gateway `v5.8.0`, you can configure the Gateway to log individual API 
 You can specify which fields are logged by configuring the `TYK_GW_ACCESSLOGS_TEMPLATE` environment variable. Below are the available values you can include:
 
 - `api_key`: Obfuscated or hashed API key used in the request.
+- `cache_hit`: A boolean (`true`/`false`) indicating whether the response was served from the API Response Cache. This field is `false` when the response is fetched from the upstream service or when caching is not enabled for the API.
 - `client_ip`: IP address of the client making the request.
 - `host`: Hostname of the request.
 - `method`: HTTP method used in the request (e.g., GET, POST).
@@ -343,7 +344,7 @@ TYK_GW_ACCESSLOGS_ENABLED=true
 Output:
 
 ```
-time="Jan 29 08:27:09" level=info api_id=b1a41c9a89984ffd7bb7d4e3c6844ded api_key=00000000 api_name=httpbin client_ip="::1" host="localhost:8080" latency_total=62 method=GET org_id=678e6771247d80fd2c435bf3 path=/get prefix=access-log protocol=HTTP/1.1 remote_addr="[::1]:63251" status=200 upstream_addr="http://httpbin.org/get" upstream_latency=61 user_agent=PostmanRuntime/7.43.0
+time="Jan 29 08:27:09" level=info api_id=b1a41c9a89984ffd7bb7d4e3c6844ded api_key=00000000 api_name=httpbin cache_hit=false client_ip="::1" host="localhost:8080" latency_total=62 method=GET org_id=678e6771247d80fd2c435bf3 path=/get prefix=access-log protocol=HTTP/1.1 remote_addr="[::1]:63251" status=200 upstream_addr="http://httpbin.org/get" upstream_latency=61 user_agent=PostmanRuntime/7.43.0
 ```
 
 ##### Custom template log example


### PR DESCRIPTION
### **User description**
## Summary
- Add documentation for the new `cache_hit` field in Tyk Gateway access logs
- This field indicates whether a response was served from the API Response Cache (`true`) or from the upstream service (`false`)
- Update the default log example output to include `cache_hit=false`

## Changes
- Added `cache_hit` field description to the list of configurable access log fields
- Updated the default log example output to include the `cache_hit` field

## Related
This documentation change supports the implementation of the `cache_hit` field in the Tyk Gateway access logs, which provides visibility into caching behavior at the individual request level.

## Test plan
- [ ] Verify MDX renders correctly on Mintlify preview
- [ ] Confirm field description is clear and accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Documentation


___

### **Description**
- Add `cache_hit` access log field docs

- Explain field boolean meaning and behavior

- Update default example with `cache_hit=false`


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>logs-metrics.mdx</strong><dd><code>Document cache_hit field in access logs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api-management/logs-metrics.mdx

<ul><li>Added <code>cache_hit</code> to access log fields list<br> <li> Updated default log example with <code>cache_hit=false</code></ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1318/files#diff-0db01cd5d67a0e4bf927feb1307fccf61b0356dc7b07b0c1125e3f2be8cb90ea">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

