### PR TITLE
Merging to release-5.8: fix: correct TLS setting path in Helm chart docs (DX-2201) (#1352)

### DIFF
--- a/product-stack/tyk-charts/tyk-control-plane-chart.mdx
+++ b/product-stack/tyk-charts/tyk-control-plane-chart.mdx
@@ -518,7 +518,7 @@ We have provided an easy way to enable TLS via the `global.tls.gateway` flag. Se
 If you want to use your own key/cert pair, please perform the following steps:
 1. Create a TLS secret using your cert and key pair.
 2. Set `global.tls.gateway` to true.
-3. Set `tyk-gateway.gateway.tls.useDefaultTykCertificate` to false.
+3. Set `global.tls.useDefaultTykCertificate` to false.
 4. Set `tyk-gateway.gateway.tls.secretName` to the name of the newly created secret.
 
 *Add Custom Certificates*

--- a/product-stack/tyk-charts/tyk-data-plane-chart.mdx
+++ b/product-stack/tyk-charts/tyk-data-plane-chart.mdx
@@ -345,7 +345,7 @@ automatically enable TLS using the certificate provided under tyk-gateway/certs/
 If you want to use your own key/cert pair, please follow the following steps:
 1. Create a TLS secret using your cert and key pair.
 2. Set `global.tls.gateway` to true.
-3. Set `tyk-gateway.gateway.tls.useDefaultTykCertificate` to false.
+3. Set `global.tls.useDefaultTykCertificate` to false.
 4. Set `tyk-gateway.gateway.tls.secretName` to the name of the newly created secret.
 
 *Add Custom CA Certificates*

--- a/product-stack/tyk-charts/tyk-oss-chart.mdx
+++ b/product-stack/tyk-charts/tyk-oss-chart.mdx
@@ -252,7 +252,7 @@ automatically enable TLS using the certificate provided under tyk-gateway/certs/
 If you want to use your own key/cert pair, please follow the following steps:
 1. Create a TLS secret using your cert and key pair.
 2. Set `global.tls.gateway` to true.
-3. Set `tyk-gateway.gateway.tls.useDefaultTykCertificate` to false.
+3. Set `global.tls.useDefaultTykCertificate` to false.
 4. Set `tyk-gateway.gateway.tls.secretName` to the name of the newly created secret.
 
 *Add Custom Certificates*

--- a/product-stack/tyk-charts/tyk-stack-chart.mdx
+++ b/product-stack/tyk-charts/tyk-stack-chart.mdx
@@ -501,7 +501,7 @@ automatically enable TLS using the certificate provided under tyk-gateway/certs/
 If you want to use your own key/cert pair, please follow the following steps:
 1. Create a TLS secret using your cert and key pair.
 2. Set `global.tls.gateway` to true.
-3. Set `tyk-gateway.gateway.tls.useDefaultTykCertificate` to false.
+3. Set `global.tls.useDefaultTykCertificate` to false.
 4. Set `tyk-gateway.gateway.tls.secretName` to the name of the newly created secret.
 
 *Add Custom Certificates*


### PR DESCRIPTION
### **User description**
fix: correct TLS setting path in Helm chart docs (DX-2201) (#1352)


___

### **PR Type**
Documentation


___

### **Description**
- Fix TLS setting key in Helm docs

- Use `global.tls.useDefaultTykCertificate` consistently


___

### Diagram Walkthrough


```mermaid
flowchart LR
  docs["Helm chart documentation pages"]
  oldKey["`tyk-gateway.gateway.tls.useDefaultTykCertificate`"]
  newKey["`global.tls.useDefaultTykCertificate`"]
  docs -- "replace incorrect reference" --> newKey
  oldKey -- "was documented as" --> docs
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tyk-control-plane-chart.mdx</strong><dd><code>Correct TLS config key in steps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

product-stack/tyk-charts/tyk-control-plane-chart.mdx

<ul><li>Replace gateway-scoped TLS key reference<br> <li> Document <code>global.tls.useDefaultTykCertificate</code> as correct</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1356/files#diff-d2778e266c748389474999dca7515f01b15c04d889d86a387d17668c58b292ae">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tyk-data-plane-chart.mdx</strong><dd><code>Fix TLS value path in instructions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

product-stack/tyk-charts/tyk-data-plane-chart.mdx

<ul><li>Update step to use global TLS value<br> <li> Remove incorrect <code>tyk-gateway.gateway.tls...</code> reference</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1356/files#diff-1a8c3653f09beea75685b63f5d369c2829d9265e6eabec019d4a43681384fc6a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tyk-oss-chart.mdx</strong><dd><code>Update TLS setting location in docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

product-stack/tyk-charts/tyk-oss-chart.mdx

<ul><li>Correct <code>useDefaultTykCertificate</code> value path<br> <li> Point instructions to <code>global.tls.useDefaultTykCertificate</code></ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1356/files#diff-309c8b9b36ec60316f1437f2527106a5add07a22821b18852d9ac341f98eb9bd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tyk-stack-chart.mdx</strong><dd><code>Align TLS docs with global setting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

product-stack/tyk-charts/tyk-stack-chart.mdx

<ul><li>Replace incorrect gateway TLS value path<br> <li> Use <code>global.tls.useDefaultTykCertificate</code> in steps</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1356/files#diff-4aee12311d14de2a765f511d87d1e0eee3448ccfc744315203af1c07df1b2e80">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

