### PR TITLE
[TT-17165] docs: Apollo Federation v2 subgraph + GraphQL subscriptions

### DIFF
--- a/api-management/data-graph.mdx
+++ b/api-management/data-graph.mdx
@@ -32,6 +32,11 @@ Currently supported DataSources:
     </Note>
 
 
+<Tip>
+**Apollo Federation v2 from your UDG schema**: A UDG schema that declares `@key` directives and runs on engine V3 (`graphql.version: "3"`) is automatically exposed as an Apollo Federation v2 subgraph — Tyk handles `_service { sdl }`, `_entities` resolution (REST or GraphQL upstream), and partial-failure semantics with no extra configuration. See [Apollo Federation v2 subgraph](/api-management/graphql/apollo-federation-v2) for the full guide.
+</Tip>
+
+
 Make sure to check some of the resources to help you start:
 - [How to create UDG schema](/api-management/data-graph#creating-schema)
 - [How to connect data sources](/api-management/data-graph#connect-datasource)

--- a/api-management/graphql.mdx
+++ b/api-management/graphql.mdx
@@ -1518,6 +1518,12 @@ Note that the `Query` type is unchecked, which indicates that all fields in `Que
 
 #### Federation Version Support
 
+Tyk supports both **Federation v1** (this section, available on engine V2 and V3) and **Apollo Federation v2** (engine V3, Tyk Enterprise Edition).
+
+<Tip>
+For Apollo Federation v2 — including auto-augmented SDL, GraphQL upstream auto-detect, proxy-mode passthrough, federated subscriptions, and per-entity partial failure — see [Apollo Federation v2 subgraph](/api-management/graphql/apollo-federation-v2). The rest of this section documents the Federation v1 behavior on Tyk Classic APIs.
+</Tip>
+
 Tyk supports Federation v1
 
 #### What is federation?
@@ -1826,6 +1832,10 @@ If the type named Person were not defined in exactly one subgraph, federation wi
 ## GraphQL WebSockets
 
 Tyk supports GraphQL via WebSockets using the protocols _graphql-transport-ws_ or _graphql-ws_ between client and Tyk Gateway.
+
+<Tip>
+For subscription configuration on **engine V3** (default subprotocol `graphql-transport-ws`, depth-limit and restricted-fields enforcement at subscribe time, Apollo Router wiring, and federated-subgraph subscriptions), see the [GraphQL Subscriptions](/api-management/graphql/graphql-subscriptions) page. The protocol-level reference below applies to V2 and V3.
+</Tip>
 
 Before this feature can be used, WebSockets need to be enabled in the Tyk Gateway configuration. To enable it set [http_server_options.enable_websockets](/tyk-oss-gateway/configuration#http_server_options-enable_websockets) to `true` in your `tyk.conf` file.
 

--- a/api-management/graphql/apollo-federation-v2.mdx
+++ b/api-management/graphql/apollo-federation-v2.mdx
@@ -1,0 +1,185 @@
+---
+title: "Apollo Federation v2 Subgraph"
+description: "Expose REST or GraphQL backends as Apollo Federation v2 subgraphs through Tyk Gateway, including subscriptions and proxy-mode passthrough."
+keywords: "Apollo Federation, Federation v2, Subgraph, GraphQL, Tyk Gateway, UDG, Universal Data Graph, Apollo Router, _entities, _service, @key, @link, partial failure, subscriptions"
+sidebarTitle: "Apollo Federation v2"
+---
+
+## Overview
+
+Tyk Gateway can act as a fully spec-compliant **Apollo Federation v2 subgraph** in any federated supergraph. Existing REST or GraphQL backends are exposed through the [Universal Data Graph (UDG)](/api-management/data-graph) without rewriting the upstream service, and Tyk can also be placed transparently in front of an existing federated subgraph or Apollo Router. Subscriptions over WebSockets, per-entity partial failures, and federation v1 versus v2 detection are all handled automatically from the customer's SDL — there are no new configuration flags to learn.
+
+<Note>
+Apollo Federation v2 subgraph behavior is part of [Tyk Enterprise Edition](https://tyk.io/contact/) and is layered exclusively on the **GraphQL engine V3** code path. Set `graphql.version: "3"` in your API definition to opt in. V2 schemas that declare `@key` will emit a startup warning pointing at this requirement.
+</Note>
+
+## What you get
+
+- **REST → subgraph**: Any REST upstream becomes a federation v2 subgraph by adding a `@key` directive to a UDG schema. Tyk resolves entity references for `_entities` using a URL template such as `https://api.example.com/users/{{.object.id}}`.
+- **GraphQL → subgraph**: A non-federated GraphQL upstream (Hasura, PostGraphile, or any introspectable schema) becomes a subgraph automatically. Tyk picks an entity-resolution strategy at API-load time — see [GraphQL upstream patterns](/api-management/graphql/graphql-upstream-patterns).
+- **Proxy mode**: Place Tyk in front of an existing federated subgraph or even another Apollo Router. Tyk forwards `_entities` and `_service { sdl }` queries unchanged and applies your normal middleware on top.
+- **Subscriptions**: WebSocket subscriptions (`graphql-ws` and `graphql-transport-ws`) work end-to-end through the federation path. See [GraphQL subscriptions](/api-management/graphql/graphql-subscriptions).
+- **Partial failure**: When a subset of entity lookups fails, Tyk returns Apollo-spec compliant per-entity `null` values plus path-tagged errors in the same `_entities` response.
+- **Auto-detection**: Federation v1 versus v2 is inferred from the SDL. An explicit `@link(url: "https://specs.apollo.dev/federation/v2.x", ...)` declares federation v2; otherwise, when `@key` is present without a `@link`, Tyk auto-prepends a federation v2 `@link` directive when emitting `_service { sdl }`.
+
+## Requirements
+
+- **Tyk Enterprise Edition** Gateway (`tyk-gateway-ee` image).
+- **GraphQL engine V3** — set `graphql.version: "3"` in the API definition.
+- **Apollo Router 2.x** or any federation v2-compatible router (Cosmo Router, GraphOS, etc.).
+
+## The simplest path: REST upstream
+
+Expose a REST `/users/:id` endpoint as a federation v2 subgraph:
+
+```json
+{
+  "name": "Users Subgraph",
+  "graphql": {
+    "enabled": true,
+    "version": "3",
+    "execution_mode": "executionEngine",
+    "schema": "type Query { _service: _Service! _entities(representations: [_Any!]!): [_Entity]! } scalar _Any union _Entity = User type _Service { sdl: String! } type User @key(fields: \"id\") { id: ID! name: String! email: String! }",
+    "engine": {
+      "data_sources": [
+        {
+          "kind": "REST",
+          "name": "users",
+          "internal": false,
+          "root_fields": [{"type": "User", "fields": ["id", "name", "email"]}],
+          "config": {
+            "url": "https://api.example.com/users/{{.object.id}}",
+            "method": "GET"
+          }
+        }
+      ]
+    }
+  },
+  "proxy": {
+    "listen_path": "/users-subgraph/",
+    "target_url": "",
+    "strip_listen_path": true
+  }
+}
+```
+
+When Apollo Router introspects this subgraph it issues `query { _service { sdl } }`. Tyk responds with the schema augmented for federation v2:
+
+```graphql
+extend schema
+  @link(url: "https://specs.apollo.dev/federation/v2.5", import: ["@key"])
+
+type User @key(fields: "id") {
+  id: ID!
+  name: String!
+  email: String!
+}
+```
+
+The `@link` line is auto-prepended because the customer SDL had `@key` without an explicit `@link`. If your SDL already includes an explicit `@link(url: "https://specs.apollo.dev/federation/v2.x", ...)`, Tyk preserves it verbatim.
+
+<Tip>
+The entity URL template uses `{{.object.<field>}}` to substitute key fields from each `_entities` representation. For composite-source upstreams use the [REST UDG configuration](/api-management/data-graph#using-external-rest-api-as-a-datasource) reference for the full template syntax.
+</Tip>
+
+## GraphQL upstream auto-detect
+
+When the upstream is itself a GraphQL service, Tyk picks one of three resolution strategies per entity at API-load time. Probes have a 5-second timeout and a failed probe causes API load to fail fast — an unreachable upstream blocks API spec acceptance rather than producing a half-broken subgraph.
+
+| Strategy | When it applies | Behaviour |
+| --- | --- | --- |
+| **Operation override** | The customer sets `has_operation: true` and provides a GraphQL `operation` template. | Tyk substitutes the key argument into the template and forwards. |
+| **Federation passthrough** | The upstream advertises `_entities` / `@key` (i.e. is itself a federation subgraph). | Tyk forwards an `_entities` representation directly. |
+| **Generated lookup** | None of the above; Tyk introspects the upstream and finds a single-arg query field such as `user(id: ID!): User`. | Tyk synthesises the lookup at load time. List-returning candidates (e.g. `users(id: ID!): [User!]!`) are filtered out. |
+
+See the [GraphQL upstream patterns deep dive](/api-management/graphql/graphql-upstream-patterns) for full configuration examples.
+
+## Proxy mode
+
+If you already operate a federated subgraph or an Apollo Router upstream, configure Tyk as a proxy in front of it. Tyk re-augments the SDL with the federation v2 `@link` if the upstream returned a federation v1 SDL, and otherwise forwards `_service { sdl }`, `_entities`, and regular operations transparently. Subscriptions are also passthrough — see [Apollo Router subscription configuration](/api-management/graphql/graphql-subscriptions#apollo-router-subscription-mode) for the upstream router config.
+
+```json
+{
+  "name": "Federated Products Proxy",
+  "graphql": {
+    "enabled": true,
+    "version": "3",
+    "execution_mode": "proxyOnly",
+    "proxy": {
+      "feature": "federation"
+    }
+  },
+  "proxy": {
+    "listen_path": "/products/",
+    "target_url": "https://internal-products-subgraph.svc.cluster.local:4001/",
+    "strip_listen_path": true
+  }
+}
+```
+
+In this mode Tyk applies the rest of your middleware (auth, rate-limits, transforms, observability) without changing the GraphQL contract.
+
+## Per-entity partial failure
+
+When a representation in an `_entities` query fails (REST 500, GraphQL error, JSON `null` body), Tyk does **not** abort the whole batch. Instead it returns a per-entity `null` plus a path-tagged error, matching the Apollo specification for `_entities` resolvers.
+
+Example response when one of three lookups fails:
+
+```json
+{
+  "data": {
+    "_entities": [
+      { "__typename": "User", "id": "1", "name": "Ada" },
+      null,
+      { "__typename": "User", "id": "3", "name": "Grace" }
+    ]
+  },
+  "errors": [
+    {
+      "message": "upstream returned status 500",
+      "path": ["_entities", 1]
+    }
+  ]
+}
+```
+
+The Apollo Router treats each null as a partial failure scoped to the corresponding query path, so other unrelated parts of the supergraph response are unaffected.
+
+## Validated against Apollo Router 2.14.0
+
+The following recordings show Tyk acting as a subgraph (and as a router-fronting proxy) against an unmodified Apollo Router 2.14.0 supergraph.
+
+- [Cast 1 — UDG federation, REST upstream](https://asciinema.org/a/ErQPtBSD2Ws9rH3h)
+- [Cast 2 — UDG federation, GraphQL upstream (Hasura), auto-detect](https://asciinema.org/a/aa8yhHC5Dg7cmmsb)
+- [Cast 3 — Partial failure (per-entity `null` + path-tagged error)](https://asciinema.org/a/gBIfFPxrL0hg0Ek5)
+- [Cast 4 — Proxy-mode passthrough in front of an existing federated subgraph](https://asciinema.org/a/2wxZAdB80xkeGZAk)
+- [Cast 5 — Tyk in both subgraph and router-proxy positions in one supergraph](https://asciinema.org/a/5ByUbRoleRnvFzc1)
+
+## How to test locally with `rover dev`
+
+Apollo Rover's `rover dev` works natively against Tyk:
+
+```bash
+# Install Rover (one-time)
+curl -sSL https://rover.apollo.dev/nix/latest | sh
+
+# With your Tyk Gateway running and the federation API loaded (graphql.version: "3"):
+rover dev --url http://localhost:8080/<your-fed-api-listen-path>/ --name tyk-subgraph
+```
+
+For deterministic CI scenarios, use `rover supergraph compose` with a standalone Apollo Router. The asciinema recordings above use this setup.
+
+## Known limitations
+
+- **Composite `@key`** — Single-field keys only. Composite keys such as `@key(fields: "id sku")` are rejected at API load.
+- **HTTP callback subscription protocol** — `callback/1.0` is intentionally deferred. Use `graphql-transport-ws` over WebSockets.
+- **Mixed-source entities** — A single entity cannot have some fields resolved from REST and others from a GraphQL upstream. Pick one source per entity.
+- **Entity batching** — `_entities` issues one upstream call per representation. Batching is a follow-up optimization.
+- **GraphOS subscription cast** — The Apollo Router subscription path requires a GraphOS commercial license. The Tyk side of the WebSocket path is independently verified by integration tests; a router-fronted subscription cast will follow once that license is available.
+
+## Related
+
+- [Universal Data Graph (UDG)](/api-management/data-graph) — schema-level configuration, header management, field mappings.
+- [GraphQL upstream patterns deep dive](/api-management/graphql/graphql-upstream-patterns) — auto-detect strategies and operation overrides.
+- [GraphQL subscriptions](/api-management/graphql/graphql-subscriptions) — WebSocket protocols, depth limits, Apollo Router wiring.
+- [GraphQL Federation v1](/api-management/graphql#graphql-federation) — legacy federation behavior on engine V2.

--- a/api-management/graphql/graphql-subscriptions.mdx
+++ b/api-management/graphql/graphql-subscriptions.mdx
@@ -1,0 +1,150 @@
+---
+title: "GraphQL Subscriptions"
+description: "WebSocket subscriptions on Tyk Gateway: graphql-ws and graphql-transport-ws protocols, federation wiring, and Apollo Router integration."
+keywords: "GraphQL, Subscriptions, WebSocket, graphql-ws, graphql-transport-ws, Apollo Router, Tyk Gateway, depth limit, restricted fields, federation"
+sidebarTitle: "GraphQL Subscriptions"
+---
+
+## Overview
+
+Tyk Gateway supports GraphQL subscriptions over WebSockets through the same engine path that handles queries and mutations. Both standard subprotocols are supported:
+
+- **`graphql-transport-ws`** — the modern protocol from [enisdenjo/graphql-ws](https://github.com/enisdenjo/graphql-ws). Default for V3 APIs when no subprotocol is configured.
+- **`graphql-ws`** — the legacy Apollo subprotocol. Still supported for backward compatibility.
+
+Subscriptions work end-to-end through the [Apollo Federation v2 subgraph](/api-management/graphql/apollo-federation-v2) path as well, allowing federated supergraphs to fan subscription operations out through Tyk-fronted subgraphs.
+
+<Note>
+GraphQL subscriptions require the **GraphQL engine V3** (`graphql.version: "3"`). The HTTP callback subscription protocol (`callback/1.0`) is intentionally not supported — use one of the WebSocket subprotocols above.
+</Note>
+
+## Enabling WebSockets
+
+Subscriptions go through the same WebSocket upgrade path as the rest of Tyk's WebSocket support. Set the following in `tyk.conf`:
+
+```json
+{
+  "http_server_options": {
+    "enable_websockets": true
+  }
+}
+```
+
+The corresponding environment variable is `TYK_GW_HTTPSERVEROPTIONS_ENABLEWEBSOCKETS=true`. See [`http_server_options.enable_websockets`](/tyk-oss-gateway/configuration#http_server_options-enable_websockets) for details.
+
+## V3 default subprotocol
+
+For engine **V3** APIs, Tyk defaults to `graphql-transport-ws` when no upstream subprotocol is configured. Earlier engine versions defaulted to `graphql-ws`. Existing API definitions that explicitly set the subprotocol are unaffected — Tyk only flips the default when the field is left empty.
+
+You can override the default per data source if your upstream insists on the legacy protocol:
+
+```json
+{
+  "kind": "GraphQL",
+  "name": "events-stream",
+  "config": {
+    "url": "wss://events.internal/graphql",
+    "subscription_type": "graphql-ws"
+  }
+}
+```
+
+Acceptable values: `graphql-transport-ws`, `graphql-ws`, `sse`. SSE upstream subscriptions are forwarded but cannot themselves be re-emitted as WebSocket subscriptions to the consumer.
+
+## Depth limit and restricted fields at subscribe-time
+
+Subscription-specific security checks run at the moment a client opens a subscription, not just per message:
+
+- **Depth limit** — the configured maximum query depth applies to the subscription document.
+- **Restricted/allowed fields** — field-based permissions from the consumer's session are evaluated against the subscription selection set. A subscription that touches a restricted field is rejected with a connection error before any messages are streamed.
+
+These checks are wired through the `WebsocketOnBeforeStart` hook on the V3 code path. Operations that violate either policy never reach the upstream; the WebSocket connection itself stays open so the client can retry with a different operation.
+
+## Subscriptions in a federated subgraph
+
+In a federation v2 subgraph, declare the `Subscription` root type alongside your `Query` and entity types. Tyk wires subscriptions through the same federation auto-detect described in [GraphQL upstream patterns](/api-management/graphql/graphql-upstream-patterns).
+
+```graphql
+extend schema
+  @link(url: "https://specs.apollo.dev/federation/v2.5", import: ["@key"])
+
+type Order @key(fields: "id") {
+  id: ID!
+  status: OrderStatus!
+}
+
+type Query {
+  order(id: ID!): Order
+}
+
+type Subscription {
+  orderStatusChanged(orderId: ID!): Order!
+}
+```
+
+Headers from the federated supergraph request are forwarded on the upstream subscription handshake; consumer-supplied authorization survives the federation hop.
+
+## Apollo Router subscription mode
+
+For self-hosted Apollo Router 2.x in front of a Tyk subgraph that exposes subscriptions, configure the `subscription` block in `router.yaml`:
+
+```yaml
+subscription:
+  enabled: true
+  mode:
+    passthrough:
+      all:
+        path: /graphql
+      subgraphs:
+        orders:
+          path: /
+          # Tyk listen path for the orders subgraph
+          # e.g. http://tyk-gateway:8080/orders-subgraph/
+```
+
+The router opens a long-lived `graphql-transport-ws` connection to the Tyk subgraph for each client subscription it serves.
+
+<Warning>
+**License**: Apollo Router's federated subscriptions through GraphOS managed plans require a commercial Apollo Router subscription license (`APOLLO_KEY` / `APOLLO_GRAPH_REF`). The Tyk side of the WebSocket path does not depend on GraphOS; you can run Apollo Router locally in dev mode for evaluation, but a production GraphOS deployment must be appropriately licensed by Apollo.
+</Warning>
+
+## Client connection example
+
+Open a `graphql-transport-ws` connection to a Tyk subscription endpoint:
+
+```javascript
+import { createClient } from 'graphql-ws';
+
+const client = createClient({
+  url: 'wss://gateway.example.com/orders-subgraph/',
+  connectionParams: {
+    Authorization: 'Bearer <api-key>',
+  },
+});
+
+const dispose = client.subscribe(
+  {
+    query: `subscription { orderStatusChanged(orderId: "42") { id status } }`,
+  },
+  {
+    next: ({ data }) => console.log(data),
+    error: (err) => console.error(err),
+    complete: () => console.log('done'),
+  },
+);
+```
+
+For the raw protocol semantics — `connection_init`, `subscribe`, `next`, `complete`, idle timeouts, and duplicate-ID handling — see the [protocol reference in the GraphQL guide](/api-management/graphql#graphql-websockets).
+
+## Known limitations
+
+- **`callback/1.0` subscription protocol** — not supported. Use `graphql-transport-ws` or `graphql-ws`.
+- **SSE → WebSocket bridging** — SSE upstream subscriptions cannot be re-emitted as WebSocket subscriptions to consumers.
+- **Kafka-source subscriptions exposed via federation** — currently a follow-up. Use the [Tyk Streams](/api-management/event-driven-apis) path for Kafka-driven event APIs.
+
+## Related
+
+- [Apollo Federation v2 subgraph](/api-management/graphql/apollo-federation-v2)
+- [GraphQL upstream patterns](/api-management/graphql/graphql-upstream-patterns)
+- [GraphQL WebSockets protocol reference](/api-management/graphql#graphql-websockets)
+- [Tyk Streams](/api-management/event-driven-apis) — Kafka, SSE, webhook event-driven APIs.

--- a/api-management/graphql/graphql-upstream-patterns.mdx
+++ b/api-management/graphql/graphql-upstream-patterns.mdx
@@ -1,0 +1,95 @@
+---
+title: "GraphQL Upstream Patterns"
+description: "How Tyk Gateway federates non-federation GraphQL backends — auto-introspection, federation passthrough, and operation overrides."
+keywords: "GraphQL, Federation, UDG, Hasura, PostGraphile, auto-detect, operation override, _entities, Tyk Gateway"
+sidebarTitle: "GraphQL Upstream Patterns"
+---
+
+## Overview
+
+When Tyk Gateway exposes a non-federation GraphQL backend as an [Apollo Federation v2 subgraph](/api-management/graphql/apollo-federation-v2), it picks one of three resolution strategies per entity at API-load time, in declared order. The chosen strategy decides how Tyk turns each `_entities` representation into an upstream call and stitches the result back into the federated response.
+
+The strategy is selected automatically; there are no configuration flags required for the auto-detect path. The only opt-in is the **operation override**, which exists for upstreams whose lookup field doesn't match Tyk's heuristic or that need a hand-written GraphQL operation.
+
+## Strategy: auto-introspection (Hasura, PostGraphile, plain GraphQL)
+
+If the upstream is reachable and exposes a single-argument lookup field whose return type matches the entity, Tyk synthesises the lookup at load time. No additional configuration is needed.
+
+For an entity like:
+
+```graphql
+type User @key(fields: "id") {
+  id: ID!
+  email: String!
+}
+```
+
+Tyk introspects the upstream and looks for a query field shaped like:
+
+```graphql
+type Query {
+  user(id: ID!): User      # picked
+  users(id: ID!): [User!]! # filtered out — list types are not eligible
+}
+```
+
+The first non-list match wins. List-returning candidates are excluded because federation `_entities` lookups must return a single object per representation. If the introspection finds **no** eligible field, API load fails with an error pointing at the missing lookup; if it finds **more than one**, the API also fails to load with an "ambiguous lookup field" error and you need to use the operation override below.
+
+This pattern works out of the box for:
+- **Hasura** — auto-generated `<table>(where: ..., limit: 1)` and `<table>_by_pk(id: ...)` fields. The latter is preferred.
+- **PostGraphile** — auto-generated `<table>ById(id: ...)` accessors.
+- **Hand-rolled GraphQL services** that expose a single-row lookup per type.
+
+## Strategy: federation passthrough
+
+If the upstream advertises `_entities` and `@key` directives — i.e. is itself an Apollo federation subgraph — Tyk forwards your federated request directly. This is the same code path used in [proxy mode](/api-management/graphql/apollo-federation-v2#proxy-mode) but invoked from a UDG data source rather than a top-level proxy API.
+
+Tyk detects this by introspecting the upstream and checking for an `_entities` field plus the federation directive set. No extra configuration is required.
+
+## Strategy: operation override
+
+When neither of the auto-detect strategies fits — for example, the upstream lookup field takes multiple required arguments, or you need to project the entity through a custom transformation — provide a GraphQL operation template explicitly. Tyk substitutes the `@key` value into the template variables and forwards.
+
+```json
+{
+  "kind": "GraphQL",
+  "name": "users-graphql",
+  "internal": false,
+  "config": {
+    "url": "https://users.internal.svc.cluster.local/graphql",
+    "method": "POST",
+    "has_operation": true,
+    "operation": "query LookupUser($userId: ID!) { user(by: { id: $userId }) { id email displayName } }",
+    "variables": "{\"userId\": \"{{.object.id}}\"}"
+  },
+  "root_fields": [
+    {"type": "User", "fields": ["id", "email", "displayName"]}
+  ]
+}
+```
+
+Notes on the override:
+- `has_operation: true` is required to take this path. Without it Tyk falls through to auto-introspection.
+- The `operation` body must be a valid GraphQL query document. A malformed template fails the API load with a parse error.
+- `variables` is a JSON object whose values use the standard UDG templating syntax (`{{.object.<field>}}`, `{{.arguments.<name>}}`, `{{.headers.<name>}}`).
+- Tyk applies the same per-entity partial failure handling to operation-override strategies — a failed upstream call yields a `null` for that representation plus a path-tagged error.
+
+## Strategy precedence
+
+Tyk evaluates the three strategies in this order per data source:
+
+1. **Operation override** — if `has_operation: true` is set, this is the only strategy considered.
+2. **Federation passthrough** — if the upstream is itself a federation subgraph.
+3. **Generated lookup** — auto-introspection, with list-returning fields filtered out.
+
+If all three fail to produce a resolver, API load fails with an explicit error. Probe timeout for the auto-detect strategies is 5 seconds.
+
+## Header forwarding
+
+For all three strategies, Tyk applies the configured [UDG header rules](/api-management/data-graph#header-management) to the upstream call. Per-data-source headers, global UDG headers, and the standard request-context variables are all available — including authorization headers passed through from the consumer's request to the federated supergraph.
+
+## Related
+
+- [Apollo Federation v2 subgraph](/api-management/graphql/apollo-federation-v2) — main feature page.
+- [Universal Data Graph](/api-management/data-graph) — UDG concepts, data sources, field mappings.
+- [GraphQL subscriptions](/api-management/graphql/graphql-subscriptions) — subscription auto-detect for GraphQL upstreams.

--- a/developer-support/release-notes/gateway.mdx
+++ b/developer-support/release-notes/gateway.mdx
@@ -15,6 +15,95 @@ Our minor releases are supported until our next minor comes out.
 
 ---
 
+## 5.13 Release Notes
+
+### 5.13.0 Release Notes
+
+#### Release Highlights
+
+This release ships **Apollo Federation v2 subgraph compliance** and **GraphQL subscriptions** on the GraphQL engine V3 code path, gated behind Tyk Enterprise Edition.
+
+- Expose existing REST or GraphQL backends as fully spec-compliant Apollo Federation v2 subgraphs through the Universal Data Graph — no schema rewriting required.
+- Auto-detect the upstream pattern (REST entity template, GraphQL auto-introspection lookup, federation passthrough, or operation override) per data source at API load.
+- Place Tyk in proxy mode in front of an existing federated subgraph or Apollo Router; `_service { sdl }` and `_entities` are forwarded transparently with the federation v2 `@link` auto-prepended where required.
+- Apollo-spec compliant per-entity partial failure for `_entities` lookups (per-representation `null` plus path-tagged error).
+- WebSocket GraphQL subscriptions over `graphql-transport-ws` and `graphql-ws`, with depth-limit and restricted-field enforcement at subscribe time. V3 default subprotocol is `graphql-transport-ws`.
+- Validated end-to-end against unmodified Apollo Router 2.14.0 — see the [Apollo Federation v2 subgraph](/api-management/graphql/apollo-federation-v2) docs for the recordings.
+
+For configuration details, see the new [Apollo Federation v2 subgraph](/api-management/graphql/apollo-federation-v2), [GraphQL upstream patterns](/api-management/graphql/graphql-upstream-patterns), and [GraphQL subscriptions](/api-management/graphql/graphql-subscriptions) pages.
+
+#### Breaking Changes
+
+There are no breaking changes in this release. **V3 customers** who declare `@key` on a GraphQL schema will automatically have Tyk respond as a federation subgraph; if you want to keep V1 behavior, do not migrate the API to V3.
+
+#### V2-only constraint
+
+Federation v2, GraphQL subscriptions, and the new auto-detect strategies are layered exclusively on the **GraphQL engine V3** code path. Set `graphql.version: "3"` in your API definition to opt in. V2 schemas that declare `@key` directives will emit a startup warning pointing at this requirement; V2 federation v1 behavior is preserved unchanged.
+
+#### Edition gating
+
+Apollo Federation v2 subgraph support and GraphQL subscriptions on V3 are part of [Tyk Enterprise Edition](https://tyk.io/contact/) and ship in the `tyk-gateway-ee` image, mirroring how Tyk Streams is licensed.
+
+#### Changelog
+
+##### Added
+
+<AccordionGroup>
+
+<Accordion title='Apollo Federation v2 subgraph compliance'>
+Tyk Gateway can act as a fully spec-compliant Apollo Federation v2 subgraph for any REST or GraphQL upstream. Schema augmentation, `_service { sdl }` emission with auto-prepended `@link`, `_entities` resolution, and partial-failure semantics are auto-detected from the customer SDL. See [Apollo Federation v2 subgraph](/api-management/graphql/apollo-federation-v2).
+</Accordion>
+
+<Accordion title='GraphQL upstream auto-detect'>
+For GraphQL upstreams Tyk picks one of three resolution strategies — operation override, federation passthrough, or generated lookup via introspection — at API load time. List-returning lookup candidates are filtered out to ensure single-object resolution per `_entities` representation. See [GraphQL upstream patterns](/api-management/graphql/graphql-upstream-patterns).
+</Accordion>
+
+<Accordion title='Proxy-mode passthrough for federated subgraphs and Apollo Router'>
+Place Tyk in front of an existing federated subgraph or Apollo Router; `_service { sdl }`, `_entities`, regular operations, and subscriptions are forwarded transparently. The federation v2 `@link` directive is auto-prepended on `_service { sdl }` responses if the upstream returned a federation v1 SDL. See [Proxy mode](/api-management/graphql/apollo-federation-v2#proxy-mode).
+</Accordion>
+
+<Accordion title='GraphQL subscriptions over WebSocket on engine V3'>
+Subscriptions over `graphql-transport-ws` and `graphql-ws` are supported through the engine V3 code path, including in federation subgraphs. The V3 default subprotocol when none is configured is `graphql-transport-ws`. Depth limits and restricted-field permissions are enforced at subscribe time via the `WebsocketOnBeforeStart` hook. See [GraphQL subscriptions](/api-management/graphql/graphql-subscriptions).
+</Accordion>
+
+<Accordion title='Per-entity partial failure for `_entities`'>
+When a representation in an `_entities` query fails, Tyk now returns a `null` for that entity plus a path-tagged error in the same response, matching the Apollo specification. Other entities in the same batch are unaffected.
+</Accordion>
+
+</AccordionGroup>
+
+##### Fixed
+
+<AccordionGroup>
+
+<Accordion title='`variables: null` requests no longer rejected with HTTP 400'>
+GraphQL POST requests with `"variables": null` in the body (sent by Apollo Router and `rover dev`) were previously rejected with HTTP 400. They are now normalized to `{}` at the request boundary across all engine versions, restoring spec-compliant behavior.
+</Accordion>
+
+<Accordion title='`_service { sdl }` returned HTTP 500 in UDG mode'>
+The `_Service.sdl` field was missing from the UDG `ChildNodes` registration, causing `_service { sdl }` queries to fail. Federation introspection now succeeds for any UDG schema with `@key` directives.
+</Accordion>
+
+<Accordion title='`_service { sdl }` was missing the federation v2 `@link`'>
+SDL emitted by `_service` lacked the `@link(url: "https://specs.apollo.dev/federation/v2.x", ...)` directive, causing Apollo Router to classify Tyk as a federation v1 subgraph. The `@link` is now auto-prepended when the SDL has `@key` but no explicit `@link`.
+</Accordion>
+
+<Accordion title='Apollo Router proxying `Query.<entity-field>` to Tyk failed'>
+UDG data sources only registered the entity, not the corresponding `Query` field, leading to "field not found" errors when Apollo Router proxied a top-level query through Tyk. Orphan `Query` fields are now stripped from the SDL emitted by `_service`.
+</Accordion>
+
+<Accordion title='Nil-map panic on JSON-`null` REST upstream responses'>
+A REST upstream returning `null` for an `_entities` representation crashed the gateway with a nil-map dereference. It now produces a per-entity failure with an Apollo-spec error path.
+</Accordion>
+
+<Accordion title='Auto-detect picked list-returning Query fields as lookup candidates'>
+Auto-introspection treated `users(id: ID!): [User!]!` as an entity-lookup candidate. List types are now filtered out so only single-object lookups are eligible.
+</Accordion>
+
+</AccordionGroup>
+
+---
+
 ## 5.12 Release Notes 
 
 ### 5.12.1 Release Notes 

--- a/developer-support/release-notes/gateway.mdx
+++ b/developer-support/release-notes/gateway.mdx
@@ -15,9 +15,9 @@ Our minor releases are supported until our next minor comes out.
 
 ---
 
-## 5.13 Release Notes
+## 5.14 Release Notes
 
-### 5.13.0 Release Notes
+### 5.14.0 Release Notes
 
 #### Release Highlights
 

--- a/docs.json
+++ b/docs.json
@@ -234,7 +234,10 @@
                 "group": "GraphQL",
                 "pages": [
                   "api-management/graphql",
-                  "api-management/graphql/graphql-schema-types"
+                  "api-management/graphql/graphql-schema-types",
+                  "api-management/graphql/apollo-federation-v2",
+                  "api-management/graphql/graphql-upstream-patterns",
+                  "api-management/graphql/graphql-subscriptions"
                 ]
               },
               "api-management/data-graph",


### PR DESCRIPTION
## Summary

Documents the Apollo Federation v2 subgraph compliance and GraphQL subscription work shipping in:

- **Gateway:** [TykTechnologies/tyk#8193](https://github.com/TykTechnologies/tyk/pull/8193)
- **Library co-change:** [TykTechnologies/graphql-go-tools#444](https://github.com/TykTechnologies/graphql-go-tools/pull/444)

The feature lets customers expose existing REST or GraphQL backends as Apollo Federation v2 subgraphs through Tyk Gateway with zero schema rewriting, place Tyk in proxy mode in front of an existing federated subgraph or Apollo Router, and run GraphQL subscriptions over WebSockets through the same path. End-to-end validated against unmodified Apollo Router 2.14.0 — five asciinema recordings are linked from the new feature page.

It is gated behind **Tyk Enterprise Edition** and the **GraphQL engine V3** code path (`graphql.version: "3"`). V2 schemas with `@key` directives emit a startup warning and continue to use Federation v1 behavior unchanged.

## Pages added

- `api-management/graphql/apollo-federation-v2.mdx` — feature landing page: requirements, REST upstream walkthrough, GraphQL upstream auto-detect overview, proxy mode, partial-failure semantics, the 5 validation casts, `rover dev` recipe, and known limitations.
- `api-management/graphql/graphql-upstream-patterns.mdx` — deep dive on the three GraphQL upstream resolution strategies (operation override, federation passthrough, generated lookup via auto-introspection) with Hasura, PostGraphile, and operation-override examples.
- `api-management/graphql/graphql-subscriptions.mdx` — V3 subscription support, V3 default subprotocol flip to `graphql-transport-ws`, subscribe-time depth-limit and restricted-field enforcement, federation-subgraph subscription wiring, and Apollo Router self-hosted subscription-mode YAML with the GraphOS license callout.

## Pages modified

- `api-management/data-graph.mdx` — added a Federation v2 callout in the UDG overview section pointing at the new feature page.
- `api-management/graphql.mdx` — added a Federation v1 vs v2 cross-link near the existing Federation section and a subscription cross-link near the WebSockets section.
- `docs.json` — added the three new pages to the GraphQL nav group.
- `developer-support/release-notes/gateway.mdx` — added a 5.13.0 changelog entry naming the feature, the V3-only constraint, the EE gating, and the 6 bugs caught and fixed during end-to-end validation.

## V3-only constraint and edition gating

Set `graphql.version: "3"` in the API definition to access federation v2 features. V2 customers who declare `@key` will see a startup warning. Federation v2 ships in the `tyk-gateway-ee` image, mirroring how Tyk Streams is licensed.

## Test plan

- [x] `scripts/validate_mintlify_docs.py . --validate-redirects` — no broken internal links, image references, or redirect issues.
- [x] `scripts/validate_mintlify_docs.py . --check-anchors --links-only` — no broken anchor fragments.
- [ ] Mintlify preview build renders the three new pages and the updated nav group.
- [ ] Cross-links from `data-graph.mdx`, `graphql.mdx`, and the changelog open the right anchors on the new pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)