### PR TITLE
Merging to release-5.12: docs: add TYK_LOGLEVEL and log_level config support (DX-2357) (#1828)

### DIFF
--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -18,13 +18,8 @@ jobs:
         
     - name: Install dependencies
       run: |
-<<<<<<< HEAD
         python -m pip install --upgrade pip
         pip install requests
-=======
-        python -m pip install --upgrade 'pip>=23.0,<25'
-        pip install 'requests>=2.31.0,<3'
->>>>>>> cb8301bf (docs: add TYK_LOGLEVEL and log_level config support (DX-2357) (#1828))
         
     - name: Validate documentation
       run: |

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -18,8 +18,13 @@ jobs:
         
     - name: Install dependencies
       run: |
+<<<<<<< HEAD
         python -m pip install --upgrade pip
         pip install requests
+=======
+        python -m pip install --upgrade 'pip>=23.0,<25'
+        pip install 'requests>=2.31.0,<3'
+>>>>>>> cb8301bf (docs: add TYK_LOGLEVEL and log_level config support (DX-2357) (#1828))
         
     - name: Validate documentation
       run: |

--- a/api-management/logs.mdx
+++ b/api-management/logs.mdx
@@ -42,11 +42,14 @@ You can set the logging verbosity for each Tyk Component using the appropriate `
 
 | Tyk component  | Config option | Environment variable | Default value if unset   |
 | :---------------- | :--------------- | :---------------------- | :-------------------------- |
-| Tyk Dashboard | Not Available  | Not Available       | `info`                   |
+| Tyk Dashboard | `log_level`  | `TYK_LOGLEVEL`       | `info`                   |
 | [Tyk Gateway](/tyk-oss-gateway/configuration#log_level)   | `log_level`   | `TYK_GW_LOGLEVEL`    | `info`                   |
 | [Tyk Pump](/tyk-pump/tyk-pump-configuration/tyk-pump-environment-variables#log_level)     | `log_level`   | `TYK_PMP_LOGLEVEL`   | `info`                   |
-| [Tyk MDCB](/tyk-multi-data-centre/mdcb-configuration-options#log_level)      | `log_level`   | `TYK_MDCB_LOGLEVEL`  | `info`                   |
 | [Tyk Developer Portal](/product-stack/tyk-enterprise-developer-portal/deploy/configuration#portal_log_level) | `logLevel`  | `PORTAL_LOG_LEVEL`   | `info`   |
+
+<Note>
+The `TYK_LOGLEVEL` environment variable is applicable to all Tyk components. If set, it takes priority and overrides any component-specific log level environment variables (such as `TYK_GW_LOGLEVEL` or `TYK_PMP_LOGLEVEL`).
+</Note>
 
 ### Log Format
 
@@ -81,6 +84,10 @@ time="Sep 05 09:04:12" level=info msg="Tyk API Gateway v5.6.0" prefix=main
 | Tyk Dashboard (Audit)  | audit.format | TYK_DB_AUDIT_FORMAT  | text                 |
 | Tyk MDCB               | Not Available  | Not Available          | text             |
 | Tyk Developer Portal   | LogFormat    | PORTAL_LOG_FORMAT     | prod (equivalent to json)   |
+
+<Note>
+The `TYK_LOGFORMAT` environment variable is shared between the Gateway and Dashboard. If set, it takes priority and overrides component-specific log format environment variables (such as `TYK_GW_LOGFORMAT` or `TYK_DB_LOGFORMAT`).
+</Note>
 
 ## Application Logs
 

--- a/api-management/troubleshooting-debugging.mdx
+++ b/api-management/troubleshooting-debugging.mdx
@@ -164,8 +164,8 @@ sidebarTitle: "Troubleshooting"
     2. Just for the Gateway via your `tyk.conf` config file  
 
     **Setting via Environment Variable**
-
     The environment variable is `TYK_LOGLEVEL`.
+
 
     By default, the setting is `info`. You also have the following options:
 
@@ -1577,7 +1577,7 @@ As shown above, the `debug` log level mode provides more information which will 
     If you’re using environment variables for your configuration:
 
     ```
-    TYK_DB_LOGLEVEL=debug
+    TYK_LOGLEVEL=debug
     ```
 
     If you're using Tyk Helm Charts. Add the following items to your `values.yaml`:

--- a/developer-support/upgrading.mdx
+++ b/developer-support/upgrading.mdx
@@ -516,7 +516,7 @@ $ curl  localhost:8080/hello | jq .
 
 **Production Kubernetes Environment Upgrade**
 
-For production environments, it is recommended to use [Helm charts](#helm) or the [Tyk Operator](/tyk-stack/tyk-operator/installing-tyk-operator/#upgrading-tyk-operator) to manage upgrades with zero downtime.
+For production environments, it is recommended to use [Helm charts](#helm) to manage upgrades with zero downtime.
 
 When upgrading Kubernetes Deployments, you should use a `RollingUpdate` strategy to ensure zero downtime. For more information on upgrade strategies, see the [Upgrade Strategies](#upgrade-strategies) section.
 

--- a/tyk-dashboard/configuration.mdx
+++ b/tyk-dashboard/configuration.mdx
@@ -30,6 +30,7 @@ The file will look like the sample below, the various fields are explained in th
 ```json
 {
   "listen_port": 3000,
+  "log_level": "info",
   "tyk_api_config": {
     "Host": "http://tyk-gateway",
     "Port": "8080",


### PR DESCRIPTION
docs: add TYK_LOGLEVEL and log_level config support (DX-2357) (#1828)

* docs: add TYK_DB_LOGLEVEL and log_level config support

* DX-2357: Update to use TYK_LOGLEVEL instead of TYK_DB_LOGLEVEL

* docs: add note about TYK_LOGLEVEL priority

* docs: add note about TYK_DB_ prefix for TYK_LOGLEVEL

* docs: add note about TYK_LOGFORMAT priority

* ci: remove --no-deps from pip install requests

* Apply suggestions from code review

Co-authored-by: Master <sharadregoti15@gmail.com>

* Update upgrade recommendations for production environments

Removed reference to Tyk Operator for production upgrades.

---------

Co-authored-by: Leonid Bugaev <leonsbox@gmail.com>
Co-authored-by: Master <sharadregoti15@gmail.com>