### PR TITLE
Merging to release-5.12: DX-2361: Add GitHub Actions to validate external URLs and internal anchor fragments (#1865)

### DIFF
--- a/.github/workflows/check-external-links.yml
+++ b/.github/workflows/check-external-links.yml
@@ -1,0 +1,23 @@
+name: Check External Links
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  external-links:
+    name: Check External URLs
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+    - name: Check external links
+      uses: lycheeverse/lychee-action@v2
+      with:
+        args: --config lychee.toml '**/*.md' '**/*.mdx'
+        fail: true

--- a/.github/workflows/mirror-pr-to-build-deploy.yml
+++ b/.github/workflows/mirror-pr-to-build-deploy.yml
@@ -28,26 +28,28 @@ jobs:
             # Create new mirror PR
             echo "Creating new mirror PR..."
           
-            # Create PR body content using printf to avoid shell parsing issues
-            printf '%s\n' \
-              "**🔗 Auto-generated mirror PR for Mintlify preview**" \
-              "" \
-              "**Original PR:** #${{ github.event.number }}" \
-              "**Author:** @${{ github.event.pull_request.user.login }}" \
-              "" \
-              "## Purpose" \
-              "This PR provides a Mintlify preview link for reviewing documentation changes." \
-              "" \
-              "## Preview Link" \
-              "The Mintlify preview will be available once this PR is processed." \
-              "" \
-              "## ⚠️ Important Notes" \
-              "- **Do not merge this PR directly**" \
-              "- This PR will be auto-merged when the original PR #${{ github.event.number }} is merged" \
-              "- Make all comments and reviews on the original PR #${{ github.event.number }}" \
-              "" \
-              "## Changes" \
-              "${{ github.event.pull_request.body }}" > pr_body.txt
+            # Write PR body to file via env var to safely handle special characters
+            # (backticks, $, quotes) without shell re-interpretation
+            cat > pr_body.txt << 'ENDBODY'
+**🔗 Auto-generated mirror PR for Mintlify preview**
+
+**Original PR:** #${{ github.event.number }}
+**Author:** @${{ github.event.pull_request.user.login }}
+
+## Purpose
+This PR provides a Mintlify preview link for reviewing documentation changes.
+
+## Preview Link
+The Mintlify preview will be available once this PR is processed.
+
+## ⚠️ Important Notes
+- **Do not merge this PR directly**
+- This PR will be auto-merged when the original PR #${{ github.event.number }} is merged
+- Make all comments and reviews on the original PR #${{ github.event.number }}
+
+## Changes
+ENDBODY
+            printf '%s\n' "$PR_BODY" >> pr_body.txt
 
             # Escape the title properly to handle special characters and spaces
             ESCAPED_TITLE=$(printf '%s' "🔄 Preview: ${{ github.event.pull_request.title }}" | sed 's/"/\\"/g')
@@ -65,6 +67,7 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
 
   cleanup-mirror-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -25,9 +25,14 @@ jobs:
       run: |
         echo "🔍 Running documentation validation..."
         python scripts/validate_mintlify_docs.py . --validate-redirects --verbose
-        
+
+    - name: Check anchor fragments
+      run: |
+        echo "⚓ Checking internal anchor fragments..."
+        python scripts/validate_mintlify_docs.py . --check-anchors --links-only
+
     - name: Validation complete
       if: success()
       run: |
         echo "✅ Documentation validation passed!"
-        echo "All links, images, navigation, and redirects are valid."
+        echo "All links, images, navigation, redirects, and anchors are valid."

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,42 @@
+# Lychee external link checker configuration
+# Docs: https://lychee.cli.rs/usage/configuration/
+
+# Only check http/https URLs — skips mailto:, file://, etc.
+scheme = ["https", "http"]
+
+# Resolve root-relative links (e.g. /img/..., /page/...) against the live docs
+# base URL. Combined with the tyk.io exclude rule below, these get silently
+# skipped rather than erroring as "cannot convert path to URI".
+base_url = "https://tyk.io"
+
+# Only check external URLs — internal links are validated by validate-docs.yml
+exclude = [
+  # Tyk-owned domains (covers root-relative paths resolved via base above)
+  "https?://(.*\\.)?tyk\\.io",
+  "https?://(.*\\.)?tyktech\\.net",
+
+  # Localhost / private addresses
+  "https?://localhost",
+  "https?://127\\.0\\.0\\.1",
+
+  # Placeholder / example URLs
+  "https?://example\\.com",
+  "https?://your-",
+  "https?://<",
+
+  # Known to block bots / return false 403s
+  "https?://(www\\.)?linkedin\\.com",
+  "https?://(www\\.)?facebook\\.com",
+]
+
+# Treat these status codes as success (429 = rate-limited but link exists)
+accept = [200, 201, 202, 203, 204, 206, 301, 302, 303, 307, 308, 429]
+
+# Retry up to 3 times before marking a link as broken
+max_retries = 3
+
+# Timeout per request in seconds
+timeout = 15
+
+# Number of concurrent requests
+max_concurrency = 8

--- a/scripts/validate_mintlify_docs.py
+++ b/scripts/validate_mintlify_docs.py
@@ -18,17 +18,25 @@ WHAT THIS SCRIPT VALIDATES:
    - Missing navigation files (navigation entries pointing to non-existent files)
    - Missing redirect destinations (redirect destinations pointing to non-existent files)
 
-3. COMPREHENSIVE CHECKS:
-   - Validates all navigation links point to existing files
-   - Ensures all redirect destinations are valid and exist
-   - Skips external URLs, anchors, and special protocols appropriately
-   - Handles anchor fragments and query parameters correctly
+3. ANCHOR VALIDATION (--check-anchors flag):
+   - Scans all internal links that contain fragment identifiers (e.g. /page#section)
+   - Resolves the target file and extracts all valid anchors from it:
+     * GFM-slugified headings (Mintlify's default anchor format)
+     * Custom heading IDs via {#id} syntax
+     * HTML <a id="..."> and <a name="..."> elements
+   - Reports links whose anchor does not exist in the target file
+
+4. EXTERNAL LINK VALIDATION (--external-links flag):
+   - Checks all external HTTP/HTTPS URLs return a non-4xx/5xx response
+   - Uses HEAD requests with a GET fallback
+   - Configurable timeout and per-request delay for rate limiting
 
 USAGE:
    python validate_mintlify_docs.py [directory] [options]
    make check-redirects    # Validate redirects and navigation only
    make validate-all       # Full validation with verbose output
    python scripts/validate_mintlify_docs.py . --external-links --external-timeout 5 --external-delay 0.5
+   python scripts/validate_mintlify_docs.py . --check-anchors
 """
 
 import os
@@ -40,7 +48,7 @@ import urllib.parse
 import requests
 import time
 from pathlib import Path
-from typing import Set, List, Tuple, Dict, Any
+from typing import Optional, Set, List, Tuple, Dict, Any
 
 def remove_comments_and_code(content: str) -> str:
     """Remove JSX comments, HTML comments, and code blocks from content."""
@@ -61,6 +69,185 @@ def remove_comments_and_code(content: str) -> str:
     content = re.sub(inline_code_pattern, '', content)
     
     return content
+
+def slugify_heading(text: str) -> str:
+    """Convert a heading string to a GFM-compatible anchor slug.
+
+    Mintlify follows GitHub Flavored Markdown slugification:
+      1. Strip leading/trailing whitespace
+      2. Lowercase
+      3. Remove characters that are not alphanumeric, spaces, or hyphens
+      4. Replace whitespace runs with a single hyphen
+      5. Collapse consecutive hyphens
+    """
+    slug = text.strip().lower()
+    # Remove inline HTML tags (e.g. <code>, <strong>)
+    slug = re.sub(r'<[^>]+>', '', slug)
+    # Remove markdown formatting characters (* _ ` ~)
+    slug = re.sub(r'[*_`~]', '', slug)
+    # Keep only word chars (a-z 0-9 _), spaces, and hyphens; drop the rest
+    slug = re.sub(r'[^\w\s-]', '', slug)
+    # Collapse whitespace to a single hyphen
+    slug = re.sub(r'\s+', '-', slug)
+    # Collapse consecutive hyphens
+    slug = re.sub(r'-{2,}', '-', slug)
+    return slug.strip('-')
+
+
+def extract_file_anchors(content: str) -> Set[str]:
+    """Return all valid anchor IDs defined within an MDX file.
+
+    Sources considered:
+    - ATX headings (## Heading) → GFM slug
+    - Custom heading IDs: ## Heading {#custom-id} → custom-id (overrides slug)
+    - HTML <a id="..."> and <a name="..."> elements
+    """
+    anchors: Set[str] = set()
+
+    # ATX headings, optionally followed by a {#custom-id} specifier.
+    # Group 1 = heading text; Group 2 = custom id (may be absent)
+    heading_re = re.compile(
+        r'^#{1,6}\s+(.+?)(?:\s+\{#([^}]+)\})?\s*$',
+        re.MULTILINE,
+    )
+    for m in heading_re.finditer(content):
+        custom_id = m.group(2)
+        if custom_id:
+            anchors.add(custom_id.strip())
+        else:
+            slug = slugify_heading(m.group(1))
+            if slug:
+                anchors.add(slug)
+
+    # <a id="..."> and <a name="...">
+    for attr in ('id', 'name'):
+        for m in re.finditer(
+            rf'<a[^>]+{attr}=["\']([^"\']+)["\']', content, re.IGNORECASE
+        ):
+            anchors.add(m.group(1))
+
+    return anchors
+
+
+def build_anchor_map(directory: str) -> Dict[str, Set[str]]:
+    """Build a mapping of normalised file path → set of anchors for every MDX file."""
+    anchor_map: Dict[str, Set[str]] = {}
+    for mdx_file in glob.glob(os.path.join(directory, '**/*.mdx'), recursive=True):
+        try:
+            with open(mdx_file, encoding='utf-8') as fh:
+                content = fh.read()
+            rel = os.path.relpath(mdx_file, directory)
+            anchor_map[rel] = extract_file_anchors(content)
+        except Exception as e:
+            print(f"Warning: could not read {mdx_file} for anchor extraction: {e}")
+    return anchor_map
+
+
+def find_internal_links_with_anchors(mdx_content: str) -> Set[Tuple[str, str]]:
+    """Extract internal links that contain an anchor fragment.
+
+    Returns a set of (normalised_path, anchor) tuples.  Only links that have
+    a non-empty fragment are included; links without fragments are handled by
+    the existing find_internal_links() function.
+    """
+    clean = remove_comments_and_code(mdx_content)
+    results: Set[Tuple[str, str]] = set()
+
+    patterns = [
+        r'\[[^\]]*\]\(([^)]+)\)',           # [text](url)
+        r'<a[^>]+href=["\']([^"\']+)["\']', # <a href="url">
+        r'<Card[^>]+href=["\']([^"\']+)["\']',  # <Card href="url">
+    ]
+
+    for pattern in patterns:
+        for m in re.finditer(pattern, clean, re.IGNORECASE):
+            raw = m.group(1).strip().strip('"\'')
+
+            # Skip external URLs and pure-anchor links
+            if raw.startswith(('http://', 'https://', 'mailto:', 'tel:', 'ftp://', '#', '<mailto:')):
+                continue
+
+            if '#' not in raw:
+                continue
+
+            path_part, anchor = raw.split('#', 1)
+            if not anchor:
+                continue
+
+            # Normalise the path the same way find_internal_links does
+            path_part = path_part.split('?')[0]  # strip query params
+            if path_part.startswith('/'):
+                path_part = path_part[1:]
+            path_part = path_part.rstrip('/')
+
+            if path_part:  # skip anchor-only refs on the current page
+                results.add((path_part, anchor))
+
+    return results
+
+
+def resolve_file_path(
+    path: str,
+    existing_files: Set[str],
+    redirects: Dict[str, str],
+) -> Optional[str]:
+    """Resolve a normalised link path to a relative file path (with .mdx extension).
+
+    Returns the relative path (e.g. 'api-management/rate-limit.mdx') or None
+    if the file cannot be found even after following redirects.
+    """
+    candidates = [
+        f"{path}.mdx",
+        path,
+        f"{path}/index.mdx",
+        f"{path}/index",
+    ]
+    for c in candidates:
+        if c in existing_files:
+            # Return with .mdx extension if it's a known file
+            return c if c.endswith('.mdx') else f"{c}.mdx"
+
+    # Try redirect
+    for key in (path, f"/{path}"):
+        if key in redirects:
+            dest = redirects[key].lstrip('/')
+            if dest != path:
+                return resolve_file_path(dest, existing_files, redirects)
+
+    return None
+
+
+def check_broken_anchors(
+    base_dir: str,
+    file_anchor_links: Dict[str, Set[Tuple[str, str]]],
+    anchor_map: Dict[str, Set[str]],
+    existing_files: Set[str],
+    redirects: Dict[str, str],
+) -> Dict[str, List[Tuple[str, str]]]:
+    """Check that every anchor fragment in internal links resolves in the target file.
+
+    Returns a dict mapping source file → list of (link_with_anchor, reason) tuples.
+    """
+    broken: Dict[str, List[Tuple[str, str]]] = {}
+
+    for source_file, links in file_anchor_links.items():
+        file_broken: List[Tuple[str, str]] = []
+        for path, anchor in sorted(links):
+            rel_file = resolve_file_path(path, existing_files, redirects)
+
+            if rel_file is None:
+                # File itself doesn't exist — already caught by broken-link check
+                continue
+
+            file_anchors = anchor_map.get(rel_file, set())
+            if anchor not in file_anchors:
+                file_broken.append((f"{path}#{anchor}", f"anchor '#{anchor}' not found in {rel_file}"))
+
+        if file_broken:
+            broken[source_file] = file_broken
+
+    return broken
+
 
 def find_internal_links(mdx_content: str) -> Set[str]:
     """Extract all internal links from MDX content, excluding links in comments and code blocks."""
@@ -178,42 +365,45 @@ def find_external_links(mdx_content: str) -> Set[str]:
     
     return external_links
 
-def scan_mdx_files(directory: str, check_external: bool = False) -> Tuple[Dict[str, Set[str]], Dict[str, Set[str]], Dict[str, Set[str]]]:
-    """Scan all MDX files and return links, images, and external links by file."""
-    file_links = {}
-    file_images = {}
-    file_external_links = {}
+def scan_mdx_files(directory: str, check_external: bool = False, check_anchors: bool = False) -> Tuple[Dict[str, Set[str]], Dict[str, Set[str]], Dict[str, Set[str]], Dict[str, Set[Tuple[str, str]]]]:
+    """Scan all MDX files and return links, images, external links, and anchor links by file."""
+    file_links: Dict[str, Set[str]] = {}
+    file_images: Dict[str, Set[str]] = {}
+    file_external_links: Dict[str, Set[str]] = {}
+    file_anchor_links: Dict[str, Set[Tuple[str, str]]] = {}
     mdx_files = glob.glob(os.path.join(directory, '**/*.mdx'), recursive=True)
-    
+
     print(f"Scanning {len(mdx_files)} MDX files for links and images...")
-    
+
     for mdx_file in mdx_files:
         try:
             with open(mdx_file, 'r', encoding='utf-8') as f:
                 content = f.read()
-                
-                # Get relative path for reporting
-                rel_path = os.path.relpath(mdx_file, directory)
-                
-                # Find links and images
-                links = find_internal_links(content)
-                images = find_image_references(content)
-                
-                if links:
-                    file_links[rel_path] = links
-                if images:
-                    file_images[rel_path] = images
-                
-                # Find external links if requested
-                if check_external:
-                    external_links = find_external_links(content)
-                    if external_links:
-                        file_external_links[rel_path] = external_links
-                    
+
+            rel_path = os.path.relpath(mdx_file, directory)
+
+            links = find_internal_links(content)
+            images = find_image_references(content)
+
+            if links:
+                file_links[rel_path] = links
+            if images:
+                file_images[rel_path] = images
+
+            if check_external:
+                external_links = find_external_links(content)
+                if external_links:
+                    file_external_links[rel_path] = external_links
+
+            if check_anchors:
+                anchor_links = find_internal_links_with_anchors(content)
+                if anchor_links:
+                    file_anchor_links[rel_path] = anchor_links
+
         except Exception as e:
             print(f"Error reading {mdx_file}: {e}")
-    
-    return file_links, file_images, file_external_links
+
+    return file_links, file_images, file_external_links, file_anchor_links
 
 def load_redirects(directory: str) -> Dict[str, str]:
     """Load redirects from docs.json or mint.json configuration files."""
@@ -384,49 +574,54 @@ def check_external_links(file_external_links: Dict[str, Set[str]], timeout: int 
     
     return file_results
 
-def check_broken_links(base_dir: str, check_external: bool = False, external_timeout: int = 10, external_delay: float = 1.0) -> Tuple[Dict[str, List[str]], Dict[str, List[str]], Dict[str, str], Dict[str, List[Dict[str, Any]]]]:
-    """Check for broken internal links, missing images, and optionally external links."""
+def check_broken_links(
+    base_dir: str,
+    check_external: bool = False,
+    external_timeout: int = 10,
+    external_delay: float = 1.0,
+    check_anchors: bool = False,
+) -> Tuple[
+    Dict[str, List[str]],
+    Dict[str, List[str]],
+    Dict[str, str],
+    Dict[str, List[Dict[str, Any]]],
+    Dict[str, List[Tuple[str, str]]],
+]:
+    """Check for broken internal links, missing images, and optionally external links and anchors."""
     print(f"Checking for broken links in: {base_dir}")
-    
-    # Load redirects from configuration
+
     redirects = load_redirects(base_dir)
-    
-    # Scan all MDX files
-    file_links, file_images, file_external_links = scan_mdx_files(base_dir, check_external)
-    
-    # Find all existing files
+    file_links, file_images, file_external_links, file_anchor_links = scan_mdx_files(
+        base_dir, check_external, check_anchors
+    )
     existing_files = find_existing_files(base_dir)
-    
-    # Check for broken links
-    broken_links = {}
-    broken_images = {}
-    
-    # Check internal links
+
+    broken_links: Dict[str, List[str]] = {}
+    broken_images: Dict[str, List[str]] = {}
+
     for file_path, links in file_links.items():
-        file_broken_links = []
-        for link in links:
-            if not check_link_exists(link, existing_files, redirects):
-                file_broken_links.append(link)
-        
-        if file_broken_links:
-            broken_links[file_path] = file_broken_links
-    
-    # Check image references
+        file_broken = [l for l in links if not check_link_exists(l, existing_files, redirects)]
+        if file_broken:
+            broken_links[file_path] = file_broken
+
     for file_path, images in file_images.items():
-        file_broken_images = []
-        for image in images:
-            if image not in existing_files:
-                file_broken_images.append(image)
-        
-        if file_broken_images:
-            broken_images[file_path] = file_broken_images
-    
-    # Check external links if requested
-    external_results = {}
+        file_broken = [img for img in images if img not in existing_files]
+        if file_broken:
+            broken_images[file_path] = file_broken
+
+    external_results: Dict[str, List[Dict[str, Any]]] = {}
     if check_external and file_external_links:
         external_results = check_external_links(file_external_links, external_timeout, external_delay)
-    
-    return broken_links, broken_images, redirects, external_results
+
+    broken_anchor_results: Dict[str, List[Tuple[str, str]]] = {}
+    if check_anchors and file_anchor_links:
+        print(f"\n🔍 Building anchor map for {base_dir}...")
+        anchor_map = build_anchor_map(base_dir)
+        broken_anchor_results = check_broken_anchors(
+            base_dir, file_anchor_links, anchor_map, existing_files, redirects
+        )
+
+    return broken_links, broken_images, redirects, external_results, broken_anchor_results
 
 
 def extract_navigation_links(navigation: Dict[str, Any]) -> Set[str]:
@@ -622,19 +817,21 @@ def main():
     parser.add_argument('--external-delay', type=float, default=1.0, help='Delay between external link requests (default: 1.0s)')
     parser.add_argument('--external-only', action='store_true', help='Only check external links')
     parser.add_argument('--external-errors-only', action='store_true', help='Only show failed external links')
-    
+    parser.add_argument('--check-anchors', action='store_true', help='Validate anchor fragments in internal links')
+
     args = parser.parse_args()
-    
+
     if not os.path.exists(args.directory):
         print(f"Error: Directory '{args.directory}' does not exist")
         return 1
-    
+
     # Check for broken links and images
-    broken_links, broken_images, redirects, external_results = check_broken_links(
-        args.directory, 
+    broken_links, broken_images, redirects, external_results, broken_anchors = check_broken_links(
+        args.directory,
         check_external=args.external_links or args.external_only,
         external_timeout=args.external_timeout,
-        external_delay=args.external_delay
+        external_delay=args.external_delay,
+        check_anchors=args.check_anchors,
     )
     
     # Validate docs.json if requested
@@ -707,6 +904,15 @@ def main():
         print(f"   🔄 Redirects (3xx): {redirected_external} links")
         print(f"   ❌ Failed: {failed_external} links")
     
+    # Report broken anchor results
+    if broken_anchors:
+        total_broken_anchors = sum(len(v) for v in broken_anchors.values())
+        print(f"\n⚓ BROKEN ANCHOR FRAGMENTS ({total_broken_anchors} total):")
+        for file_path, issues in sorted(broken_anchors.items()):
+            print(f"\n  📄 {file_path}:")
+            for link, reason in sorted(issues):
+                print(f"    ❌ {link}  ({reason})")
+
     # Report validation results
     if validation_results:
         print(f"\n{'='*60}")
@@ -780,31 +986,54 @@ def main():
             print(f"❌ Found {total_broken_images} broken image references in {len(broken_images)} files")
         else:
             print("✅ No broken image references found!")
-    
+
+    if args.external_links or args.external_only:
+        if external_results:
+            failed_count = sum(1 for results in external_results.values() for r in results if not r['accessible'])
+            if failed_count:
+                print(f"❌ Found {failed_count} broken external links")
+            else:
+                print("✅ All external links are reachable!")
+        else:
+            print("✅ No external links found!")
+
+    if args.check_anchors:
+        if broken_anchors:
+            total_broken_anchors = sum(len(v) for v in broken_anchors.values())
+            print(f"❌ Found {total_broken_anchors} broken anchor fragments in {len(broken_anchors)} files")
+        else:
+            print("✅ No broken anchor fragments found!")
+
     if validation_results and 'error' not in validation_results:
-        total_issues = (len(validation_results['self_referencing_redirects']) + 
-                       len(validation_results['navigation_redirect_conflicts']) + 
+        total_issues = (len(validation_results['self_referencing_redirects']) +
+                       len(validation_results['navigation_redirect_conflicts']) +
                        len(validation_results['invalid_redirects']))
         if total_issues > 0:
             print(f"❌ Found {total_issues} redirect validation issues")
         else:
             print("✅ No redirect validation issues found!")
-    
+
     if args.verbose:
         print(f"\nScanned files in: {args.directory}")
         print(f"Total MDX files processed: {len(glob.glob(os.path.join(args.directory, '**/*.mdx'), recursive=True))}")
-    
+
     # Return non-zero exit code if any issues found
     has_broken_links = broken_links and not args.images_only
     has_broken_images = broken_images and not args.links_only
-    has_validation_issues = (validation_results and 'error' not in validation_results and 
-                           (validation_results['self_referencing_redirects'] or 
-                            validation_results['navigation_redirect_conflicts'] or 
+    has_broken_anchors = bool(broken_anchors) and args.check_anchors
+    has_broken_external = bool(external_results) and any(
+        not result['accessible']
+        for results in external_results.values()
+        for result in results
+    )
+    has_validation_issues = (validation_results and 'error' not in validation_results and
+                           (validation_results['self_referencing_redirects'] or
+                            validation_results['navigation_redirect_conflicts'] or
                             validation_results['invalid_redirects'] or
                             validation_results['missing_navigation_files'] or
                             validation_results['missing_redirect_destinations']))
-    
-    return 1 if (has_broken_links or has_broken_images or has_validation_issues) else 0
+
+    return 1 if (has_broken_links or has_broken_images or has_broken_anchors or has_broken_external or has_validation_issues) else 0
 
 if __name__ == '__main__':
     exit(main())


### PR DESCRIPTION
DX-2361: Add GitHub Actions to validate external URLs and internal anchor fragments (#1865)

* DX-2361: Add GitHub Actions to validate external URLs and internal anchors

- Extend validate_mintlify_docs.py with --check-anchors flag that extracts
  GFM-slugified heading anchors, {#custom-id} syntax, and <a id/name> elements
  from target MDX files and verifies every internal #fragment resolves
- Update validate-docs.yml to run anchor check on every PR
- Add check-external-links.yml workflow: weekly scheduled (Mon 07:00 UTC) and
  manual-trigger run that HEAD-checks all external HTTP/HTTPS URLs

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

* DX-2361: Run external link check on every pull request

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

* DX-2361: Fix exit code not failing on broken external links

External link failures were reported but never factored into the
exit code, so CI was passing despite 404s. Added has_broken_external
check and a summary line for external link results.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

* DX-2361: Switch external link checker to lychee

Replace sequential Python/requests approach with lycheeverse/lychee-action.
Lychee runs checks in parallel, has built-in retry logic, and is purpose-built
for link checking — much faster on a repo with 1500+ external URLs.

Add lychee.toml to exclude tyk-owned domains, localhost, placeholder URLs,
and sites known to block bots (LinkedIn, Facebook). Accept 429 as non-broken
to handle rate-limited responses gracefully.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

* Fix mirror-pr workflow failing on PR bodies with special characters

GitHub Actions expands ${{ }} expressions before the shell runs, so
backticks and $ signs in PR bodies were injected raw into the script
and interpreted as shell command substitution.

Fix: write static content via a single-quoted heredoc (no shell
expansion), then append the PR body via printf with an env var
($PR_BODY). Shell variables accessed as "$VAR" are never
re-interpreted, making any PR body content safe.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

* Fix lychee checking internal/relative links

Add scheme = ["https", "http"] to lychee.toml so lychee only attempts
to check http/https URLs. Without this, lychee tries to resolve
root-relative paths (/img/..., /page/...) as file URIs and fails.
Internal links are already validated by validate-docs.yml.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

* Fix lychee erroring on root-relative paths

scheme = ["https", "http"] didn't help because lychee fails to build
the URL before the scheme filter runs. Set base = "https://tyk.io" so
root-relative paths (/img/..., /page/...) are resolved to
https://tyk.io/... and then silently skipped by the existing tyk.io
exclude rule, rather than producing "cannot convert path to URI" errors.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

* Fix lychee config: base -> base_url

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

---------

Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>