### PR TITLE
docs: add RED metrics starter template and fix dimension label names

### DIFF
--- a/api-management/metrics/custom-metrics.mdx
+++ b/api-management/metrics/custom-metrics.mdx
@@ -37,6 +37,68 @@ The behavior of this field depends on its value:
 | Empty array `[]` | API-level metrics are disabled entirely — no request metrics are exported. |
 | Populated array | Only the instruments you define are exported. Default RED metrics are not exported unless you explicitly define them. |
 
+<Tip>
+**Preserving default RED metrics**
+
+When you populate `api_metrics`, the built-in RED instruments are no longer exported automatically. Use the block below as a starting point — it re-creates all four default instruments — then append your custom instruments after them.
+
+```json
+{
+  "opentelemetry": {
+    "metrics": {
+      "enabled": true,
+      "api_metrics": [
+        {
+          "name": "http.server.request.duration",
+          "type": "histogram",
+          "description": "End-to-end request latency",
+          "histogram_source": "total",
+          "dimensions": [
+            { "source": "metadata", "key": "method",        "label": "http.request.method" },
+            { "source": "metadata", "key": "response_code", "label": "http.response.status_code" },
+            { "source": "metadata", "key": "api_id",        "label": "tyk.api.id" },
+            { "source": "metadata", "key": "response_flag", "label": "tyk.response_flag" }
+          ]
+        },
+        {
+          "name": "tyk.gateway.request.duration",
+          "type": "histogram",
+          "description": "Gateway processing time",
+          "histogram_source": "gateway",
+          "dimensions": [
+            { "source": "metadata", "key": "method",        "label": "http.request.method" },
+            { "source": "metadata", "key": "api_id",        "label": "tyk.api.id" },
+            { "source": "metadata", "key": "response_flag", "label": "tyk.response_flag" }
+          ]
+        },
+        {
+          "name": "tyk.upstream.request.duration",
+          "type": "histogram",
+          "description": "Upstream response time",
+          "histogram_source": "upstream",
+          "dimensions": [
+            { "source": "metadata", "key": "method",        "label": "http.request.method" },
+            { "source": "metadata", "key": "api_id",        "label": "tyk.api.id" },
+            { "source": "metadata", "key": "response_flag", "label": "tyk.response_flag" }
+          ]
+        },
+        {
+          "name": "tyk.api.requests.total",
+          "type": "counter",
+          "description": "Request count with identity dimensions",
+          "dimensions": [
+            { "source": "metadata", "key": "method",        "label": "http.request.method" },
+            { "source": "metadata", "key": "response_code", "label": "http.response.status_code" },
+            { "source": "metadata", "key": "api_id",        "label": "tyk.api.id" }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+</Tip>
+
 ## Instrument Types
 
 Each entry in `api_metrics` defines one instrument:

--- a/api-management/metrics/default-metrics.mdx
+++ b/api-management/metrics/default-metrics.mdx
@@ -32,7 +32,7 @@ The three-way latency breakdown is particularly useful for distinguishing gatewa
 
 Default dimensions vary by instrument:
 
-| Instrument | `method` | `http.response.status_code` | `api_id` | `response_flag` |
+| Instrument | `http.request.method` | `http.response.status_code` | `tyk.api.id` | `tyk.response_flag` |
 |-----------|:---:|:---:|:---:|:---:|
 | `http.server.request.duration` | Yes | Yes | Yes | Yes |
 | `tyk.gateway.request.duration` | Yes | — | Yes | Yes |
@@ -41,10 +41,10 @@ Default dimensions vary by instrument:
 
 | Dimension | Description |
 |-----------|-------------|
-| `method` | HTTP request method (`GET`, `POST`, etc.). |
-| `api_id` | The Tyk API ID. |
+| `http.request.method` | HTTP request method (`GET`, `POST`, etc.). |
+| `tyk.api.id` | The Tyk API ID. |
 | `http.response.status_code` | HTTP response status code (`200`, `404`, `500`, etc.). |
-| `response_flag` | Tyk 3-letter error classification code (e.g., `AKI`, `URS`, `CBO`), or the HTTP status code string (e.g., `"200"`) for successful requests or when error classification is absent. See the [full list of response flags](/api-management/logs#error-classification). |
+| `tyk.response_flag` | Tyk 3-letter error classification code (e.g., `AKI`, `URS`, `CBO`), or the HTTP status code string (e.g., `"200"`) for successful requests or when error classification is absent. See the [full list of response flags](/api-management/logs#error-classification). |
 
 You can add more dimensions to any instrument using [custom metrics](/api-management/metrics/custom-metrics).
 

--- a/api-management/metrics/opentelemetry-configuration.mdx
+++ b/api-management/metrics/opentelemetry-configuration.mdx
@@ -11,6 +11,8 @@ Tyk Gateway can export metrics natively via the OpenTelemetry Protocol (OTLP). W
 
 Metrics can be enabled independently — distributed tracing does not need to be configured. To configure distributed tracing alongside metrics, see [Distributed Tracing](/api-management/traces).
 
+All settings on this page are part of the Tyk Gateway configuration. They can be set in `tyk.conf` or via environment variables. See the [Tyk Gateway Configuration Reference](/tyk-oss-gateway/configuration#opentelemetry) for the full list of fields and their environment variable equivalents.
+
 ## Quick Start
 
 ### Metrics only
@@ -50,52 +52,7 @@ This is enough to start exporting [default gateway metrics](/api-management/metr
 
 ## Full Configuration Reference
 
-```json
-{
-  "opentelemetry": {
-    "traces": {
-      "enabled": true,
-      "exporter": "grpc",
-      "endpoint": "otel-collector:4317",
-      "headers": {},
-      "connection_timeout": 5,
-      "resource_name": "tyk",
-      "tls": { "... TLS options ..." }
-    },
-    "metrics": {
-      "enabled": true,
-      "exporter": "grpc",
-      "endpoint": "otel-collector:4317",
-      "headers": {},
-      "connection_timeout": 5,
-      "resource_name": "tyk",
-      "tls": { "... TLS options ..." },
-      "export_interval": 30,
-      "temporality": "cumulative",
-      "shutdown_timeout": 5,
-      "retry": { "... retry options ..." },
-      "runtime_metrics": true,
-      "api_metrics": [ "... custom metric definitions ..." ]
-    }
-  }
-}
-```
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `enabled` | bool | `false` | Enables metrics export. |
-| `exporter` | string | `"grpc"` | Transport protocol: `"grpc"` (OTLP/gRPC) or `"http"` (OTLP/HTTP). |
-| `endpoint` | string | inherits from `traces.endpoint` if set | OTLP endpoint to send metrics to. |
-| `headers` | map[string]string | — | Additional headers sent with each export request (e.g. for authentication). |
-| `connection_timeout` | int | — | Connection timeout in seconds. |
-| `resource_name` | string | `"tyk"` | Service name reported in resource attributes. |
-| `tls` | TLS object | — | TLS configuration for the exporter connection. |
-| `export_interval` | int | `30` | How often metrics are pushed to the endpoint, in seconds. |
-| `temporality` | string | `"cumulative"` | Aggregation temporality: `"cumulative"` (values accumulate since startup) or `"delta"` (values since the last export). Use `"delta"` for backends like Datadog or Dynatrace that prefer it. |
-| `shutdown_timeout` | int | — | Graceful shutdown timeout in seconds. |
-| `retry` | object | — | Retry configuration for failed export attempts. |
-| `runtime_metrics` | bool | `true` | Exports Go runtime metrics (memory, goroutines, GC). Set to `false` to disable. |
-| `api_metrics` | array | — | Custom metric instrument definitions. See [Custom Metrics](/api-management/metrics/custom-metrics). |
+For a complete reference of all `opentelemetry.metrics` configuration fields, see [Tyk Gateway Configuration Reference](/tyk-oss-gateway/configuration#opentelemetry).
 
 <Note>
 Root-level configuration such as `opentelemetry.enabled` and `opentelemetry.endpoint` still work for traces but are deprecated. Use `opentelemetry.traces.*` for new deployments.
@@ -131,7 +88,7 @@ The metrics exporter sends data using standard OTLP, so any OTLP-compatible back
 
 Each unique combination of dimension values creates a separate time series in your metrics backend. For example, a metric with 100 APIs × 5 methods × 10 status codes = 5,000 time series. Adding dimensions that have many possible values (such as user IDs or free-text fields) can create millions of time series, causing high storage costs and potential out-of-memory crashes.
 
-The `cardinality_limit` field caps how many unique attribute combinations are tracked per metric instrument:
+The `opentelemetry.metrics.cardinality_limit` field caps how many unique attribute combinations are tracked per metric instrument:
 
 - **Default limit:** 2,000 combinations per instrument
 - **When the limit is reached:** New attribute combinations are aggregated into an overflow bucket marked with `otel.metric.overflow=true`


### PR DESCRIPTION
Addresses review feedback on #1808 from @sedkis.

Adds a Tip callout in `custom-metrics.mdx` with a copy-pasteable `api_metrics` starter block containing all four default RED instruments, so users know how to re-declare them when customising metrics. Also fixes incorrect dimension label names in both `custom-metrics.mdx` and `default-metrics.mdx` (`method` → `http.request.method`, `api_id` → `tyk.api.id`, `response_flag` → `tyk.response_flag`). The `opentelemetry-configuration.mdx` changes (replacing the inline config reference table with a link to the gateway config reference) were already present in the base branch.