### PR TITLE
fix: convert relative markdown links to absolute paths and add CI check

### DIFF
--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -34,6 +34,22 @@ jobs:
         echo "⚓ Checking internal anchor fragments..."
         python scripts/validate_mintlify_docs.py . --check-anchors --links-only
 
+    - name: Check for relative markdown links
+      run: |
+        echo "Checking for relative markdown links (must start with /)..."
+        RELATIVE_LINKS=$(grep -rEn --include="*.md" --include="*.mdx" '\]\([^/\)\s#][^)]*\)' . \
+          | grep -vE '\]\((https?://|mailto:|ftp://|\{|<mailto)' \
+          | grep -v '{/\*' \
+          | grep -v '`\[' \
+          | grep -v "'\[" \
+          || true)
+        if [ -n "$RELATIVE_LINKS" ]; then
+          echo "Found relative markdown links that should use absolute paths (starting with /):"
+          echo "$RELATIVE_LINKS"
+          exit 1
+        fi
+        echo "All internal markdown links use absolute paths."
+
     - name: Validation complete
       if: success()
       run: |

--- a/api-management/observability.mdx
+++ b/api-management/observability.mdx
@@ -69,7 +69,7 @@ All OTel signals produced by Tyk Gateway include resource attributes: metadata s
 | `tyk.gw.id` / `service.instance.id` | Yes | Unique ID for this Gateway instance. |
 | `tyk.gw.dataplane` | Yes | Whether the Gateway is running in a distributed Data Plane. |
 | `tyk.gw.group.id` | No | Data Plane group ID. Populated only for Gateways in distributed Data Planes. |
-| `tyk.gw.tags` | No | Segment tags. Populated only when the Gateway is [segmented](api-management/multiple-environments#what-is-api-sharding-). |
+| `tyk.gw.tags` | No | Segment tags. Populated only when the Gateway is [segmented](/api-management/multiple-environments#what-is-api-sharding-). |
 
 Standard OTel attributes (`service.name`, `service.version`, `host.name`, `host.arch`, `host.ip`, `process.pid`) are also included automatically.
 

--- a/developer-support/release-notes/mdcb.mdx
+++ b/developer-support/release-notes/mdcb.mdx
@@ -67,7 +67,7 @@ For distributed deployments, deploy MDCB 2.11.0 before upgrading Tyk Pump to 1.1
 <Accordion title='Add support for MCP Proxy analytics'>
 MDCB 2.11.0 introduces support for routing MCP analytics to the Control Plane in distributed deployments. MCP analytics records — both raw and pre-aggregated — are routed separately from standard API analytics, keeping MCP traffic isolated in your analytics storage backend.
 
-No additional MDCB configuration is required. For details, see the [MCP analytics documentation](ai-management/mcp-gateway/mcp-observability).
+No additional MDCB configuration is required. For details, see the [MCP analytics documentation](/ai-management/mcp-gateway/mcp-observability).
 </Accordion>
 
 </AccordionGroup>

--- a/snippets/pump-config.mdx
+++ b/snippets/pump-config.mdx
@@ -5181,7 +5181,7 @@ Defines if tyk-pump should ignore all the values in configuration file. Speciall
 ENV: <b>TYK_PMP_HTTPPROFILE</b><br />
 Type: `bool`<br />
 
-Expose profiling information to support debugging of Tyk Pump. This operates in the same way as for Tyk Gateway, as explained [here](api-management/troubleshooting-debugging).
+Expose profiling information to support debugging of Tyk Pump. This operates in the same way as for Tyk Gateway, as explained [here](/api-management/troubleshooting-debugging).
 
 ### raw_request_decoded
 ENV: <b>TYK_PMP_DECODERAWREQUEST</b><br />


### PR DESCRIPTION
## Summary

- Fixed 3 internal markdown links missing a leading `/` that would resolve incorrectly in the docs site
- Added a `Check for relative markdown links` step to the existing `validate-docs.yml` PR workflow to catch this in future

## Files changed

| File | Change |
|------|--------|
| `developer-support/release-notes/mdcb.mdx` | `(ai-management/...)` → `(/ai-management/...)` |
| `api-management/observability.mdx` | `(api-management/...)` → `(/api-management/...)` |
| `snippets/pump-config.mdx` | `(api-management/...)` → `(/api-management/...)` |
| `.github/workflows/validate-docs.yml` | Added CI step to fail PRs that introduce relative links |

## Test plan

- [ ] Verify the three corrected links resolve correctly in the docs preview
- [ ] Confirm the new CI step passes on this PR
- [ ] Merge a test PR with a relative link to confirm the check blocks it

🤖 Generated with [Claude Code](https://claude.com/claude-code)