### PR TITLE
Revamp Developer Portal: Add: Password Reset Issues troubleshooting page

### DIFF
--- a/portal/troubleshooting/password-reset-issues.mdx
+++ b/portal/troubleshooting/password-reset-issues.mdx
@@ -1,8 +1,99 @@
 ---
 title: "Password Reset Issues"
-description: "Troubleshoot common password reset problems in the Tyk Developer Portal, including blank page redirects, temporary password reuse, and profile update bugs."
+description: "Troubleshoot password reset problems in the Tyk Developer Portal, including blank page redirects, temporary password reuse, and profile update bugs."
+sidebarTitle: "Password Reset Issues"
+keywords: "Developer Portal, password reset, SSO, CallbackBaseURL, ReturnURL, troubleshooting, forgotten password, admin reset"
 ---
 
+This page covers common password reset issues in the Tyk Developer Portal. For details on the standard password reset flow, see [Reset your password](/tyk-developer-portal/tyk-enterprise-developer-portal/api-consumer-portal/reset-password).
+
+## Symptoms
+
+<AccordionGroup>
+
+<Accordion title="Clicking a password reset link redirects to a blank page">
+
+This issue affects users who authenticate through SSO via the Tyk Identity Broker (TIB).
+
+**Cause**
+
+The password reset flow relies on two URL fields in the SSO profile configuration:
+
+- `CallbackBaseURL`: the URL of TIB, used to construct the endpoint where the identity provider sends authorization data after the user authenticates.
+- `ReturnURL`: the URL where TIB redirects the user after successful authentication, typically `https://<your-portal-domain>/sso`.
+
+If either value is incorrect, the redirect after clicking the reset link fails. This typically produces a blank page, a CORS error, or a 404/500 response.
+
 <Note>
-This page is a placeholder. Content is being written.
+Before v1.16.0, the `CallbackBaseURL` and `ReturnURL` fields appeared editable in the SSO profile form but reverted to auto-generated values after saving. Upgrade to v1.16.0 or later to persist your changes to these fields.
 </Note>
+
+**Fix**
+
+**1.** In the Admin Portal, navigate to **Settings > SSO Profiles**. Depending on your version, this may appear as **System Management > Identity Management**.
+
+{/* TODO: Screenshot — Admin Portal SSO Profiles list page showing a list of configured SSO profiles */}
+
+**2.** Open the SSO profile used by your portal.
+
+**3.** Set **CallbackBaseURL** to the URL of your TIB instance.
+
+**4.** Set **ReturnURL** to `https://<your-portal-domain>/sso`.
+
+**5.** Select **Save**.
+
+{/* TODO: Screenshot — SSO profile edit form with CallbackBaseURL and ReturnURL fields visible and filled in */}
+
+After saving, ask the user to request a new password reset email and retry the link.
+
+</Accordion>
+
+<Accordion title="Temporary password can be set as the permanent password">
+
+When a Portal Admin manually sets a user's password from the Admin Portal, the portal does not prevent the user from keeping that password without changing it. This is a concern when the temporary password is shared over a less secure channel.
+
+<Note>
+This issue was fixed in v1.16.0. If you are running v1.16.0 or later, no action is needed.
+</Note>
+
+**Workaround for versions earlier than v1.16.0**
+
+When setting the temporary password in the user's profile, check the **User must change password at the next login** checkbox. This forces the user to set a new password on their next sign-in.
+
+See [Reset a user's password from the Admin Portal](#reset-a-users-password-from-the-admin-portal) for the full steps.
+
+</Accordion>
+
+<Accordion title="Editing a user profile changes their password unexpectedly">
+
+In versions earlier than v1.13.1, saving a user's profile in the Admin Portal unintentionally overwrote their password due to a double encryption issue during the save operation. This prevented the affected user from logging in with their existing credentials.
+
+<Note>
+This issue was fixed in v1.13.1. Upgrade to v1.13.1 or later to resolve it. After upgrading, editing a user profile no longer affects their password.
+</Note>
+
+**If you are on a version earlier than v1.13.1**
+
+The affected user's password has been changed by the profile edit. Reset their password manually to restore access. See [Reset a user's password from the Admin Portal](#reset-a-users-password-from-the-admin-portal).
+
+</Accordion>
+
+</AccordionGroup>
+
+## Reset a user's password from the Admin Portal
+
+Portal Admins can set a new password for any user directly from the Admin Portal. The portal does not send an automated notification when an admin resets a password. Communicate the new credentials to the user through a secure channel.
+
+**1.** In the Admin Portal, navigate to **API Consumers > Users**.
+
+{/* TODO: Screenshot — Admin Portal API Consumers > Users page showing the user list */}
+
+**2.** Select the user whose password you want to reset.
+
+**3.** In the **Set password** field, enter the new password.
+
+**4.** To require the user to change their password on their next login, check **User must change password at the next login**.
+
+**5.** Select **Save changes**.
+
+{/* TODO: Screenshot — User profile edit page showing the Set password field and the "User must change password at the next login" checkbox */}


### PR DESCRIPTION
## Summary

- Adds the `portal/troubleshooting/password-reset-issues.mdx` page (B5 from the Developer Portal docs overhaul plan)
- Covers three symptoms: blank page on SSO reset link, temporary password reuse, profile edit overwriting password
- Includes admin how-to for manually resetting a user's password from the Admin Portal
- Version callouts for v1.13.1 and v1.16.0 fixes
- Screenshot TODO placeholders in place for all UI steps

## Test plan

- [ ] Verify page renders correctly on Netlify preview (AccordionGroup, Note components, internal anchor links)
- [ ] Confirm anchor links (`#reset-a-users-password-from-the-admin-portal`) resolve correctly
- [ ] Add screenshots and remove TODO comments before merging