### PR TITLE
Merging to release-5.11: Docs: Clarify SSE support in UDG for REST data sources (DX-2203) (#1366)

### DIFF
--- a/api-management/data-graph.mdx
+++ b/api-management/data-graph.mdx
@@ -445,10 +445,16 @@ You can add Datasources to your Universal Data Graph without adding them to Tyk 
 If you want to add quotas, rate limiting, body transformations etc. to a REST Datasource it is recommended to first import the API to Tyk.
 
 Supported DataSources:
-- REST
-- GraphQL
-- SOAP (through the REST DataSource)
-- Kafka
+- REST (Query and Mutation only)
+- GraphQL (Query, Mutation, and Subscription)
+- SOAP (through the REST DataSource, Query and Mutation only)
+- Kafka (Subscription only)
+
+
+
+<Note>
+UDG subscriptions (including SSE) are only supported for data sources of kind **GraphQL** or **Kafka**. REST data sources do not support subscriptions. If your upstream service exposes subscriptions via SSE, configure it as a **GraphQL** data source with the appropriate `subscription_type`. See [GraphQL Subscriptions](/api-management/graphql#graphql-subscriptions) for configuration details.
+</Note>
 
 ### GraphQL
 
@@ -1249,6 +1255,12 @@ Here is a sample API definition for the Kafka DataSource.
 ### REST
 
 The REST Datasource is a base component of UDG to help you add existing REST APIs to your data graph. By attaching a REST datasource to a field the engine will use the REST resource for resolving.
+
+<Note>
+REST data sources only support **Query** and **Mutation** operations. **Subscriptions** (including SSE and WebSockets) are **not supported** for REST kind data sources.
+
+To use GraphQL subscriptions with UDG (including SSE), you must use a data source of kind **GraphQL** or **Kafka**. See [GraphQL Subscriptions](/api-management/graphql#graphql-subscriptions) for details on configuring SSE subscriptions with a GraphQL data source.
+</Note>
 
 We have a video which demoes this functionality for you.
 

--- a/api-management/graphql.mdx
+++ b/api-management/graphql.mdx
@@ -2009,6 +2009,10 @@ If you need to use HTTP `GET` then you can omit `sse_use_post` or set it to `fal
 
 ##### Universal Data Graph
 
+<Note>
+In UDG, the `subscription_type` setting only applies to data sources of kind **GraphQL**. It is not supported for REST kind data sources. REST data sources can only resolve Query and Mutation operations. If your upstream exposes subscriptions via SSE, you must configure it as a GraphQL data source.
+</Note>
+
 ```
 {
   ...,
@@ -2019,6 +2023,7 @@ If you need to use HTTP `GET` then you can omit `sse_use_post` or set it to `fal
       "data_sources": [
         ...,
         {
+          "kind": "GraphQL",
           ...,
           "subscription_type": "sse"
         }
@@ -2027,6 +2032,44 @@ If you need to use HTTP `GET` then you can omit `sse_use_post` or set it to `fal
   }
 }
 ```
+
+**Example: Configuring an SSE subscription with a GraphQL data source in UDG**
+
+The following example shows a complete data source configuration for a GraphQL upstream that uses SSE for subscriptions. The data source is of kind `GraphQL` and the `subscription_type` is set to `sse`:
+
+```json
+{
+  "graphql": {
+    "engine": {
+      "data_sources": [
+        {
+          "kind": "GraphQL",
+          "name": "my-graphql-sse-upstream",
+          "internal": false,
+          "root_fields": [
+            {
+              "type": "Subscription",
+              "fields": ["onMessage"]
+            }
+          ],
+          "config": {
+            "url": "https://my-graphql-upstream.example.com/graphql",
+            "method": "POST",
+            "headers": {}
+          },
+          "subscription_type": "sse"
+        }
+      ]
+    }
+  }
+}
+```
+
+In this configuration:
+- `kind` must be `"GraphQL"` — SSE subscriptions are not available for REST data sources.
+- `root_fields` maps the `Subscription` type and its fields to this data source.
+- `subscription_type` is set to `"sse"` to use Server-Sent Events for the upstream connection.
+- Use `"graphql-ws"` or `"graphql-transport-ws"` instead of `"sse"` if your upstream uses WebSockets.
 
 ##### Federation
 


### PR DESCRIPTION
### **User description**
Docs: Clarify SSE support in UDG for REST data sources (DX-2203) (#1366)


___

### **PR Type**
Documentation


___

### **Description**
- Clarify UDG subscriptions supported data sources

- Annotate data source kinds with operations

- Add REST notes excluding subscriptions/SSE

- Add UDG SSE GraphQL configuration example


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["UDG Supported DataSources list"] -- "add operation support notes" --> B["REST/GraphQL/SOAP/Kafka annotated"]
  C["UDG subscriptions guidance"] -- "clarify supported kinds" --> D["GraphQL or Kafka only"]
  E["REST datasource section"] -- "add Note block" --> F["No subscriptions (SSE/WS)"]
  G["GraphQL subscriptions docs"] -- "add UDG note + examples" --> H["SSE config for GraphQL kind"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>data-graph.mdx</strong><dd><code>Clarify data source operation and subscription support</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api-management/data-graph.mdx

<ul><li>Annotate supported data sources with operations<br> <li> Add note: subscriptions/SSE only GraphQL/Kafka<br> <li> Add REST section note excluding subscriptions<br> <li> Link to GraphQL subscriptions configuration docs</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1372/files#diff-8ecfaaa8d27c4d79369e12e79a4fbaa39130b4b46701851728e565b18a28c532">+16/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>graphql.mdx</strong><dd><code>Add UDG SSE subscription guidance and example</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api-management/graphql.mdx

<ul><li>Add note: <code>subscription_type</code> only for GraphQL kind<br> <li> Update snippet to include <code>kind</code>: <code>GraphQL</code><br> <li> Add full JSON example for SSE subscriptions<br> <li> Document key fields and WS alternatives</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1372/files#diff-11cad9a1bb73b9679d7899de402da851ba41670262e4c86dddda473ef4a18970">+43/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

