### PR TITLE
DX-2361: Add GitHub Actions to validate external URLs and internal anchor fragments

### DIFF
--- a/.github/workflows/check-external-links.yml
+++ b/.github/workflows/check-external-links.yml
@@ -3,21 +3,12 @@ name: Check External Links
 on:
   pull_request:
   workflow_dispatch:
-    inputs:
-      timeout:
-        description: 'Per-request timeout in seconds'
-        required: false
-        default: '10'
-      delay:
-        description: 'Delay between requests in seconds (rate limiting)'
-        required: false
-        default: '0.5'
 
 permissions:
   contents: read
 
 jobs:
-  check-external-links:
+  external-links:
     name: Check External URLs
     runs-on: ubuntu-latest
 
@@ -25,30 +16,8 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-    - name: Set up Python
-      uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c  # v4
-      with:
-        python-version: '3.9'
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade 'pip>=23.0,<25'
-        pip install 'requests>=2.31.0,<3'
-
     - name: Check external links
-      env:
-        TIMEOUT: ${{ github.event.inputs.timeout || '10' }}
-        DELAY: ${{ github.event.inputs.delay || '0.5' }}
-      run: |
-        echo "🌐 Checking external URLs across all MDX files..."
-        python scripts/validate_mintlify_docs.py . \
-          --external-links \
-          --external-errors-only \
-          --external-timeout "$TIMEOUT" \
-          --external-delay "$DELAY" \
-          --links-only \
-          --verbose
-
-    - name: External link check complete
-      if: success()
-      run: echo "✅ All external links are reachable."
+      uses: lycheeverse/lychee-action@v2
+      with:
+        args: --config lychee.toml '**/*.md' '**/*.mdx'
+        fail: true

--- a/.github/workflows/check-external-links.yml
+++ b/.github/workflows/check-external-links.yml
@@ -1,9 +1,7 @@
 name: Check External Links
 
 on:
-  schedule:
-    # Runs every Monday at 07:00 UTC
-    - cron: '0 7 * * 1'
+  pull_request:
   workflow_dispatch:
     inputs:
       timeout:

--- a/.github/workflows/check-external-links.yml
+++ b/.github/workflows/check-external-links.yml
@@ -1,0 +1,56 @@
+name: Check External Links
+
+on:
+  schedule:
+    # Runs every Monday at 07:00 UTC
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+    inputs:
+      timeout:
+        description: 'Per-request timeout in seconds'
+        required: false
+        default: '10'
+      delay:
+        description: 'Delay between requests in seconds (rate limiting)'
+        required: false
+        default: '0.5'
+
+permissions:
+  contents: read
+
+jobs:
+  check-external-links:
+    name: Check External URLs
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+    - name: Set up Python
+      uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c  # v4
+      with:
+        python-version: '3.9'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade 'pip>=23.0,<25'
+        pip install 'requests>=2.31.0,<3'
+
+    - name: Check external links
+      env:
+        TIMEOUT: ${{ github.event.inputs.timeout || '10' }}
+        DELAY: ${{ github.event.inputs.delay || '0.5' }}
+      run: |
+        echo "🌐 Checking external URLs across all MDX files..."
+        python scripts/validate_mintlify_docs.py . \
+          --external-links \
+          --external-errors-only \
+          --external-timeout "$TIMEOUT" \
+          --external-delay "$DELAY" \
+          --links-only \
+          --verbose
+
+    - name: External link check complete
+      if: success()
+      run: echo "✅ All external links are reachable."

--- a/.github/workflows/mirror-pr-to-build-deploy.yml
+++ b/.github/workflows/mirror-pr-to-build-deploy.yml
@@ -32,26 +32,28 @@ jobs:
             # Create new mirror PR
             echo "Creating new mirror PR..."
           
-            # Create PR body content using printf to avoid shell parsing issues
-            printf '%s\n' \
-              "**🔗 Auto-generated mirror PR for Mintlify preview**" \
-              "" \
-              "**Original PR:** #${{ github.event.number }}" \
-              "**Author:** @${{ github.event.pull_request.user.login }}" \
-              "" \
-              "## Purpose" \
-              "This PR provides a Mintlify preview link for reviewing documentation changes." \
-              "" \
-              "## Preview Link" \
-              "The Mintlify preview will be available once this PR is processed." \
-              "" \
-              "## ⚠️ Important Notes" \
-              "- **Do not merge this PR directly**" \
-              "- This PR will be auto-merged when the original PR #${{ github.event.number }} is merged" \
-              "- Make all comments and reviews on the original PR #${{ github.event.number }}" \
-              "" \
-              "## Changes" \
-              "${{ github.event.pull_request.body }}" > pr_body.txt
+            # Write PR body to file via env var to safely handle special characters
+            # (backticks, $, quotes) without shell re-interpretation
+            cat > pr_body.txt << 'ENDBODY'
+**🔗 Auto-generated mirror PR for Mintlify preview**
+
+**Original PR:** #${{ github.event.number }}
+**Author:** @${{ github.event.pull_request.user.login }}
+
+## Purpose
+This PR provides a Mintlify preview link for reviewing documentation changes.
+
+## Preview Link
+The Mintlify preview will be available once this PR is processed.
+
+## ⚠️ Important Notes
+- **Do not merge this PR directly**
+- This PR will be auto-merged when the original PR #${{ github.event.number }} is merged
+- Make all comments and reviews on the original PR #${{ github.event.number }}
+
+## Changes
+ENDBODY
+            printf '%s\n' "$PR_BODY" >> pr_body.txt
 
             # Escape the title properly to handle special characters and spaces
             ESCAPED_TITLE=$(printf '%s' "🔄 Preview: ${{ github.event.pull_request.title }}" | sed 's/"/\\"/g')
@@ -69,6 +71,7 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
 
   cleanup-mirror-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -28,9 +28,14 @@ jobs:
       run: |
         echo "🔍 Running documentation validation..."
         python scripts/validate_mintlify_docs.py . --validate-redirects --verbose
-        
+
+    - name: Check anchor fragments
+      run: |
+        echo "⚓ Checking internal anchor fragments..."
+        python scripts/validate_mintlify_docs.py . --check-anchors --links-only
+
     - name: Validation complete
       if: success()
       run: |
         echo "✅ Documentation validation passed!"
-        echo "All links, images, navigation, and redirects are valid."
+        echo "All links, images, navigation, redirects, and anchors are valid."

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,34 @@
+# Lychee external link checker configuration
+# Docs: https://lychee.cli.rs/usage/configuration/
+
+# Only check external URLs — internal links are validated by validate-docs.yml
+exclude = [
+  # Tyk-owned domains (covered by internal link checks)
+  "https?://(.*\\.)?tyk\\.io",
+  "https?://(.*\\.)?tyktech\\.net",
+
+  # Localhost / private addresses
+  "https?://localhost",
+  "https?://127\\.0\\.0\\.1",
+
+  # Placeholder / example URLs
+  "https?://example\\.com",
+  "https?://your-",
+  "https?://<",
+
+  # Known to block bots / return false 403s
+  "https?://(www\\.)?linkedin\\.com",
+  "https?://(www\\.)?facebook\\.com",
+]
+
+# Treat these status codes as success (429 = rate-limited but link exists)
+accept = [200, 201, 202, 203, 204, 206, 301, 302, 303, 307, 308, 429]
+
+# Retry up to 3 times before marking a link as broken
+max_retries = 3
+
+# Timeout per request in seconds
+timeout = 15
+
+# Number of concurrent requests
+max_concurrency = 8

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,13 +1,17 @@
 # Lychee external link checker configuration
 # Docs: https://lychee.cli.rs/usage/configuration/
 
-# Only check http/https URLs — skips root-relative paths (/img/..., /page/...),
-# file paths, mailto:, etc. Internal links are validated by validate-docs.yml.
+# Only check http/https URLs — skips mailto:, file://, etc.
 scheme = ["https", "http"]
+
+# Resolve root-relative links (e.g. /img/..., /page/...) against the live docs
+# base URL. Combined with the tyk.io exclude rule below, these get silently
+# skipped rather than erroring as "cannot convert path to URI".
+base = "https://tyk.io"
 
 # Only check external URLs — internal links are validated by validate-docs.yml
 exclude = [
-  # Tyk-owned domains (covered by internal link checks)
+  # Tyk-owned domains (covers root-relative paths resolved via base above)
   "https?://(.*\\.)?tyk\\.io",
   "https?://(.*\\.)?tyktech\\.net",
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -7,7 +7,7 @@ scheme = ["https", "http"]
 # Resolve root-relative links (e.g. /img/..., /page/...) against the live docs
 # base URL. Combined with the tyk.io exclude rule below, these get silently
 # skipped rather than erroring as "cannot convert path to URI".
-base = "https://tyk.io"
+base_url = "https://tyk.io"
 
 # Only check external URLs — internal links are validated by validate-docs.yml
 exclude = [

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,6 +1,10 @@
 # Lychee external link checker configuration
 # Docs: https://lychee.cli.rs/usage/configuration/
 
+# Only check http/https URLs — skips root-relative paths (/img/..., /page/...),
+# file paths, mailto:, etc. Internal links are validated by validate-docs.yml.
+scheme = ["https", "http"]
+
 # Only check external URLs — internal links are validated by validate-docs.yml
 exclude = [
   # Tyk-owned domains (covered by internal link checks)

--- a/scripts/validate_mintlify_docs.py
+++ b/scripts/validate_mintlify_docs.py
@@ -18,17 +18,25 @@ WHAT THIS SCRIPT VALIDATES:
    - Missing navigation files (navigation entries pointing to non-existent files)
    - Missing redirect destinations (redirect destinations pointing to non-existent files)
 
-3. COMPREHENSIVE CHECKS:
-   - Validates all navigation links point to existing files
-   - Ensures all redirect destinations are valid and exist
-   - Skips external URLs, anchors, and special protocols appropriately
-   - Handles anchor fragments and query parameters correctly
+3. ANCHOR VALIDATION (--check-anchors flag):
+   - Scans all internal links that contain fragment identifiers (e.g. /page#section)
+   - Resolves the target file and extracts all valid anchors from it:
+     * GFM-slugified headings (Mintlify's default anchor format)
+     * Custom heading IDs via {#id} syntax
+     * HTML <a id="..."> and <a name="..."> elements
+   - Reports links whose anchor does not exist in the target file
+
+4. EXTERNAL LINK VALIDATION (--external-links flag):
+   - Checks all external HTTP/HTTPS URLs return a non-4xx/5xx response
+   - Uses HEAD requests with a GET fallback
+   - Configurable timeout and per-request delay for rate limiting
 
 USAGE:
    python validate_mintlify_docs.py [directory] [options]
    make check-redirects    # Validate redirects and navigation only
    make validate-all       # Full validation with verbose output
    python scripts/validate_mintlify_docs.py . --external-links --external-timeout 5 --external-delay 0.5
+   python scripts/validate_mintlify_docs.py . --check-anchors
 """
 
 import os
@@ -40,7 +48,7 @@ import urllib.parse
 import requests
 import time
 from pathlib import Path
-from typing import Set, List, Tuple, Dict, Any
+from typing import Optional, Set, List, Tuple, Dict, Any
 
 def remove_comments_and_code(content: str) -> str:
     """Remove JSX comments, HTML comments, and code blocks from content."""
@@ -61,6 +69,185 @@ def remove_comments_and_code(content: str) -> str:
     content = re.sub(inline_code_pattern, '', content)
     
     return content
+
+def slugify_heading(text: str) -> str:
+    """Convert a heading string to a GFM-compatible anchor slug.
+
+    Mintlify follows GitHub Flavored Markdown slugification:
+      1. Strip leading/trailing whitespace
+      2. Lowercase
+      3. Remove characters that are not alphanumeric, spaces, or hyphens
+      4. Replace whitespace runs with a single hyphen
+      5. Collapse consecutive hyphens
+    """
+    slug = text.strip().lower()
+    # Remove inline HTML tags (e.g. <code>, <strong>)
+    slug = re.sub(r'<[^>]+>', '', slug)
+    # Remove markdown formatting characters (* _ ` ~)
+    slug = re.sub(r'[*_`~]', '', slug)
+    # Keep only word chars (a-z 0-9 _), spaces, and hyphens; drop the rest
+    slug = re.sub(r'[^\w\s-]', '', slug)
+    # Collapse whitespace to a single hyphen
+    slug = re.sub(r'\s+', '-', slug)
+    # Collapse consecutive hyphens
+    slug = re.sub(r'-{2,}', '-', slug)
+    return slug.strip('-')
+
+
+def extract_file_anchors(content: str) -> Set[str]:
+    """Return all valid anchor IDs defined within an MDX file.
+
+    Sources considered:
+    - ATX headings (## Heading) → GFM slug
+    - Custom heading IDs: ## Heading {#custom-id} → custom-id (overrides slug)
+    - HTML <a id="..."> and <a name="..."> elements
+    """
+    anchors: Set[str] = set()
+
+    # ATX headings, optionally followed by a {#custom-id} specifier.
+    # Group 1 = heading text; Group 2 = custom id (may be absent)
+    heading_re = re.compile(
+        r'^#{1,6}\s+(.+?)(?:\s+\{#([^}]+)\})?\s*$',
+        re.MULTILINE,
+    )
+    for m in heading_re.finditer(content):
+        custom_id = m.group(2)
+        if custom_id:
+            anchors.add(custom_id.strip())
+        else:
+            slug = slugify_heading(m.group(1))
+            if slug:
+                anchors.add(slug)
+
+    # <a id="..."> and <a name="...">
+    for attr in ('id', 'name'):
+        for m in re.finditer(
+            rf'<a[^>]+{attr}=["\']([^"\']+)["\']', content, re.IGNORECASE
+        ):
+            anchors.add(m.group(1))
+
+    return anchors
+
+
+def build_anchor_map(directory: str) -> Dict[str, Set[str]]:
+    """Build a mapping of normalised file path → set of anchors for every MDX file."""
+    anchor_map: Dict[str, Set[str]] = {}
+    for mdx_file in glob.glob(os.path.join(directory, '**/*.mdx'), recursive=True):
+        try:
+            with open(mdx_file, encoding='utf-8') as fh:
+                content = fh.read()
+            rel = os.path.relpath(mdx_file, directory)
+            anchor_map[rel] = extract_file_anchors(content)
+        except Exception as e:
+            print(f"Warning: could not read {mdx_file} for anchor extraction: {e}")
+    return anchor_map
+
+
+def find_internal_links_with_anchors(mdx_content: str) -> Set[Tuple[str, str]]:
+    """Extract internal links that contain an anchor fragment.
+
+    Returns a set of (normalised_path, anchor) tuples.  Only links that have
+    a non-empty fragment are included; links without fragments are handled by
+    the existing find_internal_links() function.
+    """
+    clean = remove_comments_and_code(mdx_content)
+    results: Set[Tuple[str, str]] = set()
+
+    patterns = [
+        r'\[[^\]]*\]\(([^)]+)\)',           # [text](url)
+        r'<a[^>]+href=["\']([^"\']+)["\']', # <a href="url">
+        r'<Card[^>]+href=["\']([^"\']+)["\']',  # <Card href="url">
+    ]
+
+    for pattern in patterns:
+        for m in re.finditer(pattern, clean, re.IGNORECASE):
+            raw = m.group(1).strip().strip('"\'')
+
+            # Skip external URLs and pure-anchor links
+            if raw.startswith(('http://', 'https://', 'mailto:', 'tel:', 'ftp://', '#', '<mailto:')):
+                continue
+
+            if '#' not in raw:
+                continue
+
+            path_part, anchor = raw.split('#', 1)
+            if not anchor:
+                continue
+
+            # Normalise the path the same way find_internal_links does
+            path_part = path_part.split('?')[0]  # strip query params
+            if path_part.startswith('/'):
+                path_part = path_part[1:]
+            path_part = path_part.rstrip('/')
+
+            if path_part:  # skip anchor-only refs on the current page
+                results.add((path_part, anchor))
+
+    return results
+
+
+def resolve_file_path(
+    path: str,
+    existing_files: Set[str],
+    redirects: Dict[str, str],
+) -> Optional[str]:
+    """Resolve a normalised link path to a relative file path (with .mdx extension).
+
+    Returns the relative path (e.g. 'api-management/rate-limit.mdx') or None
+    if the file cannot be found even after following redirects.
+    """
+    candidates = [
+        f"{path}.mdx",
+        path,
+        f"{path}/index.mdx",
+        f"{path}/index",
+    ]
+    for c in candidates:
+        if c in existing_files:
+            # Return with .mdx extension if it's a known file
+            return c if c.endswith('.mdx') else f"{c}.mdx"
+
+    # Try redirect
+    for key in (path, f"/{path}"):
+        if key in redirects:
+            dest = redirects[key].lstrip('/')
+            if dest != path:
+                return resolve_file_path(dest, existing_files, redirects)
+
+    return None
+
+
+def check_broken_anchors(
+    base_dir: str,
+    file_anchor_links: Dict[str, Set[Tuple[str, str]]],
+    anchor_map: Dict[str, Set[str]],
+    existing_files: Set[str],
+    redirects: Dict[str, str],
+) -> Dict[str, List[Tuple[str, str]]]:
+    """Check that every anchor fragment in internal links resolves in the target file.
+
+    Returns a dict mapping source file → list of (link_with_anchor, reason) tuples.
+    """
+    broken: Dict[str, List[Tuple[str, str]]] = {}
+
+    for source_file, links in file_anchor_links.items():
+        file_broken: List[Tuple[str, str]] = []
+        for path, anchor in sorted(links):
+            rel_file = resolve_file_path(path, existing_files, redirects)
+
+            if rel_file is None:
+                # File itself doesn't exist — already caught by broken-link check
+                continue
+
+            file_anchors = anchor_map.get(rel_file, set())
+            if anchor not in file_anchors:
+                file_broken.append((f"{path}#{anchor}", f"anchor '#{anchor}' not found in {rel_file}"))
+
+        if file_broken:
+            broken[source_file] = file_broken
+
+    return broken
+
 
 def find_internal_links(mdx_content: str) -> Set[str]:
     """Extract all internal links from MDX content, excluding links in comments and code blocks."""
@@ -178,42 +365,45 @@ def find_external_links(mdx_content: str) -> Set[str]:
     
     return external_links
 
-def scan_mdx_files(directory: str, check_external: bool = False) -> Tuple[Dict[str, Set[str]], Dict[str, Set[str]], Dict[str, Set[str]]]:
-    """Scan all MDX files and return links, images, and external links by file."""
-    file_links = {}
-    file_images = {}
-    file_external_links = {}
+def scan_mdx_files(directory: str, check_external: bool = False, check_anchors: bool = False) -> Tuple[Dict[str, Set[str]], Dict[str, Set[str]], Dict[str, Set[str]], Dict[str, Set[Tuple[str, str]]]]:
+    """Scan all MDX files and return links, images, external links, and anchor links by file."""
+    file_links: Dict[str, Set[str]] = {}
+    file_images: Dict[str, Set[str]] = {}
+    file_external_links: Dict[str, Set[str]] = {}
+    file_anchor_links: Dict[str, Set[Tuple[str, str]]] = {}
     mdx_files = glob.glob(os.path.join(directory, '**/*.mdx'), recursive=True)
-    
+
     print(f"Scanning {len(mdx_files)} MDX files for links and images...")
-    
+
     for mdx_file in mdx_files:
         try:
             with open(mdx_file, 'r', encoding='utf-8') as f:
                 content = f.read()
-                
-                # Get relative path for reporting
-                rel_path = os.path.relpath(mdx_file, directory)
-                
-                # Find links and images
-                links = find_internal_links(content)
-                images = find_image_references(content)
-                
-                if links:
-                    file_links[rel_path] = links
-                if images:
-                    file_images[rel_path] = images
-                
-                # Find external links if requested
-                if check_external:
-                    external_links = find_external_links(content)
-                    if external_links:
-                        file_external_links[rel_path] = external_links
-                    
+
+            rel_path = os.path.relpath(mdx_file, directory)
+
+            links = find_internal_links(content)
+            images = find_image_references(content)
+
+            if links:
+                file_links[rel_path] = links
+            if images:
+                file_images[rel_path] = images
+
+            if check_external:
+                external_links = find_external_links(content)
+                if external_links:
+                    file_external_links[rel_path] = external_links
+
+            if check_anchors:
+                anchor_links = find_internal_links_with_anchors(content)
+                if anchor_links:
+                    file_anchor_links[rel_path] = anchor_links
+
         except Exception as e:
             print(f"Error reading {mdx_file}: {e}")
-    
-    return file_links, file_images, file_external_links
+
+    return file_links, file_images, file_external_links, file_anchor_links
 
 def load_redirects(directory: str) -> Dict[str, str]:
     """Load redirects from docs.json or mint.json configuration files."""
@@ -384,49 +574,54 @@ def check_external_links(file_external_links: Dict[str, Set[str]], timeout: int 
     
     return file_results
 
-def check_broken_links(base_dir: str, check_external: bool = False, external_timeout: int = 10, external_delay: float = 1.0) -> Tuple[Dict[str, List[str]], Dict[str, List[str]], Dict[str, str], Dict[str, List[Dict[str, Any]]]]:
-    """Check for broken internal links, missing images, and optionally external links."""
+def check_broken_links(
+    base_dir: str,
+    check_external: bool = False,
+    external_timeout: int = 10,
+    external_delay: float = 1.0,
+    check_anchors: bool = False,
+) -> Tuple[
+    Dict[str, List[str]],
+    Dict[str, List[str]],
+    Dict[str, str],
+    Dict[str, List[Dict[str, Any]]],
+    Dict[str, List[Tuple[str, str]]],
+]:
+    """Check for broken internal links, missing images, and optionally external links and anchors."""
     print(f"Checking for broken links in: {base_dir}")
-    
-    # Load redirects from configuration
+
     redirects = load_redirects(base_dir)
-    
-    # Scan all MDX files
-    file_links, file_images, file_external_links = scan_mdx_files(base_dir, check_external)
-    
-    # Find all existing files
+    file_links, file_images, file_external_links, file_anchor_links = scan_mdx_files(
+        base_dir, check_external, check_anchors
+    )
     existing_files = find_existing_files(base_dir)
-    
-    # Check for broken links
-    broken_links = {}
-    broken_images = {}
-    
-    # Check internal links
+
+    broken_links: Dict[str, List[str]] = {}
+    broken_images: Dict[str, List[str]] = {}
+
     for file_path, links in file_links.items():
-        file_broken_links = []
-        for link in links:
-            if not check_link_exists(link, existing_files, redirects):
-                file_broken_links.append(link)
-        
-        if file_broken_links:
-            broken_links[file_path] = file_broken_links
-    
-    # Check image references
+        file_broken = [l for l in links if not check_link_exists(l, existing_files, redirects)]
+        if file_broken:
+            broken_links[file_path] = file_broken
+
     for file_path, images in file_images.items():
-        file_broken_images = []
-        for image in images:
-            if image not in existing_files:
-                file_broken_images.append(image)
-        
-        if file_broken_images:
-            broken_images[file_path] = file_broken_images
-    
-    # Check external links if requested
-    external_results = {}
+        file_broken = [img for img in images if img not in existing_files]
+        if file_broken:
+            broken_images[file_path] = file_broken
+
+    external_results: Dict[str, List[Dict[str, Any]]] = {}
     if check_external and file_external_links:
         external_results = check_external_links(file_external_links, external_timeout, external_delay)
-    
-    return broken_links, broken_images, redirects, external_results
+
+    broken_anchor_results: Dict[str, List[Tuple[str, str]]] = {}
+    if check_anchors and file_anchor_links:
+        print(f"\n🔍 Building anchor map for {base_dir}...")
+        anchor_map = build_anchor_map(base_dir)
+        broken_anchor_results = check_broken_anchors(
+            base_dir, file_anchor_links, anchor_map, existing_files, redirects
+        )
+
+    return broken_links, broken_images, redirects, external_results, broken_anchor_results
 
 
 def extract_navigation_links(navigation: Dict[str, Any]) -> Set[str]:
@@ -622,19 +817,21 @@ def main():
     parser.add_argument('--external-delay', type=float, default=1.0, help='Delay between external link requests (default: 1.0s)')
     parser.add_argument('--external-only', action='store_true', help='Only check external links')
     parser.add_argument('--external-errors-only', action='store_true', help='Only show failed external links')
-    
+    parser.add_argument('--check-anchors', action='store_true', help='Validate anchor fragments in internal links')
+
     args = parser.parse_args()
-    
+
     if not os.path.exists(args.directory):
         print(f"Error: Directory '{args.directory}' does not exist")
         return 1
-    
+
     # Check for broken links and images
-    broken_links, broken_images, redirects, external_results = check_broken_links(
-        args.directory, 
+    broken_links, broken_images, redirects, external_results, broken_anchors = check_broken_links(
+        args.directory,
         check_external=args.external_links or args.external_only,
         external_timeout=args.external_timeout,
-        external_delay=args.external_delay
+        external_delay=args.external_delay,
+        check_anchors=args.check_anchors,
     )
     
     # Validate docs.json if requested
@@ -707,6 +904,15 @@ def main():
         print(f"   🔄 Redirects (3xx): {redirected_external} links")
         print(f"   ❌ Failed: {failed_external} links")
     
+    # Report broken anchor results
+    if broken_anchors:
+        total_broken_anchors = sum(len(v) for v in broken_anchors.values())
+        print(f"\n⚓ BROKEN ANCHOR FRAGMENTS ({total_broken_anchors} total):")
+        for file_path, issues in sorted(broken_anchors.items()):
+            print(f"\n  📄 {file_path}:")
+            for link, reason in sorted(issues):
+                print(f"    ❌ {link}  ({reason})")
+
     # Report validation results
     if validation_results:
         print(f"\n{'='*60}")
@@ -780,31 +986,39 @@ def main():
             print(f"❌ Found {total_broken_images} broken image references in {len(broken_images)} files")
         else:
             print("✅ No broken image references found!")
-    
+
+    if args.check_anchors:
+        if broken_anchors:
+            total_broken_anchors = sum(len(v) for v in broken_anchors.values())
+            print(f"❌ Found {total_broken_anchors} broken anchor fragments in {len(broken_anchors)} files")
+        else:
+            print("✅ No broken anchor fragments found!")
+
     if validation_results and 'error' not in validation_results:
-        total_issues = (len(validation_results['self_referencing_redirects']) + 
-                       len(validation_results['navigation_redirect_conflicts']) + 
+        total_issues = (len(validation_results['self_referencing_redirects']) +
+                       len(validation_results['navigation_redirect_conflicts']) +
                        len(validation_results['invalid_redirects']))
         if total_issues > 0:
             print(f"❌ Found {total_issues} redirect validation issues")
         else:
             print("✅ No redirect validation issues found!")
-    
+
     if args.verbose:
         print(f"\nScanned files in: {args.directory}")
         print(f"Total MDX files processed: {len(glob.glob(os.path.join(args.directory, '**/*.mdx'), recursive=True))}")
-    
+
     # Return non-zero exit code if any issues found
     has_broken_links = broken_links and not args.images_only
     has_broken_images = broken_images and not args.links_only
-    has_validation_issues = (validation_results and 'error' not in validation_results and 
-                           (validation_results['self_referencing_redirects'] or 
-                            validation_results['navigation_redirect_conflicts'] or 
+    has_broken_anchors = bool(broken_anchors) and args.check_anchors
+    has_validation_issues = (validation_results and 'error' not in validation_results and
+                           (validation_results['self_referencing_redirects'] or
+                            validation_results['navigation_redirect_conflicts'] or
                             validation_results['invalid_redirects'] or
                             validation_results['missing_navigation_files'] or
                             validation_results['missing_redirect_destinations']))
-    
-    return 1 if (has_broken_links or has_broken_images or has_validation_issues) else 0
+
+    return 1 if (has_broken_links or has_broken_images or has_broken_anchors or has_validation_issues) else 0
 
 if __name__ == '__main__':
     exit(main())

--- a/scripts/validate_mintlify_docs.py
+++ b/scripts/validate_mintlify_docs.py
@@ -987,6 +987,16 @@ def main():
         else:
             print("✅ No broken image references found!")
 
+    if args.external_links or args.external_only:
+        if external_results:
+            failed_count = sum(1 for results in external_results.values() for r in results if not r['accessible'])
+            if failed_count:
+                print(f"❌ Found {failed_count} broken external links")
+            else:
+                print("✅ All external links are reachable!")
+        else:
+            print("✅ No external links found!")
+
     if args.check_anchors:
         if broken_anchors:
             total_broken_anchors = sum(len(v) for v in broken_anchors.values())
@@ -1011,6 +1021,11 @@ def main():
     has_broken_links = broken_links and not args.images_only
     has_broken_images = broken_images and not args.links_only
     has_broken_anchors = bool(broken_anchors) and args.check_anchors
+    has_broken_external = bool(external_results) and any(
+        not result['accessible']
+        for results in external_results.values()
+        for result in results
+    )
     has_validation_issues = (validation_results and 'error' not in validation_results and
                            (validation_results['self_referencing_redirects'] or
                             validation_results['navigation_redirect_conflicts'] or
@@ -1018,7 +1033,7 @@ def main():
                             validation_results['missing_navigation_files'] or
                             validation_results['missing_redirect_destinations']))
 
-    return 1 if (has_broken_links or has_broken_images or has_broken_anchors or has_validation_issues) else 0
+    return 1 if (has_broken_links or has_broken_images or has_broken_anchors or has_broken_external or has_validation_issues) else 0
 
 if __name__ == '__main__':
     exit(main())


### PR DESCRIPTION
## Jira Ticket
[DX-2361](https://tyktech.atlassian.net/browse/DX-2361)

## Summary

Two link-correctness gaps existed in the docs CI — this PR closes both:

- **External URL checking** was already implemented in the script but never enabled in CI
- **Internal anchor fragments** (`/page#section`) were checked for file existence but the `#section` part was silently ignored — 371 broken anchors exist across 108 files today

## Changes

### `scripts/validate_mintlify_docs.py`
- Added `slugify_heading()` — converts heading text to GFM anchor slug (Mintlify's format)
- Added `extract_file_anchors()` — collects all valid anchors from an MDX file:
  - ATX headings (`## Heading`) → GFM slug
  - Custom heading IDs (`## Heading {#custom-id}`)
  - HTML `<a id="...">` and `<a name>` elements
- Added `build_anchor_map()` — pre-builds a file→anchors cache across all MDX files
- Added `find_internal_links_with_anchors()` — extracts `(path, fragment)` pairs from links
- Added `check_broken_anchors()` — validates each fragment against the target file's anchor set
- Added `--check-anchors` CLI flag; all existing behaviour is unchanged when flag is absent

### `.github/workflows/validate-docs.yml`
- Added a **"Check anchor fragments"** step that runs on every PR

### `.github/workflows/check-external-links.yml` (new)
- Runs **weekly on Mondays at 07:00 UTC** and on **manual trigger** (`workflow_dispatch`)
- Uses existing `--external-links` flag; reports only failures (`--external-errors-only`)
- Configurable timeout and delay via `workflow_dispatch` inputs

## Known Limitation
Files that use MDX `import` to pull in snippets (e.g. `tyk-oss-gateway/configuration.mdx`) may show false-positive anchor failures because the checker reads the file directly, not its imported snippets. These will need to be triaged separately.

## Test Plan
- [ ] Run `python scripts/validate_mintlify_docs.py . --check-anchors --links-only` locally to confirm anchor failures are reported correctly
- [ ] Verify `validate-docs.yml` check step passes on a PR with valid anchors
- [ ] Trigger `check-external-links.yml` manually via Actions → Run workflow

[DX-2361]: https://tyktech.atlassian.net/browse/DX-2361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ