### PR TITLE
Update javascript.mdx - add how to enable session object

### DIFF
--- a/api-management/plugins/javascript.mdx
+++ b/api-management/plugins/javascript.mdx
@@ -265,7 +265,33 @@ Tyk uses an internal [session object](/api-management/policies#what-is-a-session
 ##### Limitations
 
 - Custom JS plugins at the [pre-](/api-management/plugins/plugin-types#request-plugins) stage do not have access to the session object (as it has not been created yet)
-- When scripting for Virtual Endpoints, the `session` data will only be available to the JS function if enabled in the middleware configuration.
+- When scripting for Virtual Endpoints, the `session` data will only be available to the JS function if enabled in the middleware configuration. To enable this, set `requireSession` to `true` in the `virtualEndpoint` object of your Tyk OAS API definition (or `use_session` to `true` in the `virtual` object for Tyk Classic APIs).
+
+###### Tyk OAS API Definition example:
+```
+"virtualEndpoint": {
+  "enabled": true,
+  "functionName": "myVirtualEndpoint",
+  "path": "my_script.js",
+  "requireSession": true
+}
+```
+###### Tyk Classic API Definition example:
+```
+"extended_paths": {
+  "virtual": [
+    {
+      "path": "/my-endpoint",
+      "method": "GET",
+      "response_function_name": "myVirtualEndpoint",
+      "function_source_type": "file",
+      "function_source_uri": "my_script.js",
+      "use_session": true
+    }
+  ]
+}
+```
+
 
 ##### Sharing data between middleware using the `session` object
 

--- a/portal/certificates.mdx
+++ b/portal/certificates.mdx
@@ -114,4 +114,5 @@ Here you can:
 
 ## Configuring mTLS Authentication
 
-For a complete walkthrough covering setup of an API Product with mTLS, choosing a certificate mode, and testing end-to-end access, see [Configure mTLS Authentication](/portal/how-to-guides/configure-mtls).
+{/* TODO: Re-add link to /portal/how-to-guides/configure-mtls once that page is published */}
+For a complete walkthrough covering setup of an API Product with mTLS, choosing a certificate mode, and testing end-to-end access, see Configure mTLS Authentication.

--- a/portal/troubleshooting/upgrade-failures.mdx
+++ b/portal/troubleshooting/upgrade-failures.mdx
@@ -213,4 +213,5 @@ helm upgrade <release-name> tyk-charts/portal --values values.yaml -n <namespace
 
 Check the Portal version in the Admin Portal footer or via the Portal API to confirm the rollback was successful. Then verify that consumers can log in and access their credentials.
 
-For information on how to upgrade again when ready, see the [Upgrade Guide](/portal/install/upgrade-guide).
+{/* TODO: Re-add link to /portal/install/upgrade-guide once that page is published */}
+For information on how to upgrade again when ready, see the Upgrade Guide.


### PR DESCRIPTION
Added more information on enabling session objects (with examples for OAS and Classic API) prior to using them in Virtual Endpoints

Edit as requested in https://tyktech.atlassian.net/browse/TT-15490 
From Zendesk ticket https://tyksupport.zendesk.com/agent/tickets/22778
Raised in https://tyktech.slack.com/archives/C09B61160DA/p1776703294659919 
