### PR TITLE
fix(seo): validate canonical URLs against nav tree before writing

### DIFF
--- a/5.10/portal/api-consumer/invite-codes.mdx
+++ b/5.10/portal/api-consumer/invite-codes.mdx
@@ -3,7 +3,7 @@ title: "Register a User using Invite Codes"
 'og:description': "How to configure basic authentication in Tyk?"
 tags: ['Authentication', 'Authorization', 'Tyk Authentication', 'Tyk Authorization', 'Secure APIs', 'Basic Authentication']
 sidebarTitle: "Invite Codes"
-canonical: "https://tyk.io/docs/portal/api-consumer/invite-codes"
+canonical: "https://tyk.io/docs/portal/api-consumer"
 ---
 
 ## Invite Codes

--- a/5.10/product-stack/tyk-enterprise-developer-portal/api-documentation/list-of-endpoints/portal-1.13.0-list-of-endpoints.mdx
+++ b/5.10/product-stack/tyk-enterprise-developer-portal/api-documentation/list-of-endpoints/portal-1.13.0-list-of-endpoints.mdx
@@ -4,7 +4,7 @@ title: "List of endpoints exposed by Tyk Enterprise Developer Portal v1.13.0"
 sidebarTitle: "Enterprise Developer Portal Admin"
 tags: ['Tyk Developer Portal', 'Enterprise Portal', 'Endpoints', 'Firewall', 'Integration', 'Portal 1.13.0']
 order: 3
-canonical: "https://tyk.io/docs/product-stack/tyk-enterprise-developer-portal/api-documentation/list-of-endpoints/portal-1.13.0-list-of-endpoints"
+canonical: "https://tyk.io/docs/product-stack/tyk-enterprise-developer-portal/api-documentation/list-of-endpoints/portal-api-list-of-endpoints"
 ---
 
 

--- a/5.10/tyk-developer-portal/tyk-enterprise-developer-portal/api-consumer-portal/access-api-product.mdx
+++ b/5.10/tyk-developer-portal/tyk-enterprise-developer-portal/api-consumer-portal/access-api-product.mdx
@@ -3,7 +3,7 @@ title: "Access an API Product"
 'og:description': "How to access an api product in Tyk developer portal"
 sidebarTitle: "Access an API Product"
 tags: ['Developer Portal', 'Tyk', 'API Consumer']
-canonical: "https://tyk.io/docs/tyk-developer-portal/tyk-enterprise-developer-portal/api-consumer-portal/access-api-product"
+canonical: "https://tyk.io/docs/portal/request-access"
 ---
 
 ## Introduction

--- a/5.10/tyk-developer-portal/tyk-portal-classic/streams.mdx
+++ b/5.10/tyk-developer-portal/tyk-portal-classic/streams.mdx
@@ -5,7 +5,7 @@ sidebarTitle: "Streams with Classic Portal"
 tags: ['streaming', 'events', 'event-driven architecture', 'event-driven architectures', 'kafka']
 order: 12
 noindex: True
-canonical: "https://tyk.io/docs/tyk-developer-portal/tyk-portal-classic/streams"
+canonical: "https://tyk.io/docs/portal/api-products"
 ---
 
 import LegacyClassicPortalApi from '/snippets/5.10/legacy-classic-portal-api.mdx';

--- a/5.10/ui-examples/feature-cards.mdx
+++ b/5.10/ui-examples/feature-cards.mdx
@@ -3,7 +3,7 @@ title: "Feature Cards"
 'og:description': "Documentation for the feature-cards shortcode in Tyk. Learn how to display responsive feature cards with icons, titles, and descriptions."
 sidebarTitle: "UI Example: Feature Cards shortcode"
 tags: ['UI Examples', 'Shortcodes', 'Feature Cards']
-canonical: "https://tyk.io/docs/ui-examples/feature-cards"
+canonical: "https://tyk.io/docs/developer-support/contributing"
 ---
 
 import UIExampleCards from '/snippets/5.10/UIExampleCards.mdx';

--- a/5.10/ui-examples/test-pill-label.mdx
+++ b/5.10/ui-examples/test-pill-label.mdx
@@ -1,7 +1,7 @@
 ---
 title: "UI Examples: Pill label shortcode"
 sidebarTitle: "UI Example: Pill Label shortcode"
-canonical: "https://tyk.io/docs/ui-examples/test-pill-label"
+canonical: "https://tyk.io/docs/developer-support/contributing"
 ---
 
 This page demonstrates all available styles and usage examples of the pill-label shortcode.

--- a/5.10/ui-examples/youtube-video-embed.mdx
+++ b/5.10/ui-examples/youtube-video-embed.mdx
@@ -3,7 +3,7 @@ title: "YouTube Video Embed"
 'og:description': "Documentation for the youtube-seo shortcode in Tyk. Learn how to embed YouTube videos in your documentation with proper styling and responsive behavior."
 sidebarTitle: "UI Example: YouTube Video Embed shortcode"
 tags: ['UI Examples', 'Shortcodes', 'Video Embed']
-canonical: "https://tyk.io/docs/ui-examples/youtube-video-embed"
+canonical: "https://tyk.io/docs/developer-support/contributing"
 ---
 
 The `youtube-seo` shortcode allows you to easily embed YouTube videos in your documentation with proper styling and responsive behavior.

--- a/5.8/developer-support/inclusive-naming-policy.mdx
+++ b/5.8/developer-support/inclusive-naming-policy.mdx
@@ -2,7 +2,7 @@
 title: "Inclusive Naming Policy"
 sidebarTitle: "Inclusive Naming Policy"
 tags: ['Inclusive Naming Initiative', 'Inclusivity', 'Inclusive']
-canonical: "https://tyk.io/docs/developer-support/inclusive-naming-policy"
+canonical: "https://tyk.io/docs/developer-support/documentation-projects/inclusive-naming"
 ---
 
 In June, 2024, we announced the launch of our *Inclusive Naming* project, dedicated to updating our documentation and aligning with the [Inclusive Naming Initiative (INI)](https://inclusivenaming.org). This initiative reflects our commitment to fostering an inclusive and respectful environment for our users and within our company.

--- a/5.8/portal/api-consumer/invite-codes.mdx
+++ b/5.8/portal/api-consumer/invite-codes.mdx
@@ -3,7 +3,7 @@ title: "Register a User using Invite Codes"
 description: "How to configure basic authentication in Tyk?"
 keywords: "Authentication, Authorization, Tyk Authentication, Tyk Authorization, Secure APIs, Basic Authentication"
 sidebarTitle: "Invite Codes"
-canonical: "https://tyk.io/docs/portal/api-consumer/invite-codes"
+canonical: "https://tyk.io/docs/portal/api-consumer"
 ---
 
 ## Invite Codes

--- a/5.8/product-stack/tyk-enterprise-developer-portal/api-documentation/list-of-endpoints/portal-1.13.0-list-of-endpoints.mdx
+++ b/5.8/product-stack/tyk-enterprise-developer-portal/api-documentation/list-of-endpoints/portal-1.13.0-list-of-endpoints.mdx
@@ -4,7 +4,7 @@ description: "Internal APIs exposed by Tyk Developer Portal"
 keywords: "Tyk Developer Portal, Enterprise Portal, Endpoints, Firewall, Integration, Portal 1.13.0"
 order: 3
 sidebarTitle: "Enterprise Developer Portal Admin"
-canonical: "https://tyk.io/docs/product-stack/tyk-enterprise-developer-portal/api-documentation/list-of-endpoints/portal-1.13.0-list-of-endpoints"
+canonical: "https://tyk.io/docs/product-stack/tyk-enterprise-developer-portal/api-documentation/list-of-endpoints/portal-api-list-of-endpoints"
 ---
 
 

--- a/5.8/tyk-developer-portal/tyk-enterprise-developer-portal/api-consumer-portal/access-api-product.mdx
+++ b/5.8/tyk-developer-portal/tyk-enterprise-developer-portal/api-consumer-portal/access-api-product.mdx
@@ -3,7 +3,7 @@ title: "Access an API Product"
 description: "How to access an api product in Tyk developer portal"
 keywords: "Developer Portal, Tyk, API Consumer"
 sidebarTitle: "Access an API Product"
-canonical: "https://tyk.io/docs/tyk-developer-portal/tyk-enterprise-developer-portal/api-consumer-portal/access-api-product"
+canonical: "https://tyk.io/docs/portal/request-access"
 ---
 
 ## Introduction

--- a/5.8/tyk-developer-portal/tyk-portal-classic/streams.mdx
+++ b/5.8/tyk-developer-portal/tyk-portal-classic/streams.mdx
@@ -5,7 +5,7 @@ keywords: "streaming, events, event-driven architecture, event-driven architectu
 order: 12
 noindex: True
 sidebarTitle: "Streams with Classic Portal"
-canonical: "https://tyk.io/docs/tyk-developer-portal/tyk-portal-classic/streams"
+canonical: "https://tyk.io/docs/portal/api-products"
 ---
 
 

--- a/5.8/tyk-stack/tyk-developer-portal/enterprise-developer-portal/api-access/manage-apps-credentials.mdx
+++ b/5.8/tyk-stack/tyk-developer-portal/enterprise-developer-portal/api-access/manage-apps-credentials.mdx
@@ -3,7 +3,7 @@ title: "Manage Applications in Developer Portal"
 description: "How to configure applications in Tyk developer portal"
 keywords: "Developer Portal, Tyk, Rate Limit"
 sidebarTitle: "Manage Applications"
-canonical: "https://tyk.io/docs/tyk-stack/tyk-developer-portal/enterprise-developer-portal/api-access/manage-apps-credentials"
+canonical: "https://tyk.io/docs/portal/developer-app"
 ---
 
 ## Introduction

--- a/5.8/tyk-stack/tyk-developer-portal/enterprise-developer-portal/getting-started-with-enterprise-portal/manage-get-started-guides-for-api-products.mdx
+++ b/5.8/tyk-stack/tyk-developer-portal/enterprise-developer-portal/getting-started-with-enterprise-portal/manage-get-started-guides-for-api-products.mdx
@@ -3,7 +3,7 @@ title: "Create Get started guides for your API Products"
 description: "How to configure API Providers in Tyk developer portal"
 keywords: "Developer Portal, Tyk, Managing Access, Catalogs, Rate Limit, Dynamic Client Registration, Documenting APIs"
 sidebarTitle: "Create Documentation"
-canonical: "https://tyk.io/docs/tyk-stack/tyk-developer-portal/enterprise-developer-portal/getting-started-with-enterprise-portal/manage-get-started-guides-for-api-products"
+canonical: "https://tyk.io/docs/portal/api-products"
 ---
 
 ## Introduction

--- a/5.8/tyk-stack/tyk-developer-portal/enterprise-developer-portal/managing-access/manage-api-consumers.mdx
+++ b/5.8/tyk-stack/tyk-developer-portal/enterprise-developer-portal/managing-access/manage-api-consumers.mdx
@@ -3,7 +3,7 @@ title: "Manage Users"
 description: "How to manage users in Tyk developer portal"
 keywords: "Developer Portal, Tyk, API Consumer, Users, Self Registration, Invite Users, Approve Requests"
 sidebarTitle: "Users"
-canonical: "https://tyk.io/docs/tyk-stack/tyk-developer-portal/enterprise-developer-portal/managing-access/manage-api-consumers"
+canonical: "https://tyk.io/docs/portal/api-consumer"
 ---
 
 ## Register a New API User

--- a/5.8/ui-examples/feature-cards.mdx
+++ b/5.8/ui-examples/feature-cards.mdx
@@ -3,7 +3,7 @@ title: "Feature Cards"
 'og:description': "Documentation for the feature-cards shortcode in Tyk. Learn how to display responsive feature cards with icons, titles, and descriptions."
 sidebarTitle: "UI Example: Feature Cards shortcode"
 tags: ['UI Examples', 'Shortcodes', 'Feature Cards']
-canonical: "https://tyk.io/docs/ui-examples/feature-cards"
+canonical: "https://tyk.io/docs/developer-support/contributing"
 ---
 
 import UIExampleCards from '/snippets/5.8/UIExampleCards.mdx';

--- a/5.8/ui-examples/test-pill-label.mdx
+++ b/5.8/ui-examples/test-pill-label.mdx
@@ -1,7 +1,7 @@
 ---
 title: "UI Examples: Pill label shortcode"
 sidebarTitle: "UI Example: Pill Label Shortcode"
-canonical: "https://tyk.io/docs/ui-examples/test-pill-label"
+canonical: "https://tyk.io/docs/developer-support/contributing"
 ---
 
 This page demonstrates all available styles and usage examples of the pill-label shortcode.

--- a/5.8/ui-examples/youtube-video-embed.mdx
+++ b/5.8/ui-examples/youtube-video-embed.mdx
@@ -3,7 +3,7 @@ title: "YouTube Video Embed"
 'og:description': "Documentation for the youtube-seo shortcode in Tyk. Learn how to embed YouTube videos in your documentation with proper styling and responsive behavior."
 sidebarTitle: "UI Example: YouTube Video Embed shortcode"
 tags: ['UI Examples', 'Shortcodes', 'Video Embed']
-canonical: "https://tyk.io/docs/ui-examples/youtube-video-embed"
+canonical: "https://tyk.io/docs/developer-support/contributing"
 ---
 
 The `youtube-seo` shortcode allows you to easily embed YouTube videos in your documentation with proper styling and responsive behavior.

--- a/scripts/add-canonical-urls/index.py
+++ b/scripts/add-canonical-urls/index.py
@@ -1,67 +1,148 @@
 import os
 import re
+import sys
+import json
 from pathlib import Path
 
 # === CONFIG ===
 ROOT_DIR = Path.cwd()
 BASE_URL = "https://tyk.io/docs"
+MAX_REDIRECT_HOPS = 10
+
 
 def find_mdx_files(directory: Path):
     """Recursively find all .mdx files excluding any folder named 'snippets'."""
     mdx_files = []
     for root, dirs, files in os.walk(directory):
-        # Skip any directory named 'snippets'
         dirs[:] = [d for d in dirs if d != "snippets"]
-
         for file in files:
             if file.endswith(".mdx"):
                 full_path = Path(root) / file
-                # Skip if any part of path is 'snippets'
                 if "snippets" in full_path.parts:
                     print(f"⏩ Skipping file inside snippets: {full_path}")
                     continue
                 mdx_files.append(full_path)
     return mdx_files
 
-def build_canonical_url(file_path: Path):
-    """Generate canonical URL, handling index.mdx and stripping version folder."""
-    relative_path = file_path.relative_to(ROOT_DIR).as_posix()
-    clean_path = re.sub(r"\.mdx$", "", relative_path)
 
-    # Remove trailing '/index' if it's an index.mdx
-    canonical_path = re.sub(r"/index$", "", clean_path)
-    if canonical_path == "index":
-        canonical_path = ""  # top-level index
+def load_docs_json() -> dict:
+    docs_path = ROOT_DIR / "docs.json"
+    if not docs_path.exists():
+        print(f"❌ docs.json not found at {docs_path}. Run this script from the repo root.")
+        sys.exit(1)
+    return json.loads(docs_path.read_text(encoding="utf-8"))
 
-    # Strip version folder if first segment is a number (like 5.8) or "nightly"
-    parts = canonical_path.split("/")
-    if parts and (re.match(r"^\d+(\.\d+)?$", parts[0]) or parts[0] == "nightly"):  # e.g., 5 or 5.8 or nightly
-        parts = parts[1:]  # remove version folder
-    canonical_path = "/".join(parts)
 
-    canonical_url = f"{BASE_URL}{'/' + canonical_path if canonical_path else ''}"
-    return canonical_url
+def extract_all_nav_pages(obj, pages: set):
+    """Recursively collect every string path from the navigation tree."""
+    if isinstance(obj, list):
+        for item in obj:
+            if isinstance(item, str):
+                pages.add(item.strip("/"))
+            else:
+                extract_all_nav_pages(item, pages)
+    elif isinstance(obj, dict):
+        for key in ("pages", "tabs", "groups", "versions"):
+            if key in obj:
+                extract_all_nav_pages(obj[key], pages)
 
-def add_or_update_canonical(file_path: Path):
+
+def build_root_nav(docs: dict) -> set:
+    """Return nav pages that belong to the latest (root) version — no version prefix."""
+    all_pages: set = set()
+    extract_all_nav_pages(docs.get("navigation", {}), all_pages)
+    return {p for p in all_pages if not re.match(r'^\d+(\.\d+)?/', p) and not p.startswith("nightly/")}
+
+
+def build_redirect_map(docs: dict) -> dict:
+    """Build a flat source -> destination map from docs.json redirects."""
+    rmap: dict = {}
+    for rule in docs.get("redirects", []):
+        src = rule.get("source", "").strip("/").removeprefix("docs/")
+        dst = rule.get("destination", "").strip("/").removeprefix("docs/")
+        if src and dst:
+            rmap[src] = dst
+    return rmap
+
+
+def page_exists_at_root(path: str) -> bool:
+    """Check whether a path corresponds to an MDX file in the root (current version)."""
+    return (ROOT_DIR / f"{path}.mdx").exists() or (ROOT_DIR / path / "index.mdx").exists()
+
+
+def resolve_canonical(stripped_path: str, root_nav: set, redirect_map: dict) -> str | None:
+    """
+    Resolve a version-stripped page path to a canonical URL.
+
+    Resolution order per hop:
+      1. Path is in the latest nav tree → valid, return URL.
+      2. Path exists as a root-level MDX file (unlisted/hidden page) → valid, return URL.
+      3. Path has a redirect entry → follow to destination and repeat.
+      4. None of the above → unresolvable, return None.
+
+    The empty path (from a versioned index.mdx) maps to the site root.
+    """
+    if not stripped_path:
+        return BASE_URL  # versioned index page → site root is always valid
+
+    current = stripped_path.strip("/")
+    visited: set = set()
+    for _ in range(MAX_REDIRECT_HOPS):
+        if current in visited:
+            return None  # redirect loop
+        visited.add(current)
+        if current in root_nav or page_exists_at_root(current):
+            return f"{BASE_URL}/{current}"
+        if current in redirect_map:
+            current = redirect_map[current].strip("/")
+        else:
+            return None
+    return None  # exceeded max hops
+
+
+def add_or_update_canonical(
+    file_path: Path,
+    root_nav: set,
+    redirect_map: dict,
+    invalid_paths: list,
+):
     """Add or update the canonical field in the MDX frontmatter."""
     content = file_path.read_text(encoding="utf-8")
 
-    # Match frontmatter between --- and ---
     frontmatter_match = re.match(r"^---\n([\s\S]*?)\n---", content)
     if not frontmatter_match:
         print(f"⚠️  No frontmatter found in: {file_path}")
         return
 
     frontmatter = frontmatter_match.group(1)
-    canonical_url = build_canonical_url(file_path)
 
-    # Add or update canonical field
+    # Derive the path segment used for canonical resolution
+    relative_path = file_path.relative_to(ROOT_DIR).as_posix()
+    clean_path = re.sub(r"\.mdx$", "", relative_path)
+    canonical_path = re.sub(r"/index$", "", clean_path)
+    if canonical_path == "index":
+        canonical_path = ""
+
+    parts = canonical_path.split("/")
+    is_versioned = bool(parts and (re.match(r"^\d+(\.\d+)?$", parts[0]) or parts[0] == "nightly"))
+
+    if is_versioned:
+        stripped_path = "/".join(parts[1:])
+        canonical_url = resolve_canonical(stripped_path, root_nav, redirect_map)
+        if canonical_url is None:
+            invalid_paths.append((str(file_path.relative_to(ROOT_DIR)), stripped_path))
+            return  # leave file unchanged; CI will report and block
+    else:
+        # Root-level (current version) file — always valid
+        canonical_url = f"{BASE_URL}{'/' + canonical_path if canonical_path else ''}"
+
+    # Write canonical into frontmatter
     if re.search(r'^["\']?canonical["\']?\s*:', frontmatter, flags=re.MULTILINE):
         new_frontmatter = re.sub(
             r'^["\']?canonical["\']?\s*:\s*.*$',
             f'canonical: "{canonical_url}"',
             frontmatter,
-            flags=re.MULTILINE
+            flags=re.MULTILINE,
         )
         print(f"🔁 Updated canonical in: {file_path}")
     else:
@@ -71,18 +152,38 @@ def add_or_update_canonical(file_path: Path):
     new_content = re.sub(
         r"^---\n([\s\S]*?)\n---",
         f"---\n{new_frontmatter}\n---",
-        content
+        content,
     )
-
     file_path.write_text(new_content, encoding="utf-8")
 
+
 def main():
+    print("📖 Loading docs.json...")
+    docs = load_docs_json()
+    root_nav = build_root_nav(docs)
+    redirect_map = build_redirect_map(docs)
+    print(f"  {len(root_nav)} root nav pages, {len(redirect_map)} redirect rules loaded")
+
     print("🔍 Searching for .mdx files...")
     mdx_files = find_mdx_files(ROOT_DIR)
     print(f"📄 Found {len(mdx_files)} eligible .mdx files")
 
+    invalid_paths: list = []
     for file_path in mdx_files:
-        add_or_update_canonical(file_path)
+        add_or_update_canonical(file_path, root_nav, redirect_map, invalid_paths)
+
+    if invalid_paths:
+        print(f"\n❌ {len(invalid_paths)} versioned page(s) could not be resolved to a valid canonical:")
+        print("   (not present in the latest nav tree and no matching redirect in docs.json)\n")
+        for file_path, stripped_path in invalid_paths:
+            print(f"  file:  {file_path}")
+            print(f"  path:  {stripped_path}")
+            print()
+        print("Fix: add a redirect in docs.json for each path above, then re-run this script.")
+        sys.exit(1)
+
+    print("\n✅ All canonicals resolved successfully.")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Problem

The `add-canonical-urls` script used a pure path-formula approach: strip the version prefix, construct a URL, write it. It never verified the resulting URL actually exists on the current docs. When pages are removed or reorganised between versions, the canonical silently points to a 404.

**Discovered broken canonicals** (written to production before this fix):
- 12 in `5.8/` — pointing to paths removed in v5.13
- 8 in `5.10/` — same issue

## Fix

Updated `scripts/add-canonical-urls/index.py` with a validation pass before writing:

**Resolution order for each versioned page:**
1. Stripped path is in the latest nav tree (`docs.json`) → use formula URL ✅
2. Stripped path exists as a root-level MDX file (unlisted/hidden page) → use formula URL ✅
3. Stripped path has a redirect in `docs.json` → follow chain to destination, verify destination with steps 1–2 → use destination URL ✅
4. None of the above → **do not write**, collect path, exit code 1 after all files ❌

**Exit code 1 behaviour:** After processing all files, if any paths were unresolvable, the script prints every invalid path with its source file and exits 1. The deploy workflow already has `|| { echo "❌ Canonical script failed"; exit 1; }` so this blocks the deployment PR until a redirect is added to `docs.json`.

## Files changed

| File | Change |
|---|---|
| `scripts/add-canonical-urls/index.py` | Loads `docs.json`, validates each versioned page via nav/filesystem/redirect before writing |
| `5.8/*.mdx` (11 files) | Fixed canonicals — now point to redirect destinations instead of 404 paths |
| `5.10/*.mdx` (7 files) | Same |

## One remaining unresolvable path

`ui-examples/test-pill-label-security` appears in `5.8/` and `5.10/` but has no redirect in `docs.json` and no root-level file. The other three `ui-examples/*` pages redirect to `developer-support/contributing`. A redirect needs to be added:

```json
{ "source": "/docs/ui-examples/test-pill-label-security", "destination": "/docs/developer-support/contributing" }
```

Once that redirect is in `docs.json`, re-running the script will stamp the correct canonical on those two files.

## Prevention going forward

When a new version folder (e.g. `5.13/`) is created at the next release, the script will automatically catch any pages that were removed or reorganised — CI blocks the deploy until a `docs.json` redirect covers each removed path.