### PR TITLE
Clarification on Dashboard TLS config

### DIFF
--- a/api-management/implement-tls.mdx
+++ b/api-management/implement-tls.mdx
@@ -483,6 +483,8 @@ When set to `true` this:
 
 The Tyk Dashboard can be configured to use HTTPS for its Control API using the `http_server_options` section in its configuration file (`tyk_analytics.conf`) or equivalent environment variables. This is similar to the section of the same name in the Gateway config, allowing configuration of TLS certificates (generic and for specific domains using SNI), the minimum TLS version, the cipher suites to be used (for TLS 1.2), and the option to skip certificate verification (recommended only for non-production deployments).
 
+Note however that, unlike the Gateway, the Dashboard **does not** support configuring a maximum TLS version. It relies on Go's default behavior, which automatically supports up to the highest available TLS version (currently TLS 1.3).
+
 <Note>
   The Dashboard does not have access to the Tyk Certificate Store when configuring its own interfaces, so certificates and keys must be available on the filesystem and referenced by path.
 </Note>


### PR DESCRIPTION
Small clarification - Dashboard does not have a configurable "max TLS version" (unlike Gateway).