### PR TITLE
fix: update broken migration-to-tyk URL to current kv-store docs

### DIFF
--- a/snippets/gateway-config.mdx
+++ b/snippets/gateway-config.mdx
@@ -1980,7 +1980,7 @@ global session lifetime, in seconds.
 ENV: <b>TYK_GW_KV_KV</b><br />
 Type: `struct`<br />
 
-See more details https://tyk.io/docs/migration-to-tyk#store-configuration-with-key-value-store/
+See more details https://tyk.io/docs/tyk-configuration-reference/kv-store
 
 ### kv.consul.address
 ENV: <b>TYK_GW_KV_CONSUL_ADDRESS</b><br />


### PR DESCRIPTION
## Summary

- Fixes a dead absolute URL in `snippets/gateway-config.mdx` (line 1983)
- `https://tyk.io/docs/migration-to-tyk#store-configuration-with-key-value-store/` → `https://tyk.io/docs/tyk-configuration-reference/kv-store`
- The `migration-to-tyk` page no longer exists; the KV store documentation has moved to `/tyk-configuration-reference/kv-store`

## Root cause

The `migration-to-tyk` page was a legacy catchall page that no longer exists. The crawler was following the base URL (without fragment) and getting a 404.