### PR TITLE
fix: correct nighlty typo to nightly in release-guide table

### DIFF
--- a/developer-support/release-guide.mdx
+++ b/developer-support/release-guide.mdx
@@ -31,7 +31,7 @@ Tyk Documentation is maintained in a [GitHub](https://github.com/TykTechnologies
 
 | **Special Branches** | **Description** | **Docs URL** |
 | :--------------------------- | :----------------- | :-------------- |
-| `main`                  | Holds docs for nightly build. | [tyk.io/docs/nighlty](https://tyk.io/docs/nighlty) |
+| `main`                  | Holds docs for nightly build. | [tyk.io/docs/nightly](https://tyk.io/docs/nightly) |
 | `release-x.y`             | Holds docs for that specific version. For example, `release-5.7` holds docs for 5.7 and its patch versions (5.7.1, 5.7.2, etc.). | [tyk.io/docs/5.7](https://tyk.io/docs/5.7) |
 | `production`                  | It acts as the single source of truth for the Mintlify platform. | [tyk.io/docs](https://tyk.io/docs) |
 


### PR DESCRIPTION
Fixes typo on line 34 of `developer-support/release-guide.mdx`: `nighlty` → `nightly` in both the link text and URL.