### PR TITLE
fix: correct YAML syntax error in mirror-pr-to-build-deploy workflow

### DIFF
--- a/.github/workflows/mirror-pr-to-build-deploy.yml
+++ b/.github/workflows/mirror-pr-to-build-deploy.yml
@@ -40,28 +40,8 @@ jobs:
             # Create new mirror PR
             echo "Creating new mirror PR..."
 
-            # Write PR body to file via env var to safely handle special characters
-            # (backticks, $, quotes) without shell re-interpretation
-            cat > pr_body.txt << 'ENDBODY'
-**🔗 Auto-generated mirror PR for Mintlify preview**
-
-**Original PR:** #${{ github.event.number }}
-**Author:** @${{ github.event.pull_request.user.login }}
-
-## Purpose
-This PR provides a Mintlify preview link for reviewing documentation changes.
-
-## Preview Link
-The Mintlify preview will be available once this PR is processed.
-
-## ⚠️ Important Notes
-- **Do not merge this PR directly**
-- This PR will be auto-merged when the original PR #${{ github.event.number }} is merged
-- Make all comments and reviews on the original PR #${{ github.event.number }}
-
-## Changes
-ENDBODY
-            printf '%s\n' "$PR_BODY" >> pr_body.txt
+            # Write PR body to file; template passed via env var to keep YAML valid
+            printf '%s\n' "$PR_TEMPLATE" "$PR_BODY" > pr_body.txt
 
             # Escape the title properly to handle special characters and spaces
             ESCAPED_TITLE=$(printf '%s' "🔄 Preview: ${{ github.event.pull_request.title }}" | sed 's/"/\\"/g')
@@ -80,6 +60,24 @@ ENDBODY
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_BODY: ${{ github.event.pull_request.body }}
+          PR_TEMPLATE: |
+            **🔗 Auto-generated mirror PR for Mintlify preview**
+
+            **Original PR:** #${{ github.event.number }}
+            **Author:** @${{ github.event.pull_request.user.login }}
+
+            ## Purpose
+            This PR provides a Mintlify preview link for reviewing documentation changes.
+
+            ## Preview Link
+            The Mintlify preview will be available once this PR is processed.
+
+            ## ⚠️ Important Notes
+            - **Do not merge this PR directly**
+            - This PR will be auto-merged when the original PR #${{ github.event.number }} is merged
+            - Make all comments and reviews on the original PR #${{ github.event.number }}
+
+            ## Changes
 
   cleanup-mirror-pr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Fixes a YAML syntax error on line 46 of `.github/workflows/mirror-pr-to-build-deploy.yml` that was causing every PR push to fail with *\"Invalid workflow file\"*
- The bug: a shell heredoc (`<< 'ENDBODY'`) was used inside a `run: |` block. Heredoc content must start at column 0, but YAML's block scalar parser treats any unindented line as leaving the block — so GitHub rejected the file before running a single job
- The fix: replaced the heredoc with a `PR_TEMPLATE` env var (using YAML's own `|` block scalar at the correct indentation level), then writes both `$PR_TEMPLATE` and `$PR_BODY` to the file with a single `printf` call

## Test plan

- [ ] Confirm the `validate` and `mirror-pr-to-build-deploy` checks both pass on this PR
- [ ] Open a test PR against `main` and verify a mirror PR is created against `production`