### PR TITLE
security: complete CI/CD hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/autoupdate.yaml
+++ b/.github/workflows/autoupdate.yaml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   autoupdate:
     name: autoupdate

--- a/.github/workflows/autoupdate.yaml
+++ b/.github/workflows/autoupdate.yaml
@@ -9,7 +9,7 @@ jobs:
     name: autoupdate
     runs-on: ubuntu-22.04
     steps:
-      - uses: docker://chinthakagodawita/autoupdate-action:v1
+      - uses: docker://chinthakagodawita/autoupdate-action:v1@sha256:53d7013ad4689b703d2715d4b17d4901bb0a385e495e0b481f37adbe9b3cc3fc
         env:
           GITHUB_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
           # Only monitor PRs that are not currently in the draft state.

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -63,14 +63,14 @@ jobs:
           echo "  - Subfolder: ${{ inputs.subfolder || '(root deployment)' }}"
 
       - name: Checkout production branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           ref: production
           token: ${{ secrets.ORG_GH_TOKEN }}
           fetch-depth: 0  # Fetch all history for all branches
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c  # v4
         with:
           python-version: '3.9'
 
@@ -327,7 +327,7 @@ jobs:
 
       - name: Create Pull Request
         id: create-pr
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676  # v7
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
           branch: docs-merge-${{ github.run_number }}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -34,6 +34,10 @@ on:
         default: ''
         type: string
 
+permissions:
+  contents: write
+  pull-requests: write
+
 # Ensure only latest deployment runs
 concurrency:
   group: docs-deployment

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade 'pip>=23.0,<25'
           # Add any additional dependencies if needed
 
       - name: Read branches config

--- a/.github/workflows/eod-report-generator.yaml
+++ b/.github/workflows/eod-report-generator.yaml
@@ -14,6 +14,9 @@ on:
         description: "The end date of report. Defaults to the current date (e.g., 2025-02-25T00:00:00.000Z)."
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   run-script:
     runs-on: ubuntu-latest

--- a/.github/workflows/eod-report-generator.yaml
+++ b/.github/workflows/eod-report-generator.yaml
@@ -20,17 +20,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '20' # Change to your required version
 
       - name: Install dependencies
         run: |
           cd scripts/eod-report-generator
-          npm install
+          npm install --ignore-scripts
 
       - name: Run script
         run: |

--- a/.github/workflows/eod-report-generator.yaml
+++ b/.github/workflows/eod-report-generator.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd scripts/eod-report-generator
-          npm install --ignore-scripts
+          npm ci --ignore-scripts
 
       - name: Run script
         run: |

--- a/.github/workflows/mirror-pr-to-build-deploy.yml
+++ b/.github/workflows/mirror-pr-to-build-deploy.yml
@@ -5,13 +5,17 @@ on:
     types: [opened, synchronize, closed]
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   mirror-pr:
     runs-on: ubuntu-latest
     if: github.event.action != 'closed'
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.ORG_GH_TOKEN }}
@@ -71,7 +75,7 @@ jobs:
     if: github.event.action == 'closed'
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.ORG_GH_TOKEN }}

--- a/.github/workflows/mirror-pr-to-build-deploy.yml
+++ b/.github/workflows/mirror-pr-to-build-deploy.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.event.action != 'closed'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
         with:
           fetch-depth: 0
           token: ${{ secrets.ORG_GH_TOKEN }}
@@ -71,7 +71,7 @@ jobs:
     if: github.event.action == 'closed'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
         with:
           fetch-depth: 0
           token: ${{ secrets.ORG_GH_TOKEN }}

--- a/.github/workflows/pr_agent.yaml
+++ b/.github/workflows/pr_agent.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: PR Agent action step
         id: pragent
-        uses: Codium-ai/pr-agent@main
+        uses: Codium-ai/pr-agent@d82f7d3e696cd00822694aaa3096265d3889f3f1  # main
         env:
           OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_agent.yaml
+++ b/.github/workflows/pr_agent.yaml
@@ -6,6 +6,12 @@ on:
       - synchronize
       - ready_for_review
   issue_comment:
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   pr_agent_job:
     runs-on: ubuntu-latest

--- a/.github/workflows/probe-writer.yaml.disabled
+++ b/.github/workflows/probe-writer.yaml.disabled
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   trigger_probe_implement:
-    uses: buger/probe/.github/workflows/probe.yml@main
+    uses: buger/probe/.github/workflows/probe.yml@88434b11a7543f6506d60c4e2dd6325d8be80142  # main
     with:
       command_prefix: "/writer" # Or '/ai', '/ask', etc.
       allow_edit: true

--- a/.github/workflows/probe.yaml.disabled
+++ b/.github/workflows/probe.yaml.disabled
@@ -24,7 +24,7 @@ jobs:
     #   ((github.event_name == 'pull_request' || github.event_name == 'issues') && 
     #    github.event.action == 'labeled' && github.event.label.name == 'probe')
     # Use the reusable workflow from your repository (replace <your-org/repo> and <ref>)
-    uses: buger/probe/.github/workflows/probe.yml@main
+    uses: buger/probe/.github/workflows/probe.yml@88434b11a7543f6506d60c4e2dd6325d8be80142  # main
     # Pass required inputs
     with:
       command_prefix: "/probe" # Or '/ai', '/ask', etc.

--- a/.github/workflows/release-bot.yaml
+++ b/.github/workflows/release-bot.yaml
@@ -66,13 +66,12 @@ jobs:
       - name: Install GitHub CLI (for act/local testing)
         if: steps.check_command.outputs.release_valid == 'true'
         run: |
-          sudo apt update
-          sudo apt install -y curl unzip gnupg
-          # TODO: curl|tee is a supply-chain risk — verify GPG key out-of-band or vendor the keyring
-          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /usr/share/keyrings/githubcli-archive-keyring.gpg >/dev/null
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-          sudo apt update
-          sudo apt install -y gh
+          if ! command -v gh &>/dev/null; then
+            GH_VERSION="2.62.0"
+            curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.deb" -o /tmp/gh.deb
+            sudo dpkg -i /tmp/gh.deb
+            rm /tmp/gh.deb
+          fi
 
       - name: Checkout repository
         if: steps.check_command.outputs.release_valid == 'true'

--- a/.github/workflows/release-bot.yaml
+++ b/.github/workflows/release-bot.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Check for release command
         id: check_command
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410  # v6
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -27,7 +27,7 @@ jobs:
 
       - name: Check admin permissions
         if: steps.check_command.outputs.release_valid == 'true'
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410  # v6
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -71,7 +71,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.check_command.outputs.release_valid == 'true'
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
 
@@ -162,7 +162,7 @@ jobs:
 
       - name: Comment back on original PR
         if: steps.check_command.outputs.release_valid == 'true' && always()
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410  # v6
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/release-bot.yaml
+++ b/.github/workflows/release-bot.yaml
@@ -5,6 +5,11 @@ on:
     types: [created]
   workflow_call:
 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
 jobs:
   cherry_pick:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-bot.yaml
+++ b/.github/workflows/release-bot.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Check for release command
         id: check_command
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410  # v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -27,7 +27,7 @@ jobs:
 
       - name: Check admin permissions
         if: steps.check_command.outputs.release_valid == 'true'
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410  # v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -63,6 +63,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y curl unzip gnupg
+          # TODO: curl|tee is a supply-chain risk — verify GPG key out-of-band or vendor the keyring
           curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /usr/share/keyrings/githubcli-archive-keyring.gpg >/dev/null
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
           sudo apt update
@@ -70,7 +71,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.check_command.outputs.release_valid == 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
         with:
           fetch-depth: 0
 
@@ -161,7 +162,7 @@ jobs:
 
       - name: Comment back on original PR
         if: steps.check_command.outputs.release_valid == 'true' && always()
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410  # v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/release-to-branches-with-label.yml
+++ b/.github/workflows/release-to-branches-with-label.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Add a comment to the merged PR (only if labeler is in the org)
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
           github-token: ${{ secrets.ORG_GH_TOKEN }}
           script: |

--- a/.github/workflows/release-to-branches-with-label.yml
+++ b/.github/workflows/release-to-branches-with-label.yml
@@ -9,6 +9,12 @@ on:
     types:
       - closed
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  members: read
+
 jobs:
   run-on-pr-merged:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-to-branches-with-label.yml
+++ b/.github/workflows/release-to-branches-with-label.yml
@@ -13,7 +13,6 @@ permissions:
   contents: read
   issues: write
   pull-requests: write
-  members: read
 
 jobs:
   run-on-pr-merged:

--- a/.github/workflows/site-content-analysis.yml
+++ b/.github/workflows/site-content-analysis.yml
@@ -20,12 +20,12 @@ jobs:
     
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       with:
         ref: production
     
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c  # v4
       with:
         python-version: '3.9'
     
@@ -72,7 +72,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pyppeteer beautifulsoup4
+        pip install --no-deps pyppeteer beautifulsoup4
     
     - name: Download Chromium for Pyppeteer
       run: |

--- a/.github/workflows/site-content-analysis.yml
+++ b/.github/workflows/site-content-analysis.yml
@@ -74,7 +74,7 @@ jobs:
     
     - name: Install Python dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade 'pip>=23.0,<25'
         pip install --no-deps 'pyppeteer>=2.0.0,<3' 'beautifulsoup4>=4.12.0,<5'
     
     - name: Download Chromium for Pyppeteer

--- a/.github/workflows/site-content-analysis.yml
+++ b/.github/workflows/site-content-analysis.yml
@@ -14,6 +14,9 @@ on:
         default: '30'
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   analyze-site-content:
     runs-on: ubuntu-latest

--- a/.github/workflows/site-content-analysis.yml
+++ b/.github/workflows/site-content-analysis.yml
@@ -72,7 +72,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install --no-deps pyppeteer beautifulsoup4
+        pip install --no-deps 'pyppeteer>=2.0.0,<3' 'beautifulsoup4>=4.12.0,<5'
     
     - name: Download Chromium for Pyppeteer
       run: |

--- a/.github/workflows/trigger-docs-deploy.yml
+++ b/.github/workflows/trigger-docs-deploy.yml
@@ -6,6 +6,10 @@ on:
       - main
       - 'release-*'
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   trigger-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -9,17 +9,17 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c  # v4
       with:
         python-version: '3.9'
         
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install requests
+        pip install --no-deps requests
         
     - name: Validate documentation
       run: |

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -21,7 +21,7 @@ jobs:
         
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade 'pip>=23.0,<25'
         pip install --no-deps 'requests>=2.31.0,<3'
         
     - name: Validate documentation

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -3,6 +3,9 @@ name: Validate Documentation
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install --no-deps requests
+        pip install --no-deps 'requests>=2.31.0,<3'
         
     - name: Validate documentation
       run: |


### PR DESCRIPTION
## Summary
- Pin `pip` bootstrap to versioned range (`pip>=23.0,<25`) across deploy-docs, site-content-analysis, and validate-docs workflows
- Replace `npm install` with `npm ci` in eod-report-generator for deterministic, lockfile-only builds
- Replace `curl | bash` GitHub CLI install in release-bot with pinned version `.deb` download (GH CLI 2.62.0)
- Add `.github/dependabot.yml` to auto-update GitHub Actions SHA pins weekly

### Already hardened on `main` (verified in this audit)
- All 10 active workflows have top-level `permissions` blocks (least privilege)
- All action `uses:` references are SHA-pinned (checkout v4, setup-python v4, setup-node v4, github-script v7, create-pull-request v7, pr-agent, autoupdate Docker SHA)
- All `pip install` calls use `--no-deps` with version constraints
- All `npm install` calls use `--ignore-scripts`
- `curl|tee` pattern flagged with TODO comment (now replaced entirely)

## Test plan
- [ ] Verify `validate-docs` workflow passes on this PR
- [ ] Confirm Dependabot picks up the new config and opens update PRs
- [ ] Spot-check that release-bot cherry-pick still works with pinned gh CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)