### PR TITLE
🤖 Auto-merge documentation from branches

### DIFF
--- a/swagger/5.12/mdcb-swagger.yml
+++ b/swagger/5.12/mdcb-swagger.yml
@@ -35,13 +35,6 @@ paths:
       summary: Retrieve information of all the connected data plane nodes.
       description: Provides a list of all the data plane nodes connected to MDCB. Data plane nodes are Tyk Gateways that make your APIs available to your consumers. MDCB offers centralised management of your data plane nodes. This endpoint offers metadata and status for all connected data plane nodes, allowing for monitoring and troubleshooting.
       operationId: dataplanesGet
-      parameters:
-        - in: header
-          name: x-tyk-authorization
-          description: Secret value set in sink.conf
-          required: true
-          schema:
-            type: string
       responses:
         "200":
           description: Successful retrieval of the connected data planes.
@@ -179,13 +172,6 @@ paths:
         ```
       operationId: configGet
       parameters:
-        - in: header
-          name: X-Tyk-Authorization
-          description: Secret value set in sink.conf
-          required: true
-          schema:
-            type: string
-          example: "your-secret-key"
         - in: query
           name: field
           description: Optional configuration field name to filter by
@@ -387,13 +373,6 @@ paths:
         ```
       operationId: envGet
       parameters:
-        - in: header
-          name: X-Tyk-Authorization
-          description: Secret value set in sink.conf
-          required: true
-          schema:
-            type: string
-          example: "your-secret-key"
         - in: query
           name: env
           description: Optional environment variable name to filter by

--- a/swagger/nightly/mdcb-swagger.yml
+++ b/swagger/nightly/mdcb-swagger.yml
@@ -35,13 +35,6 @@ paths:
       summary: Retrieve information of all the connected data plane nodes.
       description: Provides a list of all the data plane nodes connected to MDCB. Data plane nodes are Tyk Gateways that make your APIs available to your consumers. MDCB offers centralised management of your data plane nodes. This endpoint offers metadata and status for all connected data plane nodes, allowing for monitoring and troubleshooting.
       operationId: dataplanesGet
-      parameters:
-        - in: header
-          name: x-tyk-authorization
-          description: Secret value set in sink.conf
-          required: true
-          schema:
-            type: string
       responses:
         "200":
           description: Successful retrieval of the connected data planes.
@@ -179,13 +172,6 @@ paths:
         ```
       operationId: configGet
       parameters:
-        - in: header
-          name: X-Tyk-Authorization
-          description: Secret value set in sink.conf
-          required: true
-          schema:
-            type: string
-          example: "your-secret-key"
         - in: query
           name: field
           description: Optional configuration field name to filter by
@@ -387,13 +373,6 @@ paths:
         ```
       operationId: envGet
       parameters:
-        - in: header
-          name: X-Tyk-Authorization
-          description: Secret value set in sink.conf
-          required: true
-          schema:
-            type: string
-          example: "your-secret-key"
         - in: query
           name: env
           description: Optional environment variable name to filter by


### PR DESCRIPTION
## 📚 Documentation Merge Summary

This PR contains automatically merged documentation from multiple branches.

**Triggered by:**
- **Branch:** release-5.12
- **Commit:** 7fbc6f028b6feaee950a7f3e9155ec4c1d5e0d19
- **PR:** #1802 - Merging to release-5.12: docs: remove duplicated x-tyk-authorization header from MDCB OpenAPI spec (DX-2238) (#1791) (cherry-pick of #1791)

**Deployment Details:**
- **Generated from:** `branches-config.json`  
- **Run ID:** 23743828745
- **Subfolder:** `(root deployment)`
- **Timestamp:** $(date)

### Changes Include:
- ✅ Merged documentation from multiple branches
- ✅ Generated unified `docs.json` configuration
- ✅ Updated assets and content structure
- ✅ Cleaned up outdated version folders

---

🚦 **This PR will be processed by merge queue to ensure proper validation and ordering.**

Previous deployment PRs have been automatically closed to prevent conflicts.