### PR TITLE
fix: make add-canonical-urls script compatible with Python 3.9

### DIFF
--- a/scripts/add-canonical-urls/index.py
+++ b/scripts/add-canonical-urls/index.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import re
 import sys


### PR DESCRIPTION
## Problem

The `Add canonical URLs to MDX files` step in the deploy workflow fails with:

```
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

Root cause: `scripts/add-canonical-urls/index.py` uses `str | None` union type syntax in a return annotation, which requires Python 3.10+. The workflow (`deploy-docs.yml`) pins `python-version: '3.9'`, so Python tries to evaluate the annotation at import time and raises a `TypeError`.

## Fix

Add `from __future__ import annotations` as the first import. This enables [PEP 563](https://peps.python.org/pep-0563/) postponed evaluation, making all annotations lazily treated as strings — fully compatible with Python 3.9+ while keeping the type hints intact for static analysis tools.

## Test

Re-running the `production Deploy Documentation` workflow after this merge should pass the `Add canonical URLs to MDX files` step.

Fixes run: https://github.com/TykTechnologies/tyk-docs/actions/runs/26395578252/job/77695384754