### PR TITLE
Revamp Developer Portal: add: Custom Domain Configuration

### DIFF
--- a/portal/install/custom-domain.mdx
+++ b/portal/install/custom-domain.mdx
@@ -1,8 +1,177 @@
 ---
 title: "Custom Domain Configuration"
-description: "How to configure a custom domain for the Tyk Developer Portal."
+description: "Configure a custom domain for the Tyk Developer Portal, with DNS records, TLS certificates, and nginx reverse proxy setup for a branded HTTPS URL."
+sidebarTitle: "Custom Domain"
+keywords: "Developer Portal, custom domain, HTTPS, TLS, DNS, CNAME, A record, nginx, reverse proxy, PORTAL_DOMAIN_DEFAULT, PORTAL_DOMAIN_ENABLE_CUSTOM"
 ---
 
+| Edition    | Deployment Type        |
+| :--------- | :--------------------- |
+| Enterprise | Self-Managed, Hybrid   |
+
 <Note>
-This page is a placeholder. Content is being written.
+**Tyk Cloud users:** Custom domain configuration for Tyk Cloud deployments is managed through the Tyk Cloud UI. See [Custom Domains (Tyk Cloud)](/tyk-cloud/using-custom-domains) for instructions.
 </Note>
+
+By default, the Developer Portal is accessible on the hostname or IP address of the server it runs on. A custom domain lets you expose the Live Portal on a URL you control, such as `developers.mycompany.com`, so API consumers see a branded, professional address.
+
+Configuring a custom domain involves three steps:
+
+- Setting the domain in the Portal configuration
+- Creating a DNS record that points your domain to the Portal
+- Configuring TLS so the Portal is accessible over HTTPS
+
+## Prerequisites
+
+- A running Developer Portal installation: [Docker](/portal/install/docker), [Kubernetes](/portal/install/kubernetes), or [Linux](/portal/install/linux)
+- A registered domain name you control
+- Access to your DNS provider to create records
+- A valid TLS certificate and private key for your domain
+
+## Configure the Portal Domain
+
+Two environment variables control custom domain behavior:
+
+| Environment Variable         | Config Key                    | Description                                                                                    |
+| :--------------------------- | :---------------------------- | :--------------------------------------------------------------------------------------------- |
+| `PORTAL_DOMAIN_ENABLE_CUSTOM` | `Domain.EnableCustomDomains` | Enables custom domain support. Set to `true`.                                                  |
+| `PORTAL_DOMAIN_DEFAULT`       | `Domain.DefaultDomain`       | The domain consumers use to access the Live Portal, for example `developers.mycompany.com`.    |
+
+Add these variables to your Portal configuration. For how to pass environment variables in your deployment type, see the install guide for [Docker](/portal/install/docker), [Kubernetes](/portal/install/kubernetes), or [Linux](/portal/install/linux).
+
+```ini
+PORTAL_DOMAIN_ENABLE_CUSTOM=true
+PORTAL_DOMAIN_DEFAULT=developers.mycompany.com
+```
+
+Restart the Portal after making this change.
+
+## Configure DNS
+
+Create a DNS record at your DNS provider that points your custom domain to the Portal:
+
+- **A record:** Use an A record if your Portal is reachable at a static public IP address.
+
+  ```
+  developers.mycompany.com.  300  IN  A  <portal-public-ip>
+  ```
+
+- **CNAME record:** Use a CNAME record if your Portal sits behind a load balancer or Ingress controller with a hostname.
+
+  ```
+  developers.mycompany.com.  300  IN  CNAME  <load-balancer-hostname>
+  ```
+
+DNS changes can take up to 60 minutes to propagate. Verify resolution with `nslookup developers.mycompany.com` before proceeding.
+
+<Note>
+Wildcard domains such as `*.mycompany.com` are not supported.
+</Note>
+
+## Configure TLS
+
+The Portal supports two approaches for TLS termination.
+
+### Portal-managed TLS
+
+The Portal can terminate TLS connections directly. Set the following environment variables:
+
+```ini
+PORTAL_TLS_ENABLE=true
+PORTAL_TLS_CERTIFICATES=[{"Name":"developers.mycompany.com","CertFile":"/path/to/cert.pem","KeyFile":"/path/to/key.pem"}]
+```
+
+The `Name` field must match your custom domain exactly. You can include multiple certificate objects in the array to support more than one domain.
+
+For the full list of TLS options (minimum version, cipher suites, and more), see the [configuration reference](/product-stack/tyk-enterprise-developer-portal/deploy/configuration).
+
+### TLS termination at a reverse proxy
+
+If you run a reverse proxy such as nginx in front of the Portal to terminate TLS, disable Portal-managed TLS and enable secure session handling:
+
+```ini
+PORTAL_TLS_ENABLE=false
+PORTAL_SESSION_SECURE=true
+```
+
+Your reverse proxy must forward the following headers to the Portal:
+
+| Header               | Value                    | Why it is required                                                    |
+| :------------------- | :----------------------- | :-------------------------------------------------------------------- |
+| `Host`               | Your custom domain       | Fallback for base URL construction                                     |
+| `X-Forwarded-Host`   | Your custom domain       | Determines the base URL host for SSO callbacks and email links        |
+| `X-Forwarded-Proto`  | `https`                  | Determines the base URL scheme; prevents mixed-content browser errors |
+| `X-Forwarded-For`    | Client IP address        | Required for per-client rate limiting and session validation           |
+| `X-Real-IP`          | Client IP address        | Additional client IP header used in session binding                   |
+
+<Warning>
+If `X-Forwarded-For` is missing, the Portal attributes all requests to the proxy IP address. Rate limit counters apply globally against that single IP, locking out all users simultaneously.
+</Warning>
+
+**nginx example:**
+
+```nginx expandable
+server {
+    listen 443 ssl;
+    server_name developers.mycompany.com;
+
+    ssl_certificate     /path/to/cert.pem;
+    ssl_certificate_key /path/to/key.pem;
+
+    location / {
+        proxy_pass         http://portal:3001;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Forwarded-Host  $host;
+        proxy_set_header   X-Forwarded-Proto https;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Real-IP         $remote_addr;
+    }
+}
+```
+
+## Verify the Custom Domain
+
+After restarting the Portal with the updated configuration:
+
+1. **Confirm DNS resolution.**
+
+   ```console
+   nslookup developers.mycompany.com
+   ```
+
+   The response should resolve to your Portal's IP address or load balancer hostname.
+
+2. **Open the Live Portal URL in a browser:** `https://developers.mycompany.com`. You should see the Portal home page served over HTTPS with a valid certificate.
+
+   {/* TODO: Screenshot — Live Portal home page loading on the custom domain with a valid padlock in the browser address bar */}
+
+3. **Test SSO (if configured).** Log in through your identity provider and confirm the callback URL resolves correctly on your custom domain.
+
+## Update the Custom Domain on an Existing Installation
+
+To change the custom domain after the initial setup:
+
+1. **Update `PORTAL_DOMAIN_DEFAULT`** to the new domain value.
+2. **Create a DNS record** pointing the new domain to the Portal (A record or CNAME, as described above).
+3. **Update your TLS certificate** to cover the new domain, either in `PORTAL_TLS_CERTIFICATES` or on your reverse proxy.
+4. **Restart the Portal** to apply the changes.
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="The browser shows a certificate error">
+    Check that the `Name` field in `PORTAL_TLS_CERTIFICATES` matches the domain exactly, including the subdomain. If you are using a reverse proxy, confirm the proxy certificate covers your custom domain and has not expired.
+  </Accordion>
+  <Accordion title="The Portal still serves on the old hostname">
+    Confirm that `PORTAL_DOMAIN_ENABLE_CUSTOM` is set to `true` and that `PORTAL_DOMAIN_DEFAULT` is set to your custom domain. Restart the Portal after making any changes to environment variables.
+  </Accordion>
+  <Accordion title="SSO callbacks or email links use the wrong host or scheme">
+    The Portal constructs base URLs from the `X-Forwarded-Host` and `X-Forwarded-Proto` headers. If these headers are missing or set incorrectly, callbacks and links will use the wrong host or scheme. Check that your reverse proxy sets both headers on every request.
+  </Accordion>
+  <Accordion title="All users are locked out after login attempts">
+    This occurs when `X-Forwarded-For` is not forwarded by the reverse proxy. Without this header, the Portal treats all requests as coming from the proxy IP address and applies rate limits globally. Add `proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;` to your proxy configuration and restart nginx.
+  </Accordion>
+  <Accordion title="DNS is not resolving to the correct address">
+    DNS propagation can take up to 60 minutes. Use `nslookup` or `dig` to check the current resolution. If the record still does not resolve after an hour, confirm it was saved correctly in your DNS provider and that no conflicting records exist.
+  </Accordion>
+</AccordionGroup>

--- a/portal/install/custom-domain.mdx
+++ b/portal/install/custom-domain.mdx
@@ -30,16 +30,14 @@ Configuring a custom domain involves three steps:
 
 ## Configure the Portal Domain
 
-Two environment variables control custom domain behavior:
+Two configuration keys control custom domain behavior:
 
-| Environment Variable          | Description                                                                                 |
-| :---------------------------- | :------------------------------------------------------------------------------------------ |
-| `PORTAL_DOMAIN_ENABLE_CUSTOM` | Enables custom domain support. Set to `true`.                                               |
-| `PORTAL_DOMAIN_DEFAULT`       | The domain consumers use to access the Live Portal, for example `developers.mycompany.com`. |
+| Config Key | Description |
+| :--------- | :---------- |
+| [`Domain.EnableCustomDomains`](/product-stack/tyk-enterprise-developer-portal/deploy/configuration) | Enables custom domain support. Set to `true`. Env var: `PORTAL_DOMAIN_ENABLE_CUSTOM`. |
+| [`Domain.DefaultDomain`](/product-stack/tyk-enterprise-developer-portal/deploy/configuration) | The domain consumers use to access the Live Portal, for example `developers.mycompany.com`. Env var: `PORTAL_DOMAIN_DEFAULT`. |
 
-For the equivalent config file keys, see the [configuration reference](/product-stack/tyk-enterprise-developer-portal/deploy/configuration).
-
-Add these variables to your Portal configuration. For how to pass environment variables in your deployment type, see the install guide for [Docker](/portal/install/docker), [Kubernetes](/portal/install/kubernetes), or [Linux](/portal/install/linux).
+Add these to your Portal configuration. For how to pass environment variables in your deployment type, see the install guide for [Docker](/portal/install/docker), [Kubernetes](/portal/install/kubernetes), or [Linux](/portal/install/linux).
 
 ```ini
 PORTAL_DOMAIN_ENABLE_CUSTOM=true

--- a/portal/install/custom-domain.mdx
+++ b/portal/install/custom-domain.mdx
@@ -2,7 +2,7 @@
 title: "Custom Domain Configuration"
 description: "Configure a custom domain for the Tyk Developer Portal, with DNS records, TLS certificates, and nginx reverse proxy setup for a branded HTTPS URL."
 sidebarTitle: "Custom Domain"
-keywords: "Developer Portal, custom domain, HTTPS, TLS, DNS, CNAME, A record, nginx, reverse proxy"
+keywords: "Developer Portal, custom domain, HTTPS, TLS, DNS, CNAME, A record, nginx, reverse proxy, PORTAL_DOMAIN_DEFAULT, PORTAL_DOMAIN_ENABLE_CUSTOM"
 ---
 
 | Edition    | Deployment Type        |
@@ -15,8 +15,9 @@ keywords: "Developer Portal, custom domain, HTTPS, TLS, DNS, CNAME, A record, ng
 
 By default, the Developer Portal is accessible on the hostname or IP address of the server it runs on. A custom domain lets you expose the Live Portal on a URL you control, such as `developers.mycompany.com`, so API consumers see a branded, professional address.
 
-Configuring a custom domain involves two steps:
+Configuring a custom domain involves three steps:
 
+- Setting the domain in the Portal configuration
 - Creating a DNS record that points your domain to the Portal
 - Configuring TLS so the Portal is accessible over HTTPS
 
@@ -26,6 +27,24 @@ Configuring a custom domain involves two steps:
 - A registered domain name you control
 - Access to your DNS provider to create records
 - A valid TLS certificate and private key for your domain
+
+## Configure the Portal Domain
+
+Two configuration keys control custom domain behavior:
+
+| Config Key | Description |
+| :--------- | :---------- |
+| [`Domain.EnableCustomDomains`](/product-stack/tyk-enterprise-developer-portal/deploy/configuration#portal-domain-enable-custom) | Enables custom domain support. Set to `true`. Env var: `PORTAL_DOMAIN_ENABLE_CUSTOM`. |
+| [`Domain.DefaultDomain`](/product-stack/tyk-enterprise-developer-portal/deploy/configuration#portal-domain-default) | The domain consumers use to access the Live Portal, for example `developers.mycompany.com`. Env var: `PORTAL_DOMAIN_DEFAULT`. |
+
+Add these to your Portal configuration. For how to pass environment variables in your deployment type, see the install guide for [Docker](/portal/install/docker), [Kubernetes](/portal/install/kubernetes), or [Linux](/portal/install/linux).
+
+```ini
+PORTAL_DOMAIN_ENABLE_CUSTOM=true
+PORTAL_DOMAIN_DEFAULT=developers.mycompany.com
+```
+
+Restart the Portal after making this change.
 
 ## Configure DNS
 
@@ -132,9 +151,10 @@ After restarting the Portal with the updated configuration:
 
 To change the custom domain after the initial setup:
 
-1. **Create a DNS record** pointing the new domain to the Portal (A record or CNAME, as described above).
-2. **Update your TLS certificate** to cover the new domain, either in `PORTAL_TLS_CERTIFICATES` or on your reverse proxy.
-3. **Restart the Portal** to apply the changes.
+1. **Update `PORTAL_DOMAIN_DEFAULT`** to the new domain value.
+2. **Create a DNS record** pointing the new domain to the Portal (A record or CNAME, as described above).
+3. **Update your TLS certificate** to cover the new domain, either in `PORTAL_TLS_CERTIFICATES` or on your reverse proxy.
+4. **Restart the Portal** to apply the changes.
 
 ## Troubleshooting
 
@@ -143,7 +163,7 @@ To change the custom domain after the initial setup:
     Check that the `Name` field in `PORTAL_TLS_CERTIFICATES` matches the domain exactly, including the subdomain. If you are using a reverse proxy, confirm the proxy certificate covers your custom domain and has not expired.
   </Accordion>
   <Accordion title="The Portal still serves on the old hostname">
-    Confirm that your DNS record is pointing to the correct IP address or hostname and that DNS propagation has completed. If you are using a reverse proxy, verify that `X-Forwarded-Host` is set to your custom domain on every request.
+    Confirm that `PORTAL_DOMAIN_ENABLE_CUSTOM` is set to `true` and that `PORTAL_DOMAIN_DEFAULT` is set to your custom domain. Restart the Portal after making any changes to environment variables.
   </Accordion>
   <Accordion title="SSO callbacks or email links use the wrong host or scheme">
     The Portal constructs base URLs from the `X-Forwarded-Host` and `X-Forwarded-Proto` headers. If these headers are missing or set incorrectly, callbacks and links will use the wrong host or scheme. Check that your reverse proxy sets both headers on every request. See [Single Sign On](/tyk-stack/tyk-developer-portal/enterprise-developer-portal/managing-access/enable-sso) for SSO configuration details.

--- a/portal/install/custom-domain.mdx
+++ b/portal/install/custom-domain.mdx
@@ -2,7 +2,7 @@
 title: "Custom Domain Configuration"
 description: "Configure a custom domain for the Tyk Developer Portal, with DNS records, TLS certificates, and nginx reverse proxy setup for a branded HTTPS URL."
 sidebarTitle: "Custom Domain"
-keywords: "Developer Portal, custom domain, HTTPS, TLS, DNS, CNAME, A record, nginx, reverse proxy, PORTAL_DOMAIN_DEFAULT, PORTAL_DOMAIN_ENABLE_CUSTOM"
+keywords: "Developer Portal, custom domain, HTTPS, TLS, DNS, CNAME, A record, nginx, reverse proxy"
 ---
 
 | Edition    | Deployment Type        |
@@ -15,9 +15,8 @@ keywords: "Developer Portal, custom domain, HTTPS, TLS, DNS, CNAME, A record, ng
 
 By default, the Developer Portal is accessible on the hostname or IP address of the server it runs on. A custom domain lets you expose the Live Portal on a URL you control, such as `developers.mycompany.com`, so API consumers see a branded, professional address.
 
-Configuring a custom domain involves three steps:
+Configuring a custom domain involves two steps:
 
-- Setting the domain in the Portal configuration
 - Creating a DNS record that points your domain to the Portal
 - Configuring TLS so the Portal is accessible over HTTPS
 
@@ -27,24 +26,6 @@ Configuring a custom domain involves three steps:
 - A registered domain name you control
 - Access to your DNS provider to create records
 - A valid TLS certificate and private key for your domain
-
-## Configure the Portal Domain
-
-Two configuration keys control custom domain behavior:
-
-| Config Key | Description |
-| :--------- | :---------- |
-| [`Domain.EnableCustomDomains`](/product-stack/tyk-enterprise-developer-portal/deploy/configuration#portal-domain-enable-custom) | Enables custom domain support. Set to `true`. Env var: `PORTAL_DOMAIN_ENABLE_CUSTOM`. |
-| [`Domain.DefaultDomain`](/product-stack/tyk-enterprise-developer-portal/deploy/configuration#portal-domain-default) | The domain consumers use to access the Live Portal, for example `developers.mycompany.com`. Env var: `PORTAL_DOMAIN_DEFAULT`. |
-
-Add these to your Portal configuration. For how to pass environment variables in your deployment type, see the install guide for [Docker](/portal/install/docker), [Kubernetes](/portal/install/kubernetes), or [Linux](/portal/install/linux).
-
-```ini
-PORTAL_DOMAIN_ENABLE_CUSTOM=true
-PORTAL_DOMAIN_DEFAULT=developers.mycompany.com
-```
-
-Restart the Portal after making this change.
 
 ## Configure DNS
 
@@ -151,10 +132,9 @@ After restarting the Portal with the updated configuration:
 
 To change the custom domain after the initial setup:
 
-1. **Update `PORTAL_DOMAIN_DEFAULT`** to the new domain value.
-2. **Create a DNS record** pointing the new domain to the Portal (A record or CNAME, as described above).
-3. **Update your TLS certificate** to cover the new domain, either in `PORTAL_TLS_CERTIFICATES` or on your reverse proxy.
-4. **Restart the Portal** to apply the changes.
+1. **Create a DNS record** pointing the new domain to the Portal (A record or CNAME, as described above).
+2. **Update your TLS certificate** to cover the new domain, either in `PORTAL_TLS_CERTIFICATES` or on your reverse proxy.
+3. **Restart the Portal** to apply the changes.
 
 ## Troubleshooting
 
@@ -163,7 +143,7 @@ To change the custom domain after the initial setup:
     Check that the `Name` field in `PORTAL_TLS_CERTIFICATES` matches the domain exactly, including the subdomain. If you are using a reverse proxy, confirm the proxy certificate covers your custom domain and has not expired.
   </Accordion>
   <Accordion title="The Portal still serves on the old hostname">
-    Confirm that `PORTAL_DOMAIN_ENABLE_CUSTOM` is set to `true` and that `PORTAL_DOMAIN_DEFAULT` is set to your custom domain. Restart the Portal after making any changes to environment variables.
+    Confirm that your DNS record is pointing to the correct IP address or hostname and that DNS propagation has completed. If you are using a reverse proxy, verify that `X-Forwarded-Host` is set to your custom domain on every request.
   </Accordion>
   <Accordion title="SSO callbacks or email links use the wrong host or scheme">
     The Portal constructs base URLs from the `X-Forwarded-Host` and `X-Forwarded-Proto` headers. If these headers are missing or set incorrectly, callbacks and links will use the wrong host or scheme. Check that your reverse proxy sets both headers on every request. See [Single Sign On](/tyk-stack/tyk-developer-portal/enterprise-developer-portal/managing-access/enable-sso) for SSO configuration details.

--- a/portal/install/custom-domain.mdx
+++ b/portal/install/custom-domain.mdx
@@ -34,8 +34,8 @@ Two configuration keys control custom domain behavior:
 
 | Config Key | Description |
 | :--------- | :---------- |
-| [`Domain.EnableCustomDomains`](/product-stack/tyk-enterprise-developer-portal/deploy/configuration) | Enables custom domain support. Set to `true`. Env var: `PORTAL_DOMAIN_ENABLE_CUSTOM`. |
-| [`Domain.DefaultDomain`](/product-stack/tyk-enterprise-developer-portal/deploy/configuration) | The domain consumers use to access the Live Portal, for example `developers.mycompany.com`. Env var: `PORTAL_DOMAIN_DEFAULT`. |
+| [`Domain.EnableCustomDomains`](/product-stack/tyk-enterprise-developer-portal/deploy/configuration#portal-domain-enable-custom) | Enables custom domain support. Set to `true`. Env var: `PORTAL_DOMAIN_ENABLE_CUSTOM`. |
+| [`Domain.DefaultDomain`](/product-stack/tyk-enterprise-developer-portal/deploy/configuration#portal-domain-default) | The domain consumers use to access the Live Portal, for example `developers.mycompany.com`. Env var: `PORTAL_DOMAIN_DEFAULT`. |
 
 Add these to your Portal configuration. For how to pass environment variables in your deployment type, see the install guide for [Docker](/portal/install/docker), [Kubernetes](/portal/install/kubernetes), or [Linux](/portal/install/linux).
 

--- a/portal/install/custom-domain.mdx
+++ b/portal/install/custom-domain.mdx
@@ -32,10 +32,12 @@ Configuring a custom domain involves three steps:
 
 Two environment variables control custom domain behavior:
 
-| Environment Variable         | Config Key                    | Description                                                                                    |
-| :--------------------------- | :---------------------------- | :--------------------------------------------------------------------------------------------- |
-| `PORTAL_DOMAIN_ENABLE_CUSTOM` | `Domain.EnableCustomDomains` | Enables custom domain support. Set to `true`.                                                  |
-| `PORTAL_DOMAIN_DEFAULT`       | `Domain.DefaultDomain`       | The domain consumers use to access the Live Portal, for example `developers.mycompany.com`.    |
+| Environment Variable          | Description                                                                                 |
+| :---------------------------- | :------------------------------------------------------------------------------------------ |
+| `PORTAL_DOMAIN_ENABLE_CUSTOM` | Enables custom domain support. Set to `true`.                                               |
+| `PORTAL_DOMAIN_DEFAULT`       | The domain consumers use to access the Live Portal, for example `developers.mycompany.com`. |
+
+For the equivalent config file keys, see the [configuration reference](/product-stack/tyk-enterprise-developer-portal/deploy/configuration).
 
 Add these variables to your Portal configuration. For how to pass environment variables in your deployment type, see the install guide for [Docker](/portal/install/docker), [Kubernetes](/portal/install/kubernetes), or [Linux](/portal/install/linux).
 
@@ -145,7 +147,7 @@ After restarting the Portal with the updated configuration:
 
    {/* TODO: Screenshot — Live Portal home page loading on the custom domain with a valid padlock in the browser address bar */}
 
-3. **Test SSO (if configured).** Log in through your identity provider and confirm the callback URL resolves correctly on your custom domain.
+3. **Test SSO (if configured).** Log in through your identity provider and confirm the callback URL resolves correctly on your custom domain. See [Single Sign On](/tyk-stack/tyk-developer-portal/enterprise-developer-portal/managing-access/enable-sso) for SSO configuration details.
 
 ## Update the Custom Domain on an Existing Installation
 
@@ -166,7 +168,7 @@ To change the custom domain after the initial setup:
     Confirm that `PORTAL_DOMAIN_ENABLE_CUSTOM` is set to `true` and that `PORTAL_DOMAIN_DEFAULT` is set to your custom domain. Restart the Portal after making any changes to environment variables.
   </Accordion>
   <Accordion title="SSO callbacks or email links use the wrong host or scheme">
-    The Portal constructs base URLs from the `X-Forwarded-Host` and `X-Forwarded-Proto` headers. If these headers are missing or set incorrectly, callbacks and links will use the wrong host or scheme. Check that your reverse proxy sets both headers on every request.
+    The Portal constructs base URLs from the `X-Forwarded-Host` and `X-Forwarded-Proto` headers. If these headers are missing or set incorrectly, callbacks and links will use the wrong host or scheme. Check that your reverse proxy sets both headers on every request. See [Single Sign On](/tyk-stack/tyk-developer-portal/enterprise-developer-portal/managing-access/enable-sso) for SSO configuration details.
   </Accordion>
   <Accordion title="All users are locked out after login attempts">
     This occurs when `X-Forwarded-For` is not forwarded by the reverse proxy. Without this header, the Portal treats all requests as coming from the proxy IP address and applies rate limits globally. Add `proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;` to your proxy configuration and restart nginx.

--- a/product-stack/tyk-enterprise-developer-portal/deploy/configuration.mdx
+++ b/product-stack/tyk-enterprise-developer-portal/deploy/configuration.mdx
@@ -285,6 +285,16 @@ You can specify any string value in this setting. Omit this setting if you don't
 **Type:** `string` <br/>
 **Description**: Redirects the portal login page to a custom SSO login URL. When set, GET requests to `/auth/password/login` are automatically redirected to this URL, and the portal's "Log in" button points to it. This is useful when using an Identity Provider (IDP) based login/SSO profile, as it allows you to bypass the default portal password login page and direct users to your external IDP login page instead. This setting only affects the login page redirect; user registration and password reset pages remain unchanged.
 
+### PORTAL_DOMAIN_ENABLE_CUSTOM
+**Config file:** Domain.EnableCustomDomains <br/>
+**Type:** `boolean` <br/>
+**Description**: Enables custom domain support for the Developer Portal. When set to `true`, the portal uses the domain specified in `PORTAL_DOMAIN_DEFAULT` as the public-facing URL for the Live Portal instead of inferring it from incoming request headers. The default value is `false`.
+
+### PORTAL_DOMAIN_DEFAULT
+**Config file:** Domain.DefaultDomain <br/>
+**Type:** `string` <br/>
+**Description**: The custom domain that API consumers use to access the Live Portal, for example `developers.mycompany.com`. This setting takes effect only when `PORTAL_DOMAIN_ENABLE_CUSTOM` is set to `true`.
+
 ## Response Headers Configuration
 This section explains how to configure custom HTTP response headers that will be added to all responses from the Portal.
 

--- a/product-stack/tyk-enterprise-developer-portal/deploy/configuration.mdx
+++ b/product-stack/tyk-enterprise-developer-portal/deploy/configuration.mdx
@@ -285,16 +285,6 @@ You can specify any string value in this setting. Omit this setting if you don't
 **Type:** `string` <br/>
 **Description**: Redirects the portal login page to a custom SSO login URL. When set, GET requests to `/auth/password/login` are automatically redirected to this URL, and the portal's "Log in" button points to it. This is useful when using an Identity Provider (IDP) based login/SSO profile, as it allows you to bypass the default portal password login page and direct users to your external IDP login page instead. This setting only affects the login page redirect; user registration and password reset pages remain unchanged.
 
-### PORTAL_DOMAIN_ENABLE_CUSTOM
-**Config file:** Domain.EnableCustomDomains <br/>
-**Type:** `boolean` <br/>
-**Description**: Enables custom domain support for the Developer Portal. When set to `true`, the portal uses the domain specified in `PORTAL_DOMAIN_DEFAULT` as the public-facing URL for the Live Portal instead of inferring it from incoming request headers. The default value is `false`.
-
-### PORTAL_DOMAIN_DEFAULT
-**Config file:** Domain.DefaultDomain <br/>
-**Type:** `string` <br/>
-**Description**: The custom domain that API consumers use to access the Live Portal, for example `developers.mycompany.com`. This setting takes effect only when `PORTAL_DOMAIN_ENABLE_CUSTOM` is set to `true`.
-
 ## Response Headers Configuration
 This section explains how to configure custom HTTP response headers that will be added to all responses from the Portal.
 


### PR DESCRIPTION
## Summary

- Adds the B16 Custom Domain Configuration page under Installation (`portal/install/custom-domain.mdx`)
- Covers `PORTAL_DOMAIN_ENABLE_CUSTOM` and `PORTAL_DOMAIN_DEFAULT` env vars (both previously undocumented)
- DNS guidance (A record vs CNAME), Portal-managed TLS, and nginx reverse proxy setup with required headers
- Includes a global-lockout warning for missing `X-Forwarded-For` header (sourced from Zendesk #25559)
- Troubleshooting section with 5 accordions

## Notes

- Screenshot placeholders are in place; screenshots to be added after content review
- Tyk Cloud users are redirected to `tyk-cloud/using-custom-domains`
- Base branch `portal-ia-structural-changes-a3-a7` already contains structural changes A1–A7 (nav entry for this page is already in `docs.json`)

## Source

Zendesk ticket #25559