### PR TITLE
[TT-16112] Correct error in path ordering logic

### DIFF
--- a/getting-started/key-concepts/url-matching.mdx
+++ b/getting-started/key-concepts/url-matching.mdx
@@ -102,9 +102,7 @@ Before attempting to [match](#pattern-matching) the incoming request to the vari
 
 The APIs loaded on the Gateway are ordered as follows:
 1. APIs that don't have a custom domain defined are moved to the end of the list.
-2. Then among each section (custom domain/no custom domain) it will sort by listen path length (longer paths first)
-    - Note that (dynamic) path parameters are not resolved at this stage so `/api/{category}/user` will rank higher than `/api/123/user`
-3. Then, for each listen path it will sort the endpoints using these rules:
+2. Then, within each group (custom/non-custom domain) it will sort the endpoints using these rules:
     - Remove path parameters (dynamic segments) in the listen path - for example `/{id}` will be replaced with `/`
     - Order by the number of segments (count of `/`) from most to least - e.g. `/api/user/profile` before `/api/user`
     - If two endpoints differ only by parameters, the non-parameterized goes first - e.g. `/api/user` before `/api/{userId}`

--- a/getting-started/key-concepts/url-matching.mdx
+++ b/getting-started/key-concepts/url-matching.mdx
@@ -9,7 +9,6 @@ When a request is made to an API hosted on Tyk Gateway, the gateway matches the 
  
 Understanding this process is crucial because it directly impacts how URLs are routed and matched, influencing both API behavior and security controls.
 
-
 ## What is URL path matching?
 
 URL path matching defines the rules for how request URLs are compared to


### PR DESCRIPTION
Fixed an issue identified in the explanation of the path ordering logic identified via TT-16112.