### PR TITLE
[DX-2209] fix: add missing snippet import rewriting in copy_snippets_with_version_structure

### DIFF
--- a/scripts/merge_docs_configs.py
+++ b/scripts/merge_docs_configs.py
@@ -449,8 +449,11 @@ class DocsMerger:
                             with open(item, 'r', encoding='utf-8') as f:
                                 content = f.read()
 
-                            # Rewrite internal links for this version
-                            modified_content = self.rewrite_internal_links(content, version, is_latest)
+                            # First: Rewrite snippet imports (always uses version)
+                            modified_content = self.rewrite_snippet_imports(content, version)
+
+                            # Then: Rewrite internal links for this version
+                            modified_content = self.rewrite_internal_links(modified_content, version, is_latest)
 
                             # Write modified content
                             with open(target_file, 'w', encoding='utf-8') as f:


### PR DESCRIPTION
### **User description**
## Summary
- Adds the missing `self.rewrite_snippet_imports()` call in `copy_snippets_with_version_structure` so that snippet MDX files have their import paths correctly versioned (e.g., `/snippets/FeatureCards.mdx` → `/snippets/5.11/FeatureCards.mdx`)
- Aligns the processing order with `copy_directory_with_link_rewriting` and `organize_content_files`, which both call `rewrite_snippet_imports` before `rewrite_internal_links`

## Test plan
- [ ] Run the merge script against a docs branch that contains snippet files with cross-snippet imports
- [ ] Verify that output snippet files under `snippets/<version>/` have correctly versioned import paths
- [ ] Confirm that the existing `rewrite_internal_links` behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Generated with Tyk AI Assistant


___

### **PR Type**
Bug fix


___

### **Description**
- Rewrite snippet import paths during snippet copy

- Ensure versioned imports before internal link rewriting


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["copy_snippets_with_version_structure"] --> B["read .md/.mdx content"]
  B -- "rewrite snippet imports" --> C["rewrite_snippet_imports(version)"]
  C -- "rewrite internal links" --> D["rewrite_internal_links(version,is_latest)"]
  D -- "write modified content" --> E["write target snippet file"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>merge_docs_configs.py</strong><dd><code>Rewrite snippet imports before internal links</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/merge_docs_configs.py

<ul><li>Call <code>rewrite_snippet_imports(content, version)</code> for <code>.md</code>/<code>.mdx</code><br> <li> Run <code>rewrite_internal_links</code> on already-modified content<br> <li> Preserve existing read/modify/write flow for snippets</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1441/files#diff-f5b2db15c3142bfe21b7bebeeaa682d62ff451093249866f68ed7071c0188445">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

