### PR TITLE
🤖 Auto-merge documentation from branches

### DIFF
--- a/5.8/api-management/data-graph.mdx
+++ b/5.8/api-management/data-graph.mdx
@@ -446,10 +446,16 @@ You can add Datasources to your Universal Data Graph without adding them to Tyk 
 If you want to add quotas, rate limiting, body transformations etc. to a REST Datasource it is recommended to first import the API to Tyk.
 
 Supported DataSources:
-- REST
-- GraphQL
-- SOAP (through the REST DataSource)
-- Kafka
+- REST (Query and Mutation only)
+- GraphQL (Query, Mutation, and Subscription)
+- SOAP (through the REST DataSource, Query and Mutation only)
+- Kafka (Subscription only)
+
+
+
+<Note>
+UDG subscriptions (including SSE) are only supported for data sources of kind **GraphQL** or **Kafka**. REST data sources do not support subscriptions. If your upstream service exposes subscriptions via SSE, configure it as a **GraphQL** data source with the appropriate `subscription_type`. See [GraphQL Subscriptions](/5.8/api-management/graphql#graphql-subscriptions) for configuration details.
+</Note>
 
 ### GraphQL
 
@@ -1250,6 +1256,12 @@ Here is a sample API definition for the Kafka DataSource.
 ### REST
 
 The REST Datasource is a base component of UDG to help you add existing REST APIs to your data graph. By attaching a REST datasource to a field the engine will use the REST resource for resolving.
+
+<Note>
+REST data sources only support **Query** and **Mutation** operations. **Subscriptions** (including SSE and WebSockets) are **not supported** for REST kind data sources.
+
+To use GraphQL subscriptions with UDG (including SSE), you must use a data source of kind **GraphQL** or **Kafka**. See [GraphQL Subscriptions](/5.8/api-management/graphql#graphql-subscriptions) for details on configuring SSE subscriptions with a GraphQL data source.
+</Note>
 
 We have a video which demoes this functionality for you.
 

--- a/5.8/api-management/graphql.mdx
+++ b/5.8/api-management/graphql.mdx
@@ -1991,6 +1991,10 @@ The values for subscription types are the same on all API types:
 
 ##### Universal Data Graph
 
+<Note>
+In UDG, the `subscription_type` setting only applies to data sources of kind **GraphQL**. It is not supported for REST kind data sources. REST data sources can only resolve Query and Mutation operations. If your upstream exposes subscriptions via SSE, you must configure it as a GraphQL data source.
+</Note>
+
 ```
 {
   ...,
@@ -2001,6 +2005,7 @@ The values for subscription types are the same on all API types:
       "data_sources": [
         ...,
         {
+          "kind": "GraphQL",
           ...,
           "subscription_type": "sse"
         }
@@ -2009,6 +2014,44 @@ The values for subscription types are the same on all API types:
   }
 }
 ```
+
+**Example: Configuring an SSE subscription with a GraphQL data source in UDG**
+
+The following example shows a complete data source configuration for a GraphQL upstream that uses SSE for subscriptions. The data source is of kind `GraphQL` and the `subscription_type` is set to `sse`:
+
+```json
+{
+  "graphql": {
+    "engine": {
+      "data_sources": [
+        {
+          "kind": "GraphQL",
+          "name": "my-graphql-sse-upstream",
+          "internal": false,
+          "root_fields": [
+            {
+              "type": "Subscription",
+              "fields": ["onMessage"]
+            }
+          ],
+          "config": {
+            "url": "https://my-graphql-upstream.example.com/graphql",
+            "method": "POST",
+            "headers": {}
+          },
+          "subscription_type": "sse"
+        }
+      ]
+    }
+  }
+}
+```
+
+In this configuration:
+- `kind` must be `"GraphQL"` — SSE subscriptions are not available for REST data sources.
+- `root_fields` maps the `Subscription` type and its fields to this data source.
+- `subscription_type` is set to `"sse"` to use Server-Sent Events for the upstream connection.
+- Use `"graphql-ws"` or `"graphql-transport-ws"` instead of `"sse"` if your upstream uses WebSockets.
 
 ##### Federation
 

--- a/api-management/data-graph.mdx
+++ b/api-management/data-graph.mdx
@@ -446,10 +446,16 @@ You can add Datasources to your Universal Data Graph without adding them to Tyk 
 If you want to add quotas, rate limiting, body transformations etc. to a REST Datasource it is recommended to first import the API to Tyk.
 
 Supported DataSources:
-- REST
-- GraphQL
-- SOAP (through the REST DataSource)
-- Kafka
+- REST (Query and Mutation only)
+- GraphQL (Query, Mutation, and Subscription)
+- SOAP (through the REST DataSource, Query and Mutation only)
+- Kafka (Subscription only)
+
+
+
+<Note>
+UDG subscriptions (including SSE) are only supported for data sources of kind **GraphQL** or **Kafka**. REST data sources do not support subscriptions. If your upstream service exposes subscriptions via SSE, configure it as a **GraphQL** data source with the appropriate `subscription_type`. See [GraphQL Subscriptions](/api-management/graphql#graphql-subscriptions) for configuration details.
+</Note>
 
 ### GraphQL
 
@@ -1250,6 +1256,12 @@ Here is a sample API definition for the Kafka DataSource.
 ### REST
 
 The REST Datasource is a base component of UDG to help you add existing REST APIs to your data graph. By attaching a REST datasource to a field the engine will use the REST resource for resolving.
+
+<Note>
+REST data sources only support **Query** and **Mutation** operations. **Subscriptions** (including SSE and WebSockets) are **not supported** for REST kind data sources.
+
+To use GraphQL subscriptions with UDG (including SSE), you must use a data source of kind **GraphQL** or **Kafka**. See [GraphQL Subscriptions](/api-management/graphql#graphql-subscriptions) for details on configuring SSE subscriptions with a GraphQL data source.
+</Note>
 
 We have a video which demoes this functionality for you.
 

--- a/api-management/graphql.mdx
+++ b/api-management/graphql.mdx
@@ -2010,6 +2010,10 @@ If you need to use HTTP `GET` then you can omit `sse_use_post` or set it to `fal
 
 ##### Universal Data Graph
 
+<Note>
+In UDG, the `subscription_type` setting only applies to data sources of kind **GraphQL**. It is not supported for REST kind data sources. REST data sources can only resolve Query and Mutation operations. If your upstream exposes subscriptions via SSE, you must configure it as a GraphQL data source.
+</Note>
+
 ```
 {
   ...,
@@ -2020,6 +2024,7 @@ If you need to use HTTP `GET` then you can omit `sse_use_post` or set it to `fal
       "data_sources": [
         ...,
         {
+          "kind": "GraphQL",
           ...,
           "subscription_type": "sse"
         }
@@ -2028,6 +2033,44 @@ If you need to use HTTP `GET` then you can omit `sse_use_post` or set it to `fal
   }
 }
 ```
+
+**Example: Configuring an SSE subscription with a GraphQL data source in UDG**
+
+The following example shows a complete data source configuration for a GraphQL upstream that uses SSE for subscriptions. The data source is of kind `GraphQL` and the `subscription_type` is set to `sse`:
+
+```json
+{
+  "graphql": {
+    "engine": {
+      "data_sources": [
+        {
+          "kind": "GraphQL",
+          "name": "my-graphql-sse-upstream",
+          "internal": false,
+          "root_fields": [
+            {
+              "type": "Subscription",
+              "fields": ["onMessage"]
+            }
+          ],
+          "config": {
+            "url": "https://my-graphql-upstream.example.com/graphql",
+            "method": "POST",
+            "headers": {}
+          },
+          "subscription_type": "sse"
+        }
+      ]
+    }
+  }
+}
+```
+
+In this configuration:
+- `kind` must be `"GraphQL"` — SSE subscriptions are not available for REST data sources.
+- `root_fields` maps the `Subscription` type and its fields to this data source.
+- `subscription_type` is set to `"sse"` to use Server-Sent Events for the upstream connection.
+- Use `"graphql-ws"` or `"graphql-transport-ws"` instead of `"sse"` if your upstream uses WebSockets.
 
 ##### Federation
 

--- a/nightly/api-management/data-graph.mdx
+++ b/nightly/api-management/data-graph.mdx
@@ -446,10 +446,16 @@ You can add Datasources to your Universal Data Graph without adding them to Tyk 
 If you want to add quotas, rate limiting, body transformations etc. to a REST Datasource it is recommended to first import the API to Tyk.
 
 Supported DataSources:
-- REST
-- GraphQL
-- SOAP (through the REST DataSource)
-- Kafka
+- REST (Query and Mutation only)
+- GraphQL (Query, Mutation, and Subscription)
+- SOAP (through the REST DataSource, Query and Mutation only)
+- Kafka (Subscription only)
+
+
+
+<Note>
+UDG subscriptions (including SSE) are only supported for data sources of kind **GraphQL** or **Kafka**. REST data sources do not support subscriptions. If your upstream service exposes subscriptions via SSE, configure it as a **GraphQL** data source with the appropriate `subscription_type`. See [GraphQL Subscriptions](/nightly/api-management/graphql#graphql-subscriptions) for configuration details.
+</Note>
 
 ### GraphQL
 
@@ -1250,6 +1256,12 @@ Here is a sample API definition for the Kafka DataSource.
 ### REST
 
 The REST Datasource is a base component of UDG to help you add existing REST APIs to your data graph. By attaching a REST datasource to a field the engine will use the REST resource for resolving.
+
+<Note>
+REST data sources only support **Query** and **Mutation** operations. **Subscriptions** (including SSE and WebSockets) are **not supported** for REST kind data sources.
+
+To use GraphQL subscriptions with UDG (including SSE), you must use a data source of kind **GraphQL** or **Kafka**. See [GraphQL Subscriptions](/nightly/api-management/graphql#graphql-subscriptions) for details on configuring SSE subscriptions with a GraphQL data source.
+</Note>
 
 We have a video which demoes this functionality for you.
 

--- a/nightly/api-management/graphql.mdx
+++ b/nightly/api-management/graphql.mdx
@@ -2010,6 +2010,10 @@ If you need to use HTTP `GET` then you can omit `sse_use_post` or set it to `fal
 
 ##### Universal Data Graph
 
+<Note>
+In UDG, the `subscription_type` setting only applies to data sources of kind **GraphQL**. It is not supported for REST kind data sources. REST data sources can only resolve Query and Mutation operations. If your upstream exposes subscriptions via SSE, you must configure it as a GraphQL data source.
+</Note>
+
 ```
 {
   ...,
@@ -2020,6 +2024,7 @@ If you need to use HTTP `GET` then you can omit `sse_use_post` or set it to `fal
       "data_sources": [
         ...,
         {
+          "kind": "GraphQL",
           ...,
           "subscription_type": "sse"
         }
@@ -2028,6 +2033,44 @@ If you need to use HTTP `GET` then you can omit `sse_use_post` or set it to `fal
   }
 }
 ```
+
+**Example: Configuring an SSE subscription with a GraphQL data source in UDG**
+
+The following example shows a complete data source configuration for a GraphQL upstream that uses SSE for subscriptions. The data source is of kind `GraphQL` and the `subscription_type` is set to `sse`:
+
+```json
+{
+  "graphql": {
+    "engine": {
+      "data_sources": [
+        {
+          "kind": "GraphQL",
+          "name": "my-graphql-sse-upstream",
+          "internal": false,
+          "root_fields": [
+            {
+              "type": "Subscription",
+              "fields": ["onMessage"]
+            }
+          ],
+          "config": {
+            "url": "https://my-graphql-upstream.example.com/graphql",
+            "method": "POST",
+            "headers": {}
+          },
+          "subscription_type": "sse"
+        }
+      ]
+    }
+  }
+}
+```
+
+In this configuration:
+- `kind` must be `"GraphQL"` — SSE subscriptions are not available for REST data sources.
+- `root_fields` maps the `Subscription` type and its fields to this data source.
+- `subscription_type` is set to `"sse"` to use Server-Sent Events for the upstream connection.
+- Use `"graphql-ws"` or `"graphql-transport-ws"` instead of `"sse"` if your upstream uses WebSockets.
 
 ##### Federation
 


### PR DESCRIPTION
### **User description**
## 📚 Documentation Merge Summary

This PR contains automatically merged documentation from multiple branches.

**Triggered by:**
- **Branch:** release-5.8
- **Commit:** 7f8478f83627a1db20f1d48d7364c8ae3a9907b6
- **PR:** #1373 - Merging to release-5.8: Docs: Clarify SSE support in UDG for REST data sources (DX-2203) (#1366) (cherry-pick of #1366)

**Deployment Details:**
- **Generated from:** `branches-config.json`  
- **Run ID:** 21944920389
- **Subfolder:** `(root deployment)`
- **Timestamp:** $(date)

### Changes Include:
- ✅ Merged documentation from multiple branches
- ✅ Generated unified `docs.json` configuration
- ✅ Updated assets and content structure
- ✅ Cleaned up outdated version folders

---

🚦 **This PR will be processed by merge queue to ensure proper validation and ordering.**

Previous deployment PRs have been automatically closed to prevent conflicts.


___

### **PR Type**
Documentation


___

### **Description**
- Annotate UDG data sources with operation support

- Clarify subscriptions/SSE unsupported for REST

- Add UDG note on `subscription_type` scope

- Provide complete GraphQL SSE subscription example


___

### Diagram Walkthrough


```mermaid
flowchart LR
  dslist["UDG supported DataSources list"] 
  ops["Operation support annotations"]
  restnote["Notes: REST no subscriptions"]
  gqlsubs["GraphQL subscriptions docs"]
  udgnote["UDG note: `subscription_type` GraphQL-only"]
  sseex["Example: GraphQL SSE data source JSON"]

  dslist -- "adds" --> ops
  ops -- "highlights" --> restnote
  gqlsubs -- "adds" --> udgnote
  gqlsubs -- "includes" --> sseex
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>data-graph.mdx</strong><dd><code>Clarify UDG data source subscription limits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

5.8/api-management/data-graph.mdx

<ul><li>Annotate supported kinds with operation types<br> <li> Add note: subscriptions/SSE only GraphQL/Kafka<br> <li> Add REST section note: query/mutation only</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1375/files#diff-c98d99df3dedcad5552efd5a1d82ed8483d42d4f0e70d66e4e93080ca505b716">+16/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>graphql.mdx</strong><dd><code>Document UDG SSE subscription configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

5.8/api-management/graphql.mdx

<ul><li>Note <code>subscription_type</code> applies to GraphQL kind<br> <li> Add <code>kind</code>: <code>GraphQL</code> to snippet<br> <li> Add full SSE GraphQL UDG example<br> <li> Mention WebSocket subscription alternatives</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1375/files#diff-d1a9dd9dc6eed73530590329e2f7bc2e3d5928568dcee331c130e2db69ff6f90">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>data-graph.mdx</strong><dd><code>Update UDG data source capabilities guidance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api-management/data-graph.mdx

<ul><li>Annotate supported kinds with operation types<br> <li> Add note: subscriptions/SSE only GraphQL/Kafka<br> <li> Add REST section note: no subscriptions</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1375/files#diff-8ecfaaa8d27c4d79369e12e79a4fbaa39130b4b46701851728e565b18a28c532">+16/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>graphql.mdx</strong><dd><code>Add UDG note and SSE example</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api-management/graphql.mdx

<ul><li>Clarify <code>subscription_type</code> GraphQL-kind only<br> <li> Update snippet with <code>kind</code>: <code>GraphQL</code><br> <li> Provide complete SSE subscription JSON example</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1375/files#diff-11cad9a1bb73b9679d7899de402da851ba41670262e4c86dddda473ef4a18970">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>data-graph.mdx</strong><dd><code>Mirror UDG subscription clarifications for nightly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nightly/api-management/data-graph.mdx

<ul><li>Annotate supported kinds with operation types<br> <li> Add note: subscriptions/SSE only GraphQL/Kafka<br> <li> Add REST section note: query/mutation only</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1375/files#diff-3ff9e314bf3494def0de0514b5c22f665c23697d0f5882d70ecfefc71ba02420">+16/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>graphql.mdx</strong><dd><code>Mirror UDG SSE guidance for nightly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nightly/api-management/graphql.mdx

<ul><li>Note <code>subscription_type</code> only for GraphQL kind<br> <li> Add <code>kind</code>: <code>GraphQL</code> to example snippet<br> <li> Add full GraphQL SSE UDG configuration example<br> <li> Mention WebSocket subscription alternatives</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1375/files#diff-700a02745ae10d60c1d12709cbec7c0123806a2033cc8438c197a6eacc78bd6c">+43/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

