### PR TITLE
Merging to release-5.12: docs: Add missing env vars for Tyk Portal webhooks (#1514)

### DIFF
--- a/product-stack/tyk-enterprise-developer-portal/deploy/configuration.mdx
+++ b/product-stack/tyk-enterprise-developer-portal/deploy/configuration.mdx
@@ -599,6 +599,58 @@ PORTAL_CORS_ALLOWED_METHODS=GET,POST,HEAD
 **Description**: Defines the frequency of the notifications job that fetches notifications from the portal's database in minutes. The default value is `30` minutes.
 
 
+## Webhooks settings
+
+This section explains how to configure webhooks in the portal.
+
+### PORTAL_WEBHOOKS_SECRET
+
+**Config file:** Webhooks.Secret <br/>
+**Type:** `string` <br/>
+**Description**: The global secret key used to sign all outgoing webhooks.
+
+### PORTAL_WEBHOOKS_PAUSE_DURATION
+
+**Config file:** Webhooks.PauseDuration <br/>
+**Type:** `int` <br/>
+**Description**: The duration (in seconds) to pause a webhook after a failed delivery attempt before retrying. Defaults to 5 seconds.
+
+### PORTAL_WEBHOOKS_CACHE_EXPIRATION
+
+**Config file:** Webhooks.CacheExpiration <br/>
+**Type:** `int` <br/>
+**Description**: The expiration time (in seconds) for the webhook cache.
+
+### PORTAL_WEBHOOKS_CACHE_CLEANUP_INTERVAL
+
+**Config file:** Webhooks.CacheCleanupInterval <br/>
+**Type:** `int` <br/>
+**Description**: The interval (in seconds) at which the webhook cache is cleaned up. Defaults to 5 seconds.
+
+### PORTAL_WEBHOOKS_DISPATCH_TIMEOUT
+
+**Config file:** Webhooks.DispatchTimeout <br/>
+**Type:** `int` <br/>
+**Description**: The timeout (in seconds) for dispatching a single webhook request.
+
+### PORTAL_WEBHOOKS_TOTAL_WORKERS
+
+**Config file:** Webhooks.TotalWorkers <br/>
+**Type:** `int` <br/>
+**Description**: The number of worker goroutines used to process webhooks concurrently. Defaults to 10.
+
+### PORTAL_WEBHOOKS_PROVIDER
+
+**Config file:** Webhooks.Provider <br/>
+**Type:** `string` <br/>
+**Description**: The storage provider used for managing webhooks (for example, `db`).
+
+### PORTAL_WEBHOOKS_DISABLE
+
+**Config file:** Webhooks.Disable <br/>
+**Type:** `bool` <br/>
+**Description**: A boolean flag (`true` or `false`) that disables webhooks entirely when set to `true`.
+
 ## Sample config file
 ```json
 {


### PR DESCRIPTION
docs: Add missing env vars for Tyk Portal webhooks (#1514)