### PR TITLE
docs: Add cache_hit field documentation for access logs

### DIFF
--- a/api-management/response-caching.mdx
+++ b/api-management/response-caching.mdx
@@ -53,6 +53,16 @@ When a request causes a cache hit, the Gateway will add a special header to indi
 
 The API Client can use this to identify cached responses from non-cached responses.
 
+#### Cache Hit Information in Access Logs
+Tyk also records cache hit information in the access logs via the `cache_hit` field in the analytics record. This field is set to `true` when a response is served from the API Response Cache, and `false` otherwise.
+
+This provides visibility into caching behavior for monitoring and troubleshooting purposes. You can use this field to:
+ - Analyze cache hit rates across your APIs
+ - Diagnose cache invalidation issues
+ - Understand the effectiveness of your caching configuration
+
+For more details on the analytics record fields, see [Tyk Analytics Record Fields](/api-management/tyk-pump#tyk-analytics-record-fields).
+
 #### Global Cache (Safe Requests)  
 We define a <b>safe request</b> as any category of API request that is considered cacheable without causing any undesired side effects or security concerns. These are requests made using the HTTP methods `GET`, `HEAD` or `OPTIONS` that do not modify data and can be safely cached for performance gains (i.e. they should be idempotent and so are good candidates for caching). If these methods are not idempotent for your API, then you should not use safe request caching.
 

--- a/api-management/tyk-pump.mdx
+++ b/api-management/tyk-pump.mdx
@@ -1350,6 +1350,12 @@ Future expiry date.
 **Remarks:** Can be used to implement automated data expiry, if supported by storage.<br/>
 **Example:** `2022-11-23T07:26:25.762+00:00`.
 
+### CacheHit
+API Response Cache hit indicator.
+
+**Remarks:** Set to `true` if the response was served from Tyk's API Response Cache (Redis), `false` otherwise. This field is specific to the API Response Cache and is not affected by other internal caches (e.g., session cache, API definitions cache).<br/>
+**Example:** `true` or `false`.
+
 ## Monitor your APIs with Prometheus
 
 Your Tyk Pump can expose Prometheus metrics for the requests served by your Tyk Gateway. This is helpful if you want to track how often your APIs are being called and how they are performing. Tyk collects latency data of how long your services take to respond to requests, how often your services are being called and what status code they return.


### PR DESCRIPTION
### **User description**
## Summary
- Add documentation for the new `cache_hit` field in the Tyk Analytics Record
- Add section explaining cache hit information in access logs to response caching documentation

## Details
This PR documents the new `cache_hit` boolean field that will be added to Tyk Gateway access logs. This field indicates whether a response was served from the API Response Cache (Redis).

### Changes Made:
1. **tyk-pump.mdx**: Added `CacheHit` field documentation to the "Tyk Analytics Record Fields" section, explaining that this field is set to `true` when a response is served from the API Response Cache and `false` otherwise.

2. **response-caching.mdx**: Added a new "Cache Hit Information in Access Logs" subsection under "Indicating a Cached Response" that:
   - Explains the `cache_hit` field's purpose
   - Describes use cases (analyzing cache hit rates, diagnosing cache invalidation, understanding caching effectiveness)
   - Links to the analytics record fields documentation

## Test plan
- [ ] Verify documentation renders correctly on the documentation site
- [ ] Verify internal links work correctly
- [ ] Review for consistency with existing documentation style

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Documentation


___

### **Description**
- Add `cache_hit` field documentation

- Explain cache hits in access logs

- Provide cache monitoring use cases

- Link analytics record fields docs


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>response-caching.mdx</strong><dd><code>Add cache hit logs documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api-management/response-caching.mdx

<ul><li>Add "Cache Hit Information in Access Logs" section<br> <li> Describe <code>cache_hit</code> field behavior<br> <li> List usage scenarios for monitoring cache<br> <li> Add link to analytics record fields</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1320/files#diff-3e1cca9a9e2bbad90922f3b6ab8c47024ceb7d1446376f4aa87d1f621cd3d4eb">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tyk-pump.mdx</strong><dd><code>Document CacheHit analytics record field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api-management/tyk-pump.mdx

<ul><li>Add <code>CacheHit</code> field entry in analytics record<br> <li> Provide remarks for caching specifics<br> <li> Include example values (<code>true</code>/<code>false</code>)</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1320/files#diff-f307a6c08710cbe4ea1bf6588ebbe9106a87de172dd1a08dac3b4332733ecd85">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

