### PR TITLE
fix: broken StatsD instrumentation link in pump-config snippet

### DIFF
--- a/snippets/pump-config.mdx
+++ b/snippets/pump-config.mdx
@@ -5022,7 +5022,7 @@ ENV: <b>TYK_PMP_STATSDCONNECTIONSTRING</b><br />
 Type: `string`<br />
 
 Connection string for StatsD monitoring for information please see the
-[Instrumentation docs](/basic-config-and-security/report-monitor-trigger-events/instrumentation).
+[Instrumentation docs](/api-management/logs-metrics).
 
 ### statsd_prefix
 ENV: <b>TYK_PMP_STATSDPREFIX</b><br />


### PR DESCRIPTION
## Problem / Task

The `snippets/pump-config.mdx` file on `release-5.10` contains a broken link for the `statsd_connection_string` field:

```
/basic-config-and-security/report-monitor-trigger-events/instrumentation
```

This path no longer exists and causes the Mintlify link-rot CI check to fail.

## Changes

Updated the link to the current path: `/api-management/logs-metrics`

This matches the pattern used in the `main` branch.

## Context

Discovered while investigating the CI failure on PR #1987 (auto-merge from `production`). The versioned snapshot `snippets/5.10/pump-config.mdx` on `production` had the same issue and was fixed directly on the `docs-merge-770` branch.