### PR TITLE
Revamp Developer Portal: Add: App Visibility Controls how-to page (B15)

### DIFF
--- a/portal/app-visibility-controls.mdx
+++ b/portal/app-visibility-controls.mdx
@@ -19,9 +19,6 @@ App Visibility Controls were introduced in Developer Portal v1.14. If you are up
 | **Team** | All members of every team the app owner belongs to |
 | **Organisation** | All members of the app owner's organisation |
 
-<Note>
-Org Admins always have visibility of all Developer Apps in their organisation, regardless of the visibility setting on individual apps.
-</Note>
 
 ## Set visibility when creating an app
 
@@ -85,14 +82,18 @@ All apps that existed before the v1.14 upgrade are automatically assigned **Orga
 
 If you want to restrict visibility on specific apps after upgrading, update each app individually using the steps in [Change visibility on an existing app](#change-visibility-on-an-existing-app).
 
-## Audit apps as an Org Admin
+## Audit apps as a Portal Admin
 
-Org Admins can view all Developer Apps in their organisation from the Admin Portal, regardless of individual visibility settings.
+Portal Admins (users with Super Admin or Provider Admin permissions) can view all Developer Apps across the portal, bypassing the consumer-level visibility rules.
 
-**1. In the Admin Portal, navigate to *API Consumers > Apps*.**
+**1. Log in to the Admin Portal and navigate to *API Consumers > Apps*.**
 
 {/* TODO: Screenshot — Admin Portal Apps list showing all apps across the organisation, including the Visibility column */}
 
-This view lists every app in the organisation along with its owner and current visibility level. Use it to audit app sharing and identify apps with broader visibility than intended.
+This view lists every app along with its owner and current visibility level. Use it to audit app sharing and identify apps with broader visibility than intended.
 
-You can also retrieve this information programmatically. The `GET /apps` endpoint returns all apps in the organisation when called with an Admin API token, with the `visibility` field included in each app record. See the [Portal API reference](/product-stack/tyk-enterprise-developer-portal/api-documentation/tyk-edp-api) for details.
+You can also retrieve this information programmatically using `GET /api/apps`. This endpoint is restricted to Super Admins and Provider Admins and returns all apps with the `visibility` field included in each record. See the [Portal API reference](/product-stack/tyk-enterprise-developer-portal/api-documentation/tyk-edp-api) for details.
+
+<Note>
+Consumer-side Org Admins are subject to the same visibility filtering as all other users. They cannot see Personal apps owned by other users.
+</Note>

--- a/portal/app-visibility-controls.mdx
+++ b/portal/app-visibility-controls.mdx
@@ -1,8 +1,98 @@
 ---
 title: "App Visibility Controls"
-description: "How to configure Personal, Team, and Organisation visibility levels for Developer Apps in the Tyk Developer Portal."
+description: "Set and change Developer App visibility in the Tyk Developer Portal. Control whether an app is visible only to you, your team, or your whole organisation."
+sidebarTitle: "App Visibility Controls"
+keywords: "Developer Portal, Developer App, visibility, Personal, Team, Organisation, app sharing, access control"
 ---
 
+Control who in the Developer Portal can see your Developer Apps. Each app has a **Visibility** setting that determines whether it is private to you, shared with your team, or visible to everyone in your organisation.
+
 <Note>
-This page is a placeholder. Content is being written.
+App Visibility Controls were introduced in Developer Portal v1.14. If you are upgrading from an earlier version, see [Upgrading from a version before v1.14](#upgrading-from-a-version-before-v114).
 </Note>
+
+## Visibility levels
+
+| Level | Who can see the app |
+|---|---|
+| **Personal** | Only the app owner |
+| **Team** | All members of every team the app owner belongs to |
+| **Organisation** | All members of the app owner's organisation |
+
+<Note>
+Org Admins always have visibility of all Developer Apps in their organisation, regardless of the visibility setting on individual apps.
+</Note>
+
+## Set visibility when creating an app
+
+**1. In the Live Portal, navigate to *My Dashboard > My Apps*.**
+
+**2. Click *Create New App*.**
+
+**3. Fill in the app details, then open the *Visibility* dropdown.**
+
+{/* TODO: Screenshot — Create New App form showing the Visibility dropdown expanded with three options: Personal, Team, and Organisation */}
+
+**4. Select your preferred level:**
+- **Personal**: only you can see this app
+- **Team**: all members of your teams can see this app
+- **Organisation**: all members of your organisation can see this app
+
+**5. Click *Create App*.**
+
+The app is created with the selected visibility applied immediately.
+
+## Change visibility on an existing app
+
+You can update the visibility of any app you own at any time.
+
+**1. Navigate to *My Dashboard > My Apps* in the Live Portal.**
+
+**2. Select the app you want to update.**
+
+**3. Click *Edit App*.**
+
+**4. Open the *Visibility* dropdown and select the new level.**
+
+{/* TODO: Screenshot — Edit App form showing the Visibility field with a level currently selected */}
+
+**5. Click *Save*.**
+
+The change takes effect immediately. Team members who previously had access will no longer see the app if you reduce the visibility level.
+
+## Exceptions
+
+<AccordionGroup>
+<Accordion title="Users in the Default Team">
+
+If you are a member of the Default Team but not assigned to any named team, the **Team** option is not available in the Visibility dropdown. You can only choose Personal or Organisation.
+
+To gain access to team-level visibility, a Portal Admin must assign you to a named team. See [Organisations and Teams](/tyk-stack/tyk-developer-portal/enterprise-developer-portal/managing-access/manage-api-consumer-organisations#developer-app-visibility-1) for more information.
+
+</Accordion>
+<Accordion title="Users in the Default Organisation">
+
+If you are a member of the Default Organisation, all of your Developer Apps are treated as **Personal** regardless of the visibility level you set. This is enforced automatically to prevent unintended data exposure when users are removed from a custom organisation and revert to the default.
+
+To access team and organisation visibility, a Portal Admin must assign you to a custom organisation. See [Organisations and Teams](/tyk-stack/tyk-developer-portal/enterprise-developer-portal/managing-access/manage-api-consumer-organisations#developer-app-visibility) for more information.
+
+</Accordion>
+</AccordionGroup>
+
+## Upgrading from a version before v1.14
+
+All apps that existed before the v1.14 upgrade are automatically assigned **Organisation** visibility. No manual action is required.
+
+If you want to restrict visibility on specific apps after upgrading, update each app individually using the steps in [Change visibility on an existing app](#change-visibility-on-an-existing-app).
+
+## Audit apps as an Org Admin
+
+Org Admins can view all Developer Apps in their organisation from the Admin Portal, regardless of individual visibility settings.
+
+**1. In the Admin Portal, navigate to *API Consumers > Apps*.**
+
+{/* TODO: Screenshot — Admin Portal Apps list showing all apps across the organisation, including the Visibility column */}
+
+This view lists every app in the organisation along with its owner and current visibility level. Use it to audit app sharing and identify apps with broader visibility than intended.
+
+You can also retrieve this information programmatically. The `GET /apps` endpoint returns all apps in the organisation when called with an Admin API token, with the `visibility` field included in each app record. See the [Portal API reference](/product-stack/tyk-enterprise-developer-portal/api-documentation/tyk-edp-api) for details.


### PR DESCRIPTION
## Summary

- Adds the new `portal/app-visibility-controls.mdx` how-to page covering the App Visibility Controls feature introduced in Developer Portal v1.14
- Covers all three visibility levels (Personal, Team, Organisation), how to set and change visibility, Default Team/Org exceptions, pre-v1.14 upgrade migration behaviour, and the Portal Admin audit view
- Page is already wired into `docs.json` via the A6 structural change on the base branch

## Content notes

- Consumer-side Org Admins follow the same visibility filtering as all users (confirmed via codebase review — the release notes claim about Org Admin bypass is not reflected in the actual code)
- Default Org restriction is enforced at the model level via a `BeforeSave` hook, not just in the UI
- Pre-v1.14 apps default to Organisation visibility via GORM auto-migration

## Test plan

- [ ] Review content accuracy and wording
- [ ] Add screenshots for the three TODO placeholders (Create App, Edit App, Admin Portal Apps list) once screenshots are available
- [ ] Verify cross-links to Organisations and Teams page resolve correctly after merge