### PR TITLE
Add cache_hit field documentation to Gateway access logs

### DIFF
--- a/api-management/logs-metrics.mdx
+++ b/api-management/logs-metrics.mdx
@@ -308,6 +308,7 @@ As of Tyk Gateway `v5.8.0`, you can configure the Gateway to log individual API 
 You can specify which fields are logged by configuring the `TYK_GW_ACCESSLOGS_TEMPLATE` environment variable. Below are the available values you can include:
 
 - `api_key`: Obfuscated or hashed API key used in the request.
+- `cache_hit`: Indicates whether the response was served from the [API Response Cache](/api-management/response-caching) (`true`) or from the upstream service (`false`).
 - `client_ip`: IP address of the client making the request.
 - `host`: Hostname of the request.
 - `method`: HTTP method used in the request (e.g., GET, POST).
@@ -343,7 +344,7 @@ TYK_GW_ACCESSLOGS_ENABLED=true
 Output:
 
 ```
-time="Jan 29 08:27:09" level=info api_id=b1a41c9a89984ffd7bb7d4e3c6844ded api_key=00000000 api_name=httpbin client_ip="::1" host="localhost:8080" latency_total=62 method=GET org_id=678e6771247d80fd2c435bf3 path=/get prefix=access-log protocol=HTTP/1.1 remote_addr="[::1]:63251" status=200 upstream_addr="http://httpbin.org/get" upstream_latency=61 user_agent=PostmanRuntime/7.43.0
+time="Jan 29 08:27:09" level=info api_id=b1a41c9a89984ffd7bb7d4e3c6844ded api_key=00000000 api_name=httpbin cache_hit=false client_ip="::1" host="localhost:8080" latency_total=62 method=GET org_id=678e6771247d80fd2c435bf3 path=/get prefix=access-log protocol=HTTP/1.1 remote_addr="[::1]:63251" status=200 upstream_addr="http://httpbin.org/get" upstream_latency=61 user_agent=PostmanRuntime/7.43.0
 ```
 
 ##### Custom template log example

--- a/api-management/tyk-pump.mdx
+++ b/api-management/tyk-pump.mdx
@@ -1344,6 +1344,12 @@ Tracked endpoint flag.
 **Remarks:** Value is `true` if the requested endpoint is configured to be tracked, otherwise `false`.<br/>
 **Example:** `true` or `false`.
 
+### CacheHit
+Cache hit indicator.
+
+**Remarks:** Value is `true` if the response was served from the Gateway's response cache, otherwise `false`. For APIs where caching is not enabled, this field will be `false`.<br/>
+**Example:** `true` or `false`.
+
 ### ExpireAt
 Future expiry date.
 


### PR DESCRIPTION
## Summary
- Documents the new `cache_hit` field in Gateway access logs that indicates whether a response was served from the API Response Cache
- Adds `cache_hit` to the list of available access log fields with a description and link to the response caching documentation
- Updates the default log output example to include `cache_hit=false`
- Adds `CacheHit` field documentation to the Tyk Analytics Record Fields section in tyk-pump.mdx

## Test plan
- [ ] Verify the documentation renders correctly on the Tyk docs site
- [ ] Verify the link to `/api-management/response-caching` works correctly
- [ ] Verify the CacheHit field appears in the Analytics Record Fields section

## Related tickets
- Jira: [TT-16529](https://tyktech.atlassian.net/browse/TT-16529) - Add cache_hit field to Gateway access logs
- Parent: [TT-9786](https://tyktech.atlassian.net/browse/TT-9786)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TT-16529]: https://tyktech.atlassian.net/browse/TT-16529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TT-9786]: https://tyktech.atlassian.net/browse/TT-9786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ