### PR TITLE
fix: prevent Go template syntax from leaking as navigable href links

### DIFF
--- a/portal/customization/menus.mdx
+++ b/portal/customization/menus.mdx
@@ -114,5 +114,5 @@ Where:
 
 So this will render all the menu items (Catalogs - as per screenshot) of the menu (Primary - the name we’ve given to the menu).
 
-3. `{{ if .Children }}`: This line checks if the menu item has any submenus. If it does it loops through those children `{{ range .Children }}` and finally renders them (using `{{.Path}}` as the link URL and `{{.Tag}}` as the link text) similarly as the main menu items.
+3. `{{ if .Children }}`: This line checks if the menu item has any submenus. If it does it loops through those children `{{ range .Children }}` and finally renders them `<a class="dropdown-item" href="{{.Path}}">{{.Tag}}</a>` similarly as the main menu items.
 So now the child of **Catalogs** which we named **Product 1** has been rendered.

--- a/portal/customization/menus.mdx
+++ b/portal/customization/menus.mdx
@@ -114,5 +114,5 @@ Where:
 
 So this will render all the menu items (Catalogs - as per screenshot) of the menu (Primary - the name we’ve given to the menu).
 
-3. `{{ if .Children }}`: This line checks if the menu item has any submenus. If it does it loops through those children `{{ range .Children }}` and finally renders them `<a class="dropdown-item" href="{{.Path}}">{{.Tag}}</a>` similarly as the main menu items.
+3. `{{ if .Children }}`: This line checks if the menu item has any submenus. If it does it loops through those children `{{ range .Children }}` and finally renders them (using `{{.Path}}` as the link URL and `{{.Tag}}` as the link text) similarly as the main menu items.
 So now the child of **Catalogs** which we named **Product 1** has been rendered.

--- a/portal/customization/templates.mdx
+++ b/portal/customization/templates.mdx
@@ -325,7 +325,7 @@ Accessible via `{{ .post }}` or `{{ range .latest_posts }}`
 | `{{ .URL }}` | Full URL of the blog post |
 
 ##### Example Usage
-```
+```html
 <h1>{{ .post.Title }}</h1>
 <img src="{{ .post.HeaderImage.URL }}" alt="{{ .post.Title }}">
 <p>{{ .post.Lede }}</p>
@@ -1161,11 +1161,11 @@ Accessible via `{{ range $invite := FilterUserInvites req }}`
 Formats a given time with a given format.
 
 ##### Example Usage
-```gotemplate
+```html
 {{ $user := CurrentUser req }}
 {{ if $user}}
 {{$time := FormatTime $user.CreatedAt "2 Jan, 2006 at 3:04:00 PM (MST)"}}
-{/* Use $time or other variables here */}
+{{/* Use $time or other variables here */}}
 ...
 {{end}}
 ```
@@ -1266,7 +1266,7 @@ Accessible via `{{ range $template := $product.Templates }}`
 Returns a list of catalogue names. Expects the request as parameter.
 
 ##### Example Usage
-```gotemplate
+```html
 {{ range $key, $value := GetCatalogueList req }}
 <option value="{{ $key }}" {{ if eq $value.Selected true }} selected {{ end }}>{{ $value.Name }}</option>
 {{ end }}

--- a/tyk-developer-portal/customise/customize-api-visibility.mdx
+++ b/tyk-developer-portal/customise/customize-api-visibility.mdx
@@ -51,7 +51,7 @@ The main difference from the default template is two changes:
 1. Get user data state at the start of template: `{{$profile := .UserData }}`
 2. Before rendering api catalog element, which renders list of APIs, we insert the following section:
 
-```go-html-template
+```html
 {{ $show := true }}
 
 {{ range $field, $value := $apiDetail.Fields }}
@@ -73,19 +73,19 @@ The main difference from the default template is two changes:
 {{ end }}
 
 {{if $show}}
-{/* Render catalog */}
+{{/* Render catalog */}}
 {{end}}
 ```
 
 <Expandable title='Click to expand and see the customized catalog template'>
-```go-html-template
+```html
 {{ define "cataloguePage" }} {{ $org_id := .OrgId}} {{ template "header" .}}
 {{ $page := .}}
 {{$profile := .UserData }}
 <body>
   {{ template "navigation" . }}
   <div>
-    {/* Main content here */}
+    {{/* Main content here */}}
     <div class="container" style="margin-top:80px;">
       <div class="row">
         <h1>API Catalog</h1>
@@ -163,7 +163,7 @@ The main difference from the default template is two changes:
   </div>
   {{ template "footer" .}}
   </div>
-  {/* /container */}
+  {{/* /container */}}
   {{ template "scripts" .}}
 </body>
 </html>
@@ -184,7 +184,7 @@ If you have enabled "Enable multiple API subscriptions" option in the portal set
 The main difference from the default template is two changes:
 1. Get user data state at the start of template: `{{$profile := .UserData }}`
 2. Before rendering `<li>` element, which renders list of APIs, we insert the following section:
-```go-html-template
+```html
 {{ range $field, $value := $apiDetail.Fields }}
 	{{ $group_match := true }}
 	{{ if (eq $field "Group") }}
@@ -205,7 +205,7 @@ The main difference from the default template is two changes:
 ```
 
 <Expandable title='Click to expand and see the full template'>
-```go-html-template
+```html
 {{ define "requestMultiKey" }} {{ template "header" .}}
 {{$catalogue := .Catalogue}}
 {{$catalogues := .Catalogues}}
@@ -398,7 +398,7 @@ The main difference from the default template is two changes:
   </div>
   {{ template "navigation" . }}
   {{ template "footer" .}}
-  {/* /container */}
+  {{/* /container */}}
   {{ template "scripts" .}}
 </body>
 </html>


### PR DESCRIPTION
## Summary

- **`tyk-developer-portal/customise/customize-api-visibility.mdx`**: Changed all 4 code fences from `go-html-template` → `html`. The `go-html-template` language identifier is not recognized by Mintlify/Shiki, which can cause the code fence to fall back to raw HTML rendering — making `<a href="{{ $page.PortalRoot }}...">` elements appear as real navigable links. Also replaced `{/* ... */}` with `{{/* ... */}}` (correct Go template comment syntax) to avoid MDX treating them as JSX comments.
- **`portal/customization/templates.mdx`**: Added `html` language to a language-less code fence containing `<a href="{{ .post.URL }}">`, changed `gotemplate` → `html` in 2 fences, and replaced `{/* */}` → `{{/* */}}`.
- **`portal/customization/menus.mdx`**: Replaced an inline backtick span containing `<a href="{{.Path}}">{{.Tag}}</a>` with plain text using separate inline code spans for the variables, eliminating any risk of HTML injection.

## Root cause

Web crawlers were reporting broken links with `%7B%7B`-encoded hrefs (e.g. `%7B%7B.post.URL%7D%7D`). These come from Go template expressions inside `<a href>` attributes being rendered as actual DOM elements rather than escaped code text. Unrecognized Shiki language identifiers (`go-html-template`, `gotemplate`) can cause Mintlify's code fence renderer to fall back to raw HTML output instead of producing a properly escaped `<pre><code>` block.

## Test plan

- [ ] Verify the three changed pages render their code blocks with proper syntax highlighting (or at minimum as escaped code text, not as live HTML)
- [ ] Confirm no `%7B%7B`-encoded hrefs appear in the next site crawl for these pages
- [ ] Check that the Go template comment syntax `{{/* */}}` displays correctly in the rendered code examples