### PR TITLE
fix: skip markdown image references when rewriting internal links

### DIFF
--- a/scripts/merge_docs_configs.py
+++ b/scripts/merge_docs_configs.py
@@ -1073,7 +1073,7 @@ class DocsMerger:
             changes_made += 1
             return f'[{text}]({prefix}{path_stripped})'
 
-        content = re.sub(r'\[([^\]]+)\]\((/[^)]*)\)', replace_markdown, content)
+        content = re.sub(r'(?<!!)\[([^\]]+)\]\((/[^)]*)\)', replace_markdown, content)
 
         # 3. Skip data paths - keep them clean, let JSX handle prefixing
         # This prevents double prefixing by not modifying path: "..." declarations
@@ -1150,7 +1150,7 @@ class DocsMerger:
 
         # This regex is too broad and conflicts with the absolute path regex above
         # It should only match relative paths (not starting with /)
-        content = re.sub(r'\[([^\]]+)\]\(([^/)][^)]*)\)', replace_relative_markdown, content)
+        content = re.sub(r'(?<!!)\[([^\]]+)\]\(([^/)][^)]*)\)', replace_relative_markdown, content)
 
         # Note: Snippet imports are now handled by the dedicated rewrite_snippet_imports function
 


### PR DESCRIPTION
## Problem

The `rewrite_internal_links` function in `scripts/merge_docs_configs.py` rewrites all markdown-style links `[text](/path)` by prepending the version prefix (e.g. `/nightly`). However, the regex also matched **image references** `![alt](/img/...)` since the `!` is not part of the bracketed expression.

For non-latest versions (e.g. nightly), this incorrectly transformed:
```
![alt text](/img/portal/foo.png)
```
into:
```
![alt text](/nightly/img/portal/foo.png)
```

Images are stored at the root `img/` folder and shared across all versions — they should never receive a version prefix. This was masked in most files because they use JSX `<img src="..."\>` syntax which is not touched by the markdown regex. Any file using markdown image syntax was affected.

## Fix

Added a negative lookbehind `(?<!!)\ ` to both the absolute and relative markdown link regexes so that image syntax `![alt](path)` is excluded from path rewriting while regular hyperlinks `[text](path)` continue to be processed correctly.