### PR TITLE
[TT-17030] Migrate PAT to GitHub App token in docs workflows

### DIFF
--- a/.github/workflows/autoupdate.yaml
+++ b/.github/workflows/autoupdate.yaml
@@ -14,9 +14,17 @@ jobs:
     name: autoupdate
     runs-on: ubuntu-22.04
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - uses: docker://chinthakagodawita/autoupdate-action:v1@sha256:53d7013ad4689b703d2715d4b17d4901bb0a385e495e0b481f37adbe9b3cc3fc
         env:
-          GITHUB_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           # Only monitor PRs that are not currently in the draft state.
           PR_READY_STATE: "ready_for_review"
           MERGE_CONFLICT_ACTION: "ignore"  # Possible option to prevent retrying failed merges

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -48,6 +48,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - name: Log deployment trigger information
         run: |
           echo "🚀 Starting documentation deployment"
@@ -70,7 +78,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           ref: production
-          token: ${{ secrets.ORG_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0  # Fetch all history for all branches
 
       - name: Set up Python
@@ -327,13 +335,13 @@ jobs:
             echo "✅ No deployment PRs found to close"
           fi
         env:
-          GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Create Pull Request
         id: create-pr
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676  # v7
         with:
-          token: ${{ secrets.ORG_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           branch: docs-merge-${{ github.run_number }}
           base: production
           title: "🤖 Auto-merge documentation from branches"
@@ -392,7 +400,7 @@ jobs:
           
           echo "✅ Auto-merge enabled on PR #$PR_NUMBER"
         env:
-          GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Create deployment summary
         run: |

--- a/.github/workflows/mirror-pr-to-build-deploy.yml
+++ b/.github/workflows/mirror-pr-to-build-deploy.yml
@@ -14,11 +14,19 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.action != 'closed'
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.ORG_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup GitHub CLI
         run: gh --version
@@ -27,11 +35,11 @@ jobs:
         run: |
           # Check if mirror PR already exists
           MIRROR_PR=$(gh pr list --base production --head ${{ github.head_ref }} --json number --jq '.[0].number // empty')
-          
+
           if [ -z "$MIRROR_PR" ]; then
             # Create new mirror PR
             echo "Creating new mirror PR..."
-          
+
             # Write PR body to file via env var to safely handle special characters
             # (backticks, $, quotes) without shell re-interpretation
             cat > pr_body.txt << 'ENDBODY'
@@ -64,30 +72,38 @@ ENDBODY
               --title "$ESCAPED_TITLE" \
               --body-file pr_body.txt \
               --draft
-          
+
             echo "✅ Mirror PR created successfully"
           else
             echo "🔄 Mirror PR #$MIRROR_PR already exists and will be auto-updated"
           fi
         env:
-          GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_BODY: ${{ github.event.pull_request.body }}
 
   cleanup-mirror-pr:
     runs-on: ubuntu-latest
     if: github.event.action == 'closed'
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.ORG_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Handle mirror PR when original is closed
         run: |
           # Find the mirror PR
           MIRROR_PR=$(gh pr list --base production --head ${{ github.head_ref }} --json number --jq '.[0].number // empty')
-          
+
           if [ -n "$MIRROR_PR" ]; then
             if [ "${{ github.event.pull_request.merged }}" = "true" ]; then
               echo "Original PR was merged, closing mirror PR #$MIRROR_PR (no need to merge)..."
@@ -102,4 +118,4 @@ ENDBODY
             echo "No mirror PR found for branch ${{ github.head_ref }}"
           fi
         env:
-          GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-bot.yaml
+++ b/.github/workflows/release-bot.yaml
@@ -14,6 +14,14 @@ jobs:
   cherry_pick:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - name: Check for release command
         id: check_command
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
@@ -112,7 +120,7 @@ jobs:
         id: cherry_pick
         if: steps.check_command.outputs.release_valid == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_REPO: ${{ github.repository }}
           GITHUB_BRANCH: ${{ steps.check_command.outputs.release_branch }}
         run: |

--- a/.github/workflows/trigger-docs-deploy.yml
+++ b/.github/workflows/trigger-docs-deploy.yml
@@ -14,6 +14,14 @@ jobs:
   trigger-deploy:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - name: Find the actual merged PR
         id: get-pr
         run: |
@@ -27,7 +35,7 @@ jobs:
           
           # Use a temporary file to avoid shell parsing issues
           curl -s \
-            -H "Authorization: token ${{ secrets.ORG_GH_TOKEN }}" \
+            -H "Authorization: token ${{ steps.app-token.outputs.token }}" \
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/repos/${{ github.repository }}/pulls?state=closed&sort=updated&direction=desc&per_page=50" > /tmp/prs.json
           
@@ -138,7 +146,7 @@ jobs:
           fi
           
           curl -X POST \
-            -H "Authorization: token ${{ secrets.ORG_GH_TOKEN }}" \
+            -H "Authorization: token ${{ steps.app-token.outputs.token }}" \
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/${{ github.repository }}/actions/workflows/deploy-docs.yml/dispatches \
             -d "$PAYLOAD"


### PR DESCRIPTION
## Summary
- Replace `ORG_GH_TOKEN` (PAT) with GitHub App token (`actions/create-github-app-token`) across all docs workflows that perform cherry-picks, mirror PRs, API calls, and deployments
- Each job gets its own `app-token` generation step using `PROBE_APP_ID` / `PROBE_APP_PRIVATE_KEY` secrets
- **Files modified:** `release-bot.yaml`, `autoupdate.yaml`, `mirror-pr-to-build-deploy.yml`, `trigger-docs-deploy.yml`, `deploy-docs.yml`

### Detailed changes
- **release-bot.yaml**: Replaced `GITHUB_TOKEN` env var (used for git clone + gh pr create/merge in cherry-pick step)
- **autoupdate.yaml**: Replaced `GITHUB_TOKEN` env var (used by autoupdate Docker action)
- **mirror-pr-to-build-deploy.yml**: Replaced in both `mirror-pr` and `cleanup-mirror-pr` jobs (checkout token + GH_TOKEN for gh CLI)
- **trigger-docs-deploy.yml**: Replaced in curl API calls (PR lookup + workflow dispatch trigger)
- **deploy-docs.yml**: Replaced in checkout token, GH_TOKEN for closing old PRs, create-pull-request token, and auto-merge GH_TOKEN

## Test plan
- [ ] Verify `/release to <branch>` command cherry-picks and creates PRs correctly
- [ ] Verify autoupdate action updates PR branches on main push
- [ ] Verify mirror PR creation/cleanup on PR open/close against main
- [ ] Verify trigger-docs-deploy finds merged PRs and dispatches deploy workflow
- [ ] Verify deploy-docs creates deployment PRs with auto-merge enabled

## Jira
[TT-17030](https://tyktech.atlassian.net/browse/TT-17030)

[TT-17030]: https://tyktech.atlassian.net/browse/TT-17030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ