### PR TITLE
fix: add redirects for gateway-api and identity-broker 404s

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -6543,6 +6543,14 @@
     {
       "source": "/deployment-and-operations/tyk-self-managed/tyk-demos-and-pocs/overview",
       "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/basic-config-and-security/security/gateway/gateway-api",
+      "destination": "/tyk-gateway-api"
+    },
+    {
+      "source": "/tyk-stack/tyk-identity-broker/getting-started",
+      "destination": "/tyk-configuration-reference/tyk-identity-broker-configuration"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds two redirect entries to `docs.json` to fix trailing-slash canonicalization 404s from the crawl audit.

| Broken URL | Redirects to |
|------------|-------------|
| `/basic-config-and-security/security/gateway/gateway-api` | `/tyk-gateway-api` |
| `/tyk-stack/tyk-identity-broker/getting-started` | `/tyk-configuration-reference/tyk-identity-broker-configuration` |

## Root cause

Both broken URLs appear in the crawl with "First found at" = the same URL **with** a trailing slash. This is a trailing-slash canonicalization issue — the pages are referenced without a trailing slash (e.g. from a sidebar or breadcrumb auto-link) but no redirect exists to handle the no-slash variant. Adding these `docs.json` redirect entries resolves both 404s.

- `gateway/gateway-api` was the legacy path for the Tyk Gateway API; current content lives at `/tyk-gateway-api`
- `tyk-stack/tyk-identity-broker/getting-started` was the legacy TIB getting-started path; current content lives at `/tyk-configuration-reference/tyk-identity-broker-configuration`