### PR TITLE
[DX-2358] Add note on default policies

### DIFF
--- a/api-management/authentication/jwt-authorization.mdx
+++ b/api-management/authentication/jwt-authorization.mdx
@@ -124,11 +124,17 @@ Prior to Tyk 5.10, the base policy claim was retrieved from `policyFieldName`; s
 
 ### Default policies
 
-You **must** configure one or more *default policies* that will be applied if no specific policies are identified from the JWT claims. These are configured using the `defaultPolicies` field in the API definition, which accepts a list of policy IDs. This prevents a session from being created with no authorization to interact with APIs on the Gateway.
-
+A *default policy* is a fallback option if no specific policies are identified from the JWT claims and prevents a session from being created with no authorization to interact with APIs on the Gateway.
+You **must** configure one or more default policies unless using [scope policies](/api-management/authentication/jwt-authorization#scope-policies).
 
 <Note>
-The Gateway will return `HTTP 403 Forbidden` if no default policies are configured, if the referenced policies don’t exist, or if policies are invalid or incorrectly formatted.
+Prior to **Tyk 5.11.0** a default policy was required even when using scope policies.
+</Note>
+
+Default policies are configured using the `defaultPolicies` field in the API definition, which accepts a list of policy IDs.
+
+<Note>
+The Gateway will return `HTTP 403 Forbidden` if no default policies are configured (prior to Tyk 5.11 or if scope policies are not in use), if the referenced policies don’t exist, or if policies are invalid or incorrectly formatted.
 </Note>
 
 


### PR DESCRIPTION
### **User description**
In Tyk 5.11 we removed the need to supply a default policy when using scope-to-policy mapping with JWT Auth


___

### **PR Type**
Documentation


___

### **Description**
- Clarify JWT default policy behavior
  - Exempt scope policies from requirement
  - Note change starting Tyk 5.11

- Update `HTTP 403` guidance

- Refine `defaultPolicies` configuration wording


___

### Diagram Walkthrough


```mermaid
flowchart LR
  jwt["JWT authorization"] 
  scopes["Scope policies enabled"]
  defaults["Default policies optional"]
  legacy["Before Tyk 5.11 default required"]
  forbidden["HTTP 403 on invalid/missing policies"]

  jwt -- "uses" --> scopes
  scopes -- "from Tyk 5.11" --> defaults
  jwt -- "before 5.11" --> legacy
  jwt -- "misconfiguration leads to" --> forbidden
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jwt-authorization.mdx</strong><dd><code>Document default policy exception for scope policies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api-management/authentication/jwt-authorization.mdx

<ul><li>Clarifies that default policies are fallback policies.<br> <li> States they are not required with scope policies.<br> <li> Adds a note about behavior before <code>Tyk 5.11.0</code>.<br> <li> Updates <code>HTTP 403 Forbidden</code> guidance for scope-policy usage.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1827/files#diff-3358c8d06cc06393e1824b7af4aadb14a0ab5d7d0802cd011df6257a7aaa682d">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

