### PR TITLE
fix: add redirect for /nighlty typo → /nightly

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1112,6 +1112,10 @@
     {
       "source": "/deployment-and-operations/tyk-self-managed/tyk-demos-and-pocs/overview",
       "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/nighlty",
+      "destination": "/nightly"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds a redirect in `docs.json`: `/nighlty` → `/nightly`

## Root cause

The page `5.10/developer-support/release-guide` contains a link to `/docs/nighlty` (typo — missing the `t`). Rather than editing the versioned page directly, adding a redirect is the least-invasive fix and also catches any other pages or external links that may have the same typo.

## Test plan

- [ ] Verify `/nighlty` redirects to `/nightly` on the deployed site