### PR TITLE
[TT-17030] Migrate remaining workflows from PAT to GitHub App token

### DIFF
--- a/.github/workflows/release-to-branches-with-label.yml
+++ b/.github/workflows/release-to-branches-with-label.yml
@@ -22,10 +22,18 @@ jobs:
     if: ${{ github.event.pull_request.merged == true }}
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - name: Add a comment to the merged PR (only if labeler is in the org)
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
-          github-token: ${{ secrets.ORG_GH_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             // 1. The label format: e.g., "release-1", "release-1.0"
             const labelRegex = /^release-[0-9]+(\.[0-9]+)?$/;


### PR DESCRIPTION
## Summary
- Replace `secrets.ORG_GH_TOKEN` (PAT) with GitHub App token (`actions/create-github-app-token`) in `release-to-branches-with-label.yml`
- Added app-token generation step to the `run-on-pr-merged` job

## Test plan
- [ ] Verify the workflow triggers correctly when a PR with a release label is merged
- [ ] Confirm the GitHub App token has sufficient permissions for org membership checks and PR comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)