### PR TITLE
fix: add leading slash to troubleshooting-debugging link in pump-config

### DIFF
--- a/snippets/pump-config.mdx
+++ b/snippets/pump-config.mdx
@@ -5158,7 +5158,7 @@ Defines if tyk-pump should ignore all the values in configuration file. Speciall
 ENV: <b>TYK_PMP_HTTPPROFILE</b><br />
 Type: `bool`<br />
 
-Expose profiling information to support debugging of Tyk Pump. This operates in the same way as for Tyk Gateway, as explained [here](api-management/troubleshooting-debugging).
+Expose profiling information to support debugging of Tyk Pump. This operates in the same way as for Tyk Gateway, as explained [here](/api-management/troubleshooting-debugging).
 
 ### raw_request_decoded
 ENV: <b>TYK_PMP_DECODERAWREQUEST</b><br />


### PR DESCRIPTION
## Summary

- Fixes a relative markdown link missing a leading `/` in `snippets/pump-config.mdx`
- `[here](api-management/troubleshooting-debugging)` → `[here](/api-management/troubleshooting-debugging)`
- Without the leading slash, Mintlify resolves the link relative to the current page path, producing a 404 at `/tyk-pump/tyk-pump-configuration/api-management/troubleshooting-debugging`

## Root cause

The link was written as a relative path. From the page at `/tyk-pump/tyk-pump-configuration/`, the relative URL `api-management/troubleshooting-debugging` resolves to `/tyk-pump/tyk-pump-configuration/api-management/troubleshooting-debugging` instead of the correct `/api-management/troubleshooting-debugging`.