### PR TITLE
fix: use ORG_GH_TOKEN for release label workflow + add workflow_dispatch

### DIFF
--- a/.github/workflows/release-to-branches-with-label.yml
+++ b/.github/workflows/release-to-branches-with-label.yml
@@ -8,6 +8,12 @@ on:
       - main
     types:
       - closed
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to process (for manual testing)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -18,30 +24,37 @@ jobs:
   run-on-pr-merged:
     runs-on: ubuntu-latest
 
-    # Only run if the PR was actually merged
-    if: ${{ github.event.pull_request.merged == true }}
+    # For pull_request events: only run if the PR was actually merged
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
 
     steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ secrets.PROBE_APP_ID }}
-          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
-          owner: TykTechnologies
-
       - name: Add a comment to the merged PR (only if labeler is in the org)
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ secrets.ORG_GH_TOKEN }}
           script: |
             // 1. The label format: e.g., "release-1", "release-1.0"
             const labelRegex = /^release-[0-9]+(\.[0-9]+)?$/;
-            
-            // 2. Get PR info
-            const pullRequestNumber = context.payload.pull_request.number;
-            const labelsOnPR = context.payload.pull_request.labels || [];
+
+            // 2. Get PR info — from event payload or workflow_dispatch input
+            let pullRequestNumber, labelsOnPR;
+            if (context.eventName === 'workflow_dispatch') {
+              const prNum = parseInt(context.payload.inputs.pr_number);
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNum
+              });
+              pullRequestNumber = prNum;
+              labelsOnPR = pr.labels || [];
+            } else {
+              pullRequestNumber = context.payload.pull_request.number;
+              labelsOnPR = context.payload.pull_request.labels || [];
+            }
+
+            console.log("PR number:", pullRequestNumber);
             console.log("Labels on the Pull Request:", labelsOnPR.map(label => label.name));
+
             // 3. Get all timeline events to see who labeled the PR
             const { data: prEvents } = await github.rest.issues.listEvents({
               owner: context.repo.owner,
@@ -51,11 +64,12 @@ jobs:
 
             // 4. Filter down to "labeled" events
             const labeledEvents = prEvents.filter(ev => ev.event === 'labeled');
-            console.log("Labeled Events:",labeledEvents.map(event => ({
+            console.log("Labeled Events:", labeledEvents.map(event => ({
                 label: event.label?.name,
                 user: event.actor?.login,
                 timestamp: event.created_at
             })));
+
             // 5. Build a map: labelName -> last user who added it
             //    (We reverse to get the *most recent* labeler, if a label was added multiple times)
             const labelToLastLabeler = {};
@@ -83,17 +97,17 @@ jobs:
                 let isMember = false;
                 try {
                   await github.rest.orgs.checkMembershipForUser({
-                    org: 'TykTechnologies',              
+                    org: 'TykTechnologies',
                     username: userWhoAddedLabel
                   });
                   // If this call succeeds, they're a member
                   isMember = true;
-                  console.log(`User '${userWhoAddedLabel}' is a member of the organization '${'TykTechnologies'}'.`);
+                  console.log(`User '${userWhoAddedLabel}' is a member of the organization 'TykTechnologies'.`);
                 } catch (error) {
                   // If 404, user is not a member. Anything else is an unexpected error.
                   if (error.status === 404) {
-                    console.log(`User '${userWhoAddedLabel}' is NOT a member of the organization '${'TykTechnologies'}'.`);
-                  }else {
+                    console.log(`User '${userWhoAddedLabel}' is NOT a member of the organization 'TykTechnologies'.`);
+                  } else {
                     console.error(`An error occurred while checking membership for user '${userWhoAddedLabel}':`, error);
                     throw error;
                   }
@@ -108,10 +122,10 @@ jobs:
                     issue_number: pullRequestNumber,
                     body: `/release to ${label.name}`
                   });
-                }else{
-                 console.log(`No comment created for label '${label.name}' on PR #${pullRequestNumber} because the user '${userWhoAddedLabel}' is not a member of the organization 'TykTechnologies'.`);
-                 }
-              }else{
+                } else {
+                  console.log(`No comment created for label '${label.name}' on PR #${pullRequestNumber} because the user '${userWhoAddedLabel}' is not a member of the organization 'TykTechnologies'.`);
+                }
+              } else {
                 console.log(`Label '${label.name}' does not match the expected format.`);
-               }
+              }
             }


### PR DESCRIPTION
## Root cause

The workflow used a GitHub App token (\`PROBE_APP_ID\`/\`PROBE_APP_PRIVATE_KEY\`) for the \`checkMembershipForUser\` API call. That App doesn't have \`members:read\` org permission, so the API returned 404 — which the script treated as \"not a member\" and silently skipped posting the comment.

Confirmed in [run #25846516955](https://github.com/TykTechnologies/tyk-docs/actions/runs/25846516955):
> `No comment created for label 'release-5.12' on PR #1954 because the user 'sharadregoti' is not a member of the organization 'TykTechnologies'.`

## Changes

- Replace GitHub App token + `actions/create-github-app-token` step with `ORG_GH_TOKEN` (already works, proven by the sync workflow fix)
- Add `workflow_dispatch` with a `pr_number` input so the workflow can be triggered manually for testing without needing to merge a PR
- Update the `if` condition to allow `workflow_dispatch` runs through
- In `workflow_dispatch` mode, fetch the PR data via API instead of reading from the event payload