### PR TITLE
fix: use ORG_GH_TOKEN for tyk-pocs checkout and PR creation

### DIFF
--- a/.github/workflows/sync-versions-to-tyk-install.yml
+++ b/.github/workflows/sync-versions-to-tyk-install.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: TykTechnologies/tyk-pocs
-          token: ${{ secrets.TYK_INSTALL_PAT }}
+          token: ${{ secrets.ORG_GH_TOKEN }}
           path: tyk-install
 
       - name: Update .env.example versions
@@ -108,4 +108,4 @@ jobs:
             --base main \
             --head "$BRANCH"
         env:
-          GH_TOKEN: ${{ secrets.TYK_INSTALL_PAT }}
+          GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}


### PR DESCRIPTION
## Summary

- Replaces the missing \`TYK_INSTALL_PAT\` secret with the org-level \`ORG_GH_TOKEN\` secret in two places:
  - \`actions/checkout\` token for checking out \`TykTechnologies/tyk-pocs\`
  - \`GH_TOKEN\` env var used by \`gh pr create\`

## Root cause

The [CI run](https://github.com/TykTechnologies/tyk-docs/actions/runs/25845709738/job/75940392489) failed with `Input required and not supplied: token` because \`TYK_INSTALL_PAT\` was never added as a repo secret. \`ORG_GH_TOKEN\` already exists at the org level and has the necessary access.