### PR TITLE
Removed fix not included in release

### DIFF
--- a/developer-support/release-notes/dashboard.mdx
+++ b/developer-support/release-notes/dashboard.mdx
@@ -107,7 +107,6 @@ Updated the Docker images to Debian 13 (Trixie) to address multiple vulnerabilit
 <Accordion title='CVE fixed'>
 Addressed the following CVEs, providing increased protection against security vulnerabilities:
 
-- <a href="https://nvd.nist.gov/vuln/detail/CVE-2026-29063" target="_blank">CVE-2026-29063</a>
 - <a href="https://nvd.nist.gov/vuln/detail/CVE-2025-15281" target="_blank">CVE-2025-15281</a>
 - <a href="https://nvd.nist.gov/vuln/detail/CVE-2026-0861" target="_blank">CVE-2026-0861</a>
 - <a href="https://nvd.nist.gov/vuln/detail/CVE-2026-0915" target="_blank">CVE-2026-0915</a>


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Removed CVE-2026-29063 entry from release notes


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashboard.mdx</strong><dd><code>Remove deprecated CVE entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

developer-support/release-notes/dashboard.mdx

- Deleted CVE-2026-29063 link under Security Fixes


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/1894/files#diff-46eab3c33b18d7ca160d2569a5d0575603ce1af6ba1af53ae2a943aff9926bb4">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

