### PR TITLE
🤖 Auto-merge documentation from branches

### DIFF
--- a/nightly/api-management/data-graph.mdx
+++ b/nightly/api-management/data-graph.mdx
@@ -446,10 +446,16 @@ You can add Datasources to your Universal Data Graph without adding them to Tyk 
 If you want to add quotas, rate limiting, body transformations etc. to a REST Datasource it is recommended to first import the API to Tyk.
 
 Supported DataSources:
-- REST
-- GraphQL
-- SOAP (through the REST DataSource)
-- Kafka
+- REST (Query and Mutation only)
+- GraphQL (Query, Mutation, and Subscription)
+- SOAP (through the REST DataSource, Query and Mutation only)
+- Kafka (Subscription only)
+
+
+
+<Note>
+UDG subscriptions (including SSE) are only supported for data sources of kind **GraphQL** or **Kafka**. REST data sources do not support subscriptions. If your upstream service exposes subscriptions via SSE, configure it as a **GraphQL** data source with the appropriate `subscription_type`. See [GraphQL Subscriptions](/nightly/api-management/graphql#graphql-subscriptions) for configuration details.
+</Note>
 
 ### GraphQL
 
@@ -1250,6 +1256,12 @@ Here is a sample API definition for the Kafka DataSource.
 ### REST
 
 The REST Datasource is a base component of UDG to help you add existing REST APIs to your data graph. By attaching a REST datasource to a field the engine will use the REST resource for resolving.
+
+<Note>
+REST data sources only support **Query** and **Mutation** operations. **Subscriptions** (including SSE and WebSockets) are **not supported** for REST kind data sources.
+
+To use GraphQL subscriptions with UDG (including SSE), you must use a data source of kind **GraphQL** or **Kafka**. See [GraphQL Subscriptions](/nightly/api-management/graphql#graphql-subscriptions) for details on configuring SSE subscriptions with a GraphQL data source.
+</Note>
 
 We have a video which demoes this functionality for you.
 

--- a/nightly/api-management/graphql.mdx
+++ b/nightly/api-management/graphql.mdx
@@ -2010,6 +2010,10 @@ If you need to use HTTP `GET` then you can omit `sse_use_post` or set it to `fal
 
 ##### Universal Data Graph
 
+<Note>
+In UDG, the `subscription_type` setting only applies to data sources of kind **GraphQL**. It is not supported for REST kind data sources. REST data sources can only resolve Query and Mutation operations. If your upstream exposes subscriptions via SSE, you must configure it as a GraphQL data source.
+</Note>
+
 ```
 {
   ...,
@@ -2020,6 +2024,7 @@ If you need to use HTTP `GET` then you can omit `sse_use_post` or set it to `fal
       "data_sources": [
         ...,
         {
+          "kind": "GraphQL",
           ...,
           "subscription_type": "sse"
         }
@@ -2028,6 +2033,44 @@ If you need to use HTTP `GET` then you can omit `sse_use_post` or set it to `fal
   }
 }
 ```
+
+**Example: Configuring an SSE subscription with a GraphQL data source in UDG**
+
+The following example shows a complete data source configuration for a GraphQL upstream that uses SSE for subscriptions. The data source is of kind `GraphQL` and the `subscription_type` is set to `sse`:
+
+```json
+{
+  "graphql": {
+    "engine": {
+      "data_sources": [
+        {
+          "kind": "GraphQL",
+          "name": "my-graphql-sse-upstream",
+          "internal": false,
+          "root_fields": [
+            {
+              "type": "Subscription",
+              "fields": ["onMessage"]
+            }
+          ],
+          "config": {
+            "url": "https://my-graphql-upstream.example.com/graphql",
+            "method": "POST",
+            "headers": {}
+          },
+          "subscription_type": "sse"
+        }
+      ]
+    }
+  }
+}
+```
+
+In this configuration:
+- `kind` must be `"GraphQL"` — SSE subscriptions are not available for REST data sources.
+- `root_fields` maps the `Subscription` type and its fields to this data source.
+- `subscription_type` is set to `"sse"` to use Server-Sent Events for the upstream connection.
+- Use `"graphql-ws"` or `"graphql-transport-ws"` instead of `"sse"` if your upstream uses WebSockets.
 
 ##### Federation
 


### PR DESCRIPTION
### **User description**
## 📚 Documentation Merge Summary

This PR contains automatically merged documentation from multiple branches.

**Triggered by:**
- **Branch:** main
- **Commit:** a3cab85ea7b625c3dac237e825d6e43d4ef6595f
- **PR:** #1366 - Docs: Clarify SSE support in UDG for REST data sources (DX-2203)

**Deployment Details:**
- **Generated from:** `branches-config.json`  
- **Run ID:** 21944876483
- **Subfolder:** `(root deployment)`
- **Timestamp:** $(date)

### Changes Include:
- ✅ Merged documentation from multiple branches
- ✅ Generated unified `docs.json` configuration
- ✅ Updated assets and content structure
- ✅ Cleaned up outdated version folders

---

🚦 **This PR will be processed by merge queue to ensure proper validation and ordering.**

Previous deployment PRs have been automatically closed to prevent conflicts.


___

### **PR Type**
Documentation


___

### **Description**
- Clarify UDG subscription/SSE data source limits

- Annotate supported data sources by operations

- Add REST notes: no subscriptions supported

- Provide complete UDG GraphQL SSE example


___

### Diagram Walkthrough


```mermaid
flowchart LR
  dslist["UDG supported data sources list"] 
  ops["Operation support annotated"]
  notesdg["UDG note: subs only GraphQL/Kafka"]
  restnote["REST note: Query/Mutation only"]
  gqlsubs["GraphQL subscriptions (UDG section)"]
  udgnote["UDG note: `subscription_type` GraphQL only"]
  sseex["Example: GraphQL data source SSE config"]

  dslist -- "add operation types" --> ops
  ops -- "clarify subscription support" --> notesdg
  notesdg -- "reinforce REST limitation" --> restnote
  gqlsubs -- "add clarification note" --> udgnote
  gqlsubs -- "add full JSON example" --> sseex
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>data-graph.mdx</strong><dd><code>Clarify data source operations and subscription support</code>&nbsp; &nbsp; </dd></summary>
<hr>

nightly/api-management/data-graph.mdx

<ul><li>Annotate each data source with supported operations<br> <li> Add UDG note: subscriptions/SSE only GraphQL/Kafka<br> <li> Add REST section note excluding subscriptions</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1374/files#diff-3ff9e314bf3494def0de0514b5c22f665c23697d0f5882d70ecfefc71ba02420">+16/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>graphql.mdx</strong><dd><code>Add UDG subscription clarification and SSE example</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nightly/api-management/graphql.mdx

<ul><li>Add note: <code>subscription_type</code> applies to GraphQL kind<br> <li> Update UDG snippet to include <code>kind</code>: <code>GraphQL</code><br> <li> Add full JSON example for GraphQL SSE subscriptions<br> <li> Document key fields and WS alternatives</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1374/files#diff-700a02745ae10d60c1d12709cbec7c0123806a2033cc8438c197a6eacc78bd6c">+43/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

