### PR TITLE
fix: update broken internal links in versioned index and release-notes overview (v5.11)

### DIFF
--- a/developer-support/release-notes/overview.mdx
+++ b/developer-support/release-notes/overview.mdx
@@ -19,7 +19,7 @@ export const releaseData = {
       }
     },
     {
-      "home": "tyk-operator",
+      "home": "tyk-stack/tyk-operator/installing-tyk-operator",
       "name": "Tyk Operator",
       "licensed": true,
       "latest": "1.2.0",
@@ -31,7 +31,7 @@ export const releaseData = {
       }
     },
     {
-      "home": "tyk-sync",
+      "home": "product-stack/tyk-sync/installing-tyk-sync",
       "name": "Tyk Sync",
       "licensed": true,
       "latest": "2.1.5",
@@ -109,7 +109,7 @@ export const releaseData = {
       }
     },
     {
-      "home": "deployment-and-operations/tyk-self-managed/deployment-lifecycle/installations/kubernetes/tyk-helm-tyk-stack",
+      "home": "product-stack/tyk-charts/overview",
       "name": "Tyk Helm Charts",
       "licensed": false,
       "latest": "5.0.0",

--- a/index.mdx
+++ b/index.mdx
@@ -7,7 +7,7 @@ export const mostViewed = [
     title: "Tyk Platforms",
     items: [
       { title: "Deployment Options",            path: "apim/" },
-      { title: "Self-managed",                  path: "tyk-on-premises/" },
+      { title: "Self-managed",                  path: "tyk-self-managed/" },
       { title: "Cloud",                         path: "tyk-cloud/" },
       { title: "Open Source Gateway",           path: "apim/open-source/" },
     ],
@@ -15,10 +15,10 @@ export const mostViewed = [
   {
     title: "API management",
     items: [
-      { title: "Create API",                    path: "getting-started/create-api/" },
-      { title: "Access an API",                 path: "getting-started/create-api-key/" },
-      { title: "Create UDG schema",             path: "universal-data-graph/udg-getting-started/creating-schema/" },
-      { title: "Using OAS API definition",      path: "getting-started/using-oas-definitions/" },
+      { title: "Create API",                    path: "getting-started/quick-start/" },
+      { title: "Access an API",                 path: "getting-started/configure-first-api/" },
+      { title: "Create UDG schema",             path: "api-management/data-graph/" },
+      { title: "Using OAS API definition",      path: "getting-started/quick-start/" },
     ],
   },
   {
@@ -34,9 +34,9 @@ export const mostViewed = [
     title: "Developer support",
     items: [
       { title: "FAQs",                          path: "frequently-asked-questions/" },
-      { title: "Latest Release",                path: "product-stack/tyk-gateway/release-notes/overview/" },
-      { title: "How to upgrade",                path: "upgrading-tyk/" },
-      { title: "Contribute to docs",            path: "contribute/" },
+      { title: "Latest Release",                path: "developer-support/release-notes/overview/" },
+      { title: "How to upgrade",                path: "developer-support/upgrading/" },
+      { title: "Contribute to docs",            path: "developer-support/contributing/" },
     ],
   },
 ];
@@ -45,16 +45,16 @@ export const tykStacksCols = [
   [
     { title: "Tyk Gateway (Open source)",          desc: "Open source Enterprise API Gateway.",                                         path: "tyk-oss-gateway/" },
     { title: "Tyk Dashboard",                      desc: "The GUI and analytics platform for Tyk.",                                    path: "tyk-dashboard/" },
-    { title: "Universal Data Graph",               desc: "Combine multiple APIs into one universal interface.",                        path: "universal-data-graph/" },
+    { title: "Universal Data Graph",               desc: "Combine multiple APIs into one universal interface.",                        path: "api-management/data-graph/" },
     { title: "Tyk Enterprise Developer Portal",    desc: "Expose APIs for third-party developers to register and use.",                path: "tyk-developer-portal/tyk-enterprise-developer-portal/" },
     { title: "Tyk Multi Data Center Bridge",       desc: "Control plane that performs management and synchronisation.",                path: "tyk-multi-data-centre/" },
   ],
   [
     { title: "Tyk Pump (Open source)",             desc: "Responsible for moving analytics into a persistent data store.",             path: "tyk-pump/" },
-    { title: "Tyk Operator",                       desc: "Manage your APIs on Tyk Gateway.",                                           path: "tyk-operator/" },
-    { title: "Tyk Sync",                           desc: "Command-line tool to manage and synchronise Tyk installation.",              path: "tyk-sync/" },
+    { title: "Tyk Operator",                       desc: "Manage your APIs on Tyk Gateway.",                                           path: "tyk-stack/tyk-operator/installing-tyk-operator/" },
+    { title: "Tyk Sync",                           desc: "Command-line tool to manage and synchronise Tyk installation.",              path: "product-stack/tyk-sync/installing-tyk-sync/" },
     { title: "Tyk Identity Broker (Open source)",  desc: "A bridge between various Identity Management Systems.",                      path: "tyk-identity-broker/" },
-    { title: "Tyk Streams",                        desc: "Expose, manage & monetise real-time event streams, brokers and async APIs.", path: "product-stack/tyk-streaming/overview/" },
+    { title: "Tyk Streams",                        desc: "Expose, manage & monetise real-time event streams, brokers and async APIs.", path: "api-management/event-driven-apis/" },
   ],
 ];
 


### PR DESCRIPTION
## Problem

The versioned landing page (`index.mdx`) and the releases overview (`developer-support/release-notes/overview.mdx`) contain internal links pointing to paths that do not exist in the versioned content folder. These generate 404s — confirmed by a site crawl.

## Changes

**`index.mdx` — 12 broken paths fixed:**

| Was | Now |
|---|---|
| `tyk-on-premises/` | `tyk-self-managed/` |
| `getting-started/create-api/` | `getting-started/quick-start/` |
| `getting-started/create-api-key/` | `getting-started/configure-first-api/` |
| `universal-data-graph/udg-getting-started/creating-schema/` | `api-management/data-graph/` |
| `getting-started/using-oas-definitions/` | `getting-started/quick-start/` |
| `product-stack/tyk-gateway/release-notes/overview/` | `developer-support/release-notes/overview/` |
| `upgrading-tyk/` | `developer-support/upgrading/` |
| `contribute/` | `developer-support/contributing/` |
| `universal-data-graph/` | `api-management/data-graph/` |
| `tyk-operator/` | `tyk-stack/tyk-operator/installing-tyk-operator/` |
| `tyk-sync/` | `product-stack/tyk-sync/installing-tyk-sync/` |
| `product-stack/tyk-streaming/overview/` | `api-management/event-driven-apis/` |

**`developer-support/release-notes/overview.mdx` — 3 broken `home` paths fixed:**

| Was | Now |
|---|---|
| `tyk-operator` | `tyk-stack/tyk-operator/installing-tyk-operator` |
| `tyk-sync` | `product-stack/tyk-sync/installing-tyk-sync` |
| `deployment-and-operations/.../tyk-helm-tyk-stack` | `product-stack/tyk-charts/overview` |

All replacement paths were verified to exist in the versioned folder before applying.