### PR TITLE
fix: add trailing-slash redirect variants for broken redirects and chain-too-long issues

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1106,7 +1106,7 @@
             "blank": true
           },
           {
-            "label": "\u00a9 Tyk Technologies 2025",
+            "label": "© Tyk Technologies 2025",
             "href": "https://tyk.io/terms-conditions/",
             "blank": true
           },
@@ -6551,6 +6551,4178 @@
     {
       "source": "/tyk-stack/tyk-identity-broker/getting-started",
       "destination": "/tyk-configuration-reference/tyk-identity-broker-configuration"
+    },
+    {
+      "source": "/tyk-cloud/environments--deployments/monitoring/",
+      "destination": "/tyk-cloud/environments-deployments/monitoring-how-it-works"
+    },
+    {
+      "source": "/tyk-cloud/environments--deployments/managing-apis/",
+      "destination": "/tyk-cloud"
+    },
+    {
+      "source": "/tyk-cloud/teams--users/user-roles/",
+      "destination": "/tyk-cloud/teams-users"
+    },
+    {
+      "source": "/tyk-cloud/environments--deployments/monitoring-usage/",
+      "destination": "/tyk-cloud/telemetry"
+    },
+    {
+      "source": "/tyk-cloud/environments--deployments/managing-environments/",
+      "destination": "/tyk-cloud/environments-deployments/managing-environments"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/install-tyk-enterprise-portal/",
+      "destination": "/portal/install"
+    },
+    {
+      "source": "/tyk-cloud/environments--deployments/managing-organisations/",
+      "destination": "/tyk-cloud/environments-deployments/managing-organisations"
+    },
+    {
+      "source": "/tyk-cloud/account--billing/managing-billing-admins/",
+      "destination": "/tyk-cloud/account-billing"
+    },
+    {
+      "source": "/tyk-cloud/account--billing/upgrade-free-trial/",
+      "destination": "/tyk-cloud/account-billing"
+    },
+    {
+      "source": "/basic-config-and-security/security/gateway/gateway-api/",
+      "destination": "/tyk-gateway-api"
+    },
+    {
+      "source": "/tyk-cloud/environments--deployments/",
+      "destination": "/tyk-cloud"
+    },
+    {
+      "source": "/tyk-cloud/troubleshooting--support/glossary/",
+      "destination": "/tyk-cloud/troubleshooting-support"
+    },
+    {
+      "source": "/tyk-cloud/troubleshooting--support/",
+      "destination": "/tyk-cloud/troubleshooting-support"
+    },
+    {
+      "source": "/tyk-cloud/environments--deployments/monitoring-how-it-works/",
+      "destination": "/tyk-cloud/environments-deployments/monitoring-how-it-works"
+    },
+    {
+      "source": "/release-notes/release-4.2/",
+      "destination": "/developer-support/release-notes/archived"
+    },
+    {
+      "source": "/tyk-cloud/teams--users/single-sign-on/",
+      "destination": "/tyk-cloud/teams-users/single-sign-on"
+    },
+    {
+      "source": "/tyk-cloud/troubleshooting--support/faqs/",
+      "destination": "/tyk-cloud/troubleshooting-support"
+    },
+    {
+      "source": "/tyk-cloud/teams--users/managing-teams/",
+      "destination": "/tyk-cloud/teams-users"
+    },
+    {
+      "source": "/tyk-cloud/teams--users/",
+      "destination": "/tyk-cloud/teams-users"
+    },
+    {
+      "source": "/tyk-cloud/account--billing/add-payment-method/",
+      "destination": "/tyk-cloud/account-billing"
+    },
+    {
+      "source": "/tyk-cloud/environments--deployments/managing-gateways/",
+      "destination": "/tyk-cloud/environments-deployments/managing-gateways"
+    },
+    {
+      "source": "/tyk-stack/tyk-identity-broker/getting-started/",
+      "destination": "/tyk-configuration-reference/tyk-identity-broker-configuration"
+    },
+    {
+      "source": "/tyk-cloud/environments--deployments/managing-control-planes/",
+      "destination": "/tyk-cloud/environments-deployments/managing-control-planes"
+    },
+    {
+      "source": "/tyk-cloud/teams--users/managing-users/",
+      "destination": "/tyk-cloud/teams-users"
+    },
+    {
+      "source": "/tyk-cloud/troubleshooting--support/tyk-cloud-mdcb-supported-versions/",
+      "destination": "/tyk-cloud/troubleshooting-support"
+    },
+    {
+      "source": "/advanced-configuration/transform-traffic/endpoint-designer/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/basic-config-and-security/control-limit-traffic/rate-limiting/",
+      "destination": "/api-management/rate-limit"
+    },
+    {
+      "source": "/tyk-stack/tyk-pump/tyk-analytics-record-fields/",
+      "destination": "/api-management/tyk-pump"
+    },
+    {
+      "source": "/tyk-pump/",
+      "destination": "/api-management/tyk-pump"
+    },
+    {
+      "source": "/tyk-developer-portal/",
+      "destination": "/portal/overview/intro"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/advanced-configurations/distributed-tracing/open-telemetry/open-telemetry-overview/",
+      "destination": "/api-management/logs-metrics"
+    },
+    {
+      "source": "/product-stack/tyk-sync/overview/",
+      "destination": "/api-management/automations/sync"
+    },
+    {
+      "source": "/developer-support/special-releases-and-features/fips-release/",
+      "destination": "/developer-support/release-types/fips-release"
+    },
+    {
+      "source": "/configure/tyk-pump-configuration/",
+      "destination": "/api-management/tyk-pump"
+    },
+    {
+      "source": "/apim-best-practice/api-security-best-practice/governance/",
+      "destination": "/api-management/security-best-practices"
+    },
+    {
+      "source": "/tyk-developer-portal/tyk-portal-classic/streams/",
+      "destination": "/portal/api-products"
+    },
+    {
+      "source": "/tyk-apis/tyk-gateway-api/api-definition-objects/ip-blacklisting/",
+      "destination": "/api-management/gateway-config-tyk-classic"
+    },
+    {
+      "source": "/tyk-self-managed/tyk-helm-chart/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/overview/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/plugins/golang-plugins/golang-plugins/",
+      "destination": "/api-management/plugins/golang"
+    },
+    {
+      "source": "/advanced-configuration/manage-multiple-environments/with-tyk-multi-cloud/",
+      "destination": "/api-management/multiple-environments"
+    },
+    {
+      "source": "/advanced-configuration/transform-traffic/request-method-transform/",
+      "destination": "/api-management/traffic-transformation/request-method"
+    },
+    {
+      "source": "/tyk-on-premises/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/plugins/",
+      "destination": "/api-management/plugins/overview"
+    },
+    {
+      "source": "/frequently-asked-questions/sla-policies/",
+      "destination": "/developer-support/support"
+    },
+    {
+      "source": "/tyk-operator/",
+      "destination": "/api-management/automations/operator"
+    },
+    {
+      "source": "/getting-started/create-security-policy/",
+      "destination": "/api-management/gateway-config-managing-classic"
+    },
+    {
+      "source": "/getting-started/",
+      "destination": "/getting-started/configure-first-api"
+    },
+    {
+      "source": "/advanced-configuration/compose-apis/virtual-endpoints/",
+      "destination": "/api-management/traffic-transformation/virtual-endpoints"
+    },
+    {
+      "source": "/tyk-stack/tyk-manager/analytics/log-browser/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/basic-config-and-security/security/authentication-authorization/openid-connect/",
+      "destination": "/api-management/client-authentication"
+    },
+    {
+      "source": "/basic-config-and-security/reduce-latency/caching/",
+      "destination": "/api-management/response-caching"
+    },
+    {
+      "source": "/plugins/supported-languages/rich-plugins/grpc/",
+      "destination": "/api-management/plugins/rich-plugins"
+    },
+    {
+      "source": "/getting-started/installation/",
+      "destination": "/apim/open-source/installation"
+    },
+    {
+      "source": "/release-notes/version-5.0/",
+      "destination": "/developer-support/release-notes/gateway"
+    },
+    {
+      "source": "/basic-config-and-security/security/authentication-authorization/",
+      "destination": "/api-management/client-authentication"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/advanced-configurations/plugins/otel-plugins/",
+      "destination": "/api-management/plugins/advance-config"
+    },
+    {
+      "source": "/tyk-developer-portal/tyk-enterprise-developer-portal/api-consumer-portal/access-api-product/",
+      "destination": "/portal/request-access"
+    },
+    {
+      "source": "/tyk-apis/tyk-gateway-api/api-definition-objects/ip-whitelisting/",
+      "destination": "/api-management/gateway-config-tyk-classic"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/advanced-configurations/distributed-tracing/open-tracing/open-tracing-overview/",
+      "destination": "/api-management/logs-metrics"
+    },
+    {
+      "source": "/basic-config-and-security/security/",
+      "destination": "/api-management/security-best-practices"
+    },
+    {
+      "source": "/getting-started/create-api-key/",
+      "destination": "/api-management/gateway-config-managing-classic"
+    },
+    {
+      "source": "/context-variables/",
+      "destination": "/api-management/traffic-transformation/request-context-variables"
+    },
+    {
+      "source": "/portal/overview/",
+      "destination": "/portal/overview/intro"
+    },
+    {
+      "source": "/tyk-dashboard-analytics/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/plugins/supported-languages/golang/",
+      "destination": "/api-management/plugins/golang"
+    },
+    {
+      "source": "/product-stack/tyk-dashboard/advanced-configurations/templates/template-overview/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/getting-started-with-enterprise-portal/manage-get-started-guides-for-api-products/",
+      "destination": "/portal/api-products"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/managing-access/manage-api-consumers/",
+      "destination": "/portal/api-consumer"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/release-notes/overview/",
+      "destination": "/developer-support/release-notes/gateway"
+    },
+    {
+      "source": "/tyk-sync/",
+      "destination": "/api-management/automations/sync"
+    },
+    {
+      "source": "/getting-started/tyk-components/pump/",
+      "destination": "/api-management/tyk-pump"
+    },
+    {
+      "source": "/tyk-oss/ce-redhat-rhel-centos/",
+      "destination": "/apim/open-source/installation"
+    },
+    {
+      "source": "/api-management/ai-management/overview/",
+      "destination": "/ai-management/ai-studio/overview"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/api-access/manage-apps-credentials/",
+      "destination": "/portal/developer-app"
+    },
+    {
+      "source": "/basic-config-and-security/control-limit-traffic/request-throttling/",
+      "destination": "/api-management/request-throttling"
+    },
+    {
+      "source": "/universal-data-graph/udg-getting-started/creating-schema/",
+      "destination": "/api-management/data-graph"
+    },
+    {
+      "source": "/api-management/async-apis/use-cases/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/tyk-oss/ce-debian-ubuntu/",
+      "destination": "/apim/open-source/installation"
+    },
+    {
+      "source": "/getting-started/key-concepts/graphql-subscriptions/",
+      "destination": "/api-management/graphql"
+    },
+    {
+      "source": "/tyk-dashboard/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/tyk-oss/ce-kubernetes/",
+      "destination": "/apim/open-source/installation"
+    },
+    {
+      "source": "/plugins/supported-languages/javascript-middleware/",
+      "destination": "/api-management/plugins/javascript"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/api-documentation/list-of-endpoints/portal-1.13.0-list-of-endpoints/",
+      "destination": "/product-stack/tyk-enterprise-developer-portal/api-documentation/list-of-endpoints/portal-api-list-of-endpoints"
+    },
+    {
+      "source": "/advanced-configuration/transform-traffic/",
+      "destination": "/api-management/traffic-transformation"
+    },
+    {
+      "source": "/tyk-stack/tyk-manager/sso/dashboard-login-azure-sso/",
+      "destination": "/api-management/external-service-integration"
+    },
+    {
+      "source": "/getting-started/installation/with-tyk-on-premises/on-ubuntu/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/getting-started/key-concepts/graphql-federation/",
+      "destination": "/api-management/graphql"
+    },
+    {
+      "source": "/getting-started/key-concepts/openapi-specification/",
+      "destination": "/api-management/gateway-config-tyk-oas"
+    },
+    {
+      "source": "/basic-config-and-security/security/authentication-authorization/bearer-tokens/",
+      "destination": "/api-management/authentication/bearer-token"
+    },
+    {
+      "source": "/contribute/",
+      "destination": "/developer-support/contributing"
+    },
+    {
+      "source": "/tyk-apis/tyk-gateway-api/api-definition-objects/proxy-settings/",
+      "destination": "/api-management/gateway-config-tyk-classic"
+    },
+    {
+      "source": "/advanced-configuration/transform-traffic/jq-transformations/",
+      "destination": "/api-management/traffic-transformation/jq-transforms"
+    },
+    {
+      "source": "/frequently-asked-questions/",
+      "destination": "/developer-support/faq"
+    },
+    {
+      "source": "/universal-data-graph/",
+      "destination": "/api-management/data-graph"
+    },
+    {
+      "source": "/getting-started/key-concepts/what-is-a-security-policy/",
+      "destination": "/api-management/policies"
+    },
+    {
+      "source": "/upgrading-tyk/",
+      "destination": "/developer-support/upgrading"
+    },
+    {
+      "source": "/tyk-dashboard/open-policy-agent/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/api-management/non-http-protocols/",
+      "destination": "/advanced-configuration/other-protocols"
+    },
+    {
+      "source": "/plugins/supported-languages/",
+      "destination": "/api-management/plugins/overview"
+    },
+    {
+      "source": "/tyk-stack/tyk-manager/sso/dashboard-login-okta-tib/",
+      "destination": "/api-management/external-service-integration"
+    },
+    {
+      "source": "/tyk-apis/tyk-gateway-api/api-definition-objects/rate-limits/",
+      "destination": "/api-management/gateway-config-tyk-classic"
+    },
+    {
+      "source": "/tyk-dashboard/rbac/",
+      "destination": "/api-management/user-management"
+    },
+    {
+      "source": "/plugins/tutorials/quick-starts/go/open-source/",
+      "destination": "/api-management/plugins/overview"
+    },
+    {
+      "source": "/graphql/introspection/",
+      "destination": "/api-management/graphql"
+    },
+    {
+      "source": "/getting-started/using-oas-definitions/",
+      "destination": "/api-management/gateway-config-managing-oas"
+    },
+    {
+      "source": "/tyk-apis/tyk-gateway-api/api-definition-objects/versioning-endpoint/",
+      "destination": "/api-management/api-versioning"
+    },
+    {
+      "source": "/tyk-apis/tyk-gateway-api/api-definition-objects/cors/",
+      "destination": "/api-management/gateway-config-tyk-classic"
+    },
+    {
+      "source": "/planning-for-production/monitoring/",
+      "destination": "/planning-for-production/monitoring/tyk-components"
+    },
+    {
+      "source": "/basic-config-and-security/security/dashboard/create-user-groups/",
+      "destination": "/api-management/user-management"
+    },
+    {
+      "source": "/release-notes/version-2.8/",
+      "destination": "/developer-support/release-notes/archived"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/inputs/kafka/",
+      "destination": "/api-management/stream-config"
+    },
+    {
+      "source": "/getting-started/key-concepts/high-level-concepts/",
+      "destination": "/api-management/gateway-config-managing-oas"
+    },
+    {
+      "source": "/plugins/tutorials/quick-starts/go/dashboard/",
+      "destination": "/api-management/plugins/overview"
+    },
+    {
+      "source": "/tyk-apis/tyk-dashboard-api/api-keys/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/advanced-configuration/transform-traffic/response-body/",
+      "destination": "/api-management/traffic-transformation/response-body"
+    },
+    {
+      "source": "/tyk-on-premises/kubernetes/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/concepts/tyk-components/identity-broker/",
+      "destination": "/api-management/external-service-integration"
+    },
+    {
+      "source": "/getting-started/create-api/",
+      "destination": "/api-management/gateway-config-managing-classic"
+    },
+    {
+      "source": "/getting-started/key-concepts/what-is-an-api-definition/",
+      "destination": "/api-management/gateway-config-introduction"
+    },
+    {
+      "source": "/tyk-stack/tyk-pump/other-data-stores/",
+      "destination": "/api-management/tyk-pump"
+    },
+    {
+      "source": "/graphql/validation/",
+      "destination": "/api-management/graphql"
+    },
+    {
+      "source": "/advanced-configuration/integrate/api-auth-mode/open-id-connect/",
+      "destination": "/api-management/client-authentication"
+    },
+    {
+      "source": "/advanced-configuration/error-templates/",
+      "destination": "/api-management/gateway-events"
+    },
+    {
+      "source": "/tyk-oss/ce-ansible/",
+      "destination": "/apim/open-source/installation"
+    },
+    {
+      "source": "/getting-started/using-oas-definitions/create-an-oas-api/",
+      "destination": "/api-management/gateway-config-managing-oas"
+    },
+    {
+      "source": "/tyk-developer-portal/portal-concepts/",
+      "destination": "/tyk-developer-portal/tyk-portal-classic/portal-concepts"
+    },
+    {
+      "source": "/planning-for-production/benchmarks/",
+      "destination": "/tyk-self-managed"
+    },
+    {
+      "source": "/graphql/field-based-permissions/",
+      "destination": "/api-management/graphql"
+    },
+    {
+      "source": "/basic-config-and-security/",
+      "destination": "/api-management/policies"
+    },
+    {
+      "source": "/planning-for-production/database-settings/postgresql/",
+      "destination": "/planning-for-production/database-settings"
+    },
+    {
+      "source": "/tyk-configuration-reference/tyk-pump-configuration/moesif/",
+      "destination": "/api-management/tyk-pump"
+    },
+    {
+      "source": "/tyk-oss/ce-helm-chart/",
+      "destination": "/apim/open-source/installation"
+    },
+    {
+      "source": "/basic-config-and-security/report-monitor-trigger-events/event-types/",
+      "destination": "/api-management/gateway-events"
+    },
+    {
+      "source": "/tyk-developer-portal/okta-dcr/",
+      "destination": "/tyk-developer-portal/tyk-portal-classic/okta-dcr"
+    },
+    {
+      "source": "/tyk-environment-variables/",
+      "destination": "/tyk-oss-gateway/configuration"
+    },
+    {
+      "source": "/getting-started/key-concepts/rate-limiting/",
+      "destination": "/api-management/rate-limit"
+    },
+    {
+      "source": "/basic-config-and-security/security/authentication-authorization/ext-oauth-middleware/",
+      "destination": "/api-management/authentication/oauth-2"
+    },
+    {
+      "source": "/advanced-configuration/transform-traffic/validate-json/",
+      "destination": "/api-management/traffic-transformation"
+    },
+    {
+      "source": "/getting-started/key-concepts/versioning/",
+      "destination": "/api-management/api-versioning"
+    },
+    {
+      "source": "/tyk-apis/tyk-dashboard-api/sso/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/security/security-policies/secure-apis-method-path/",
+      "destination": "/api-management/policies"
+    },
+    {
+      "source": "/tyk-cloud/getting-started/",
+      "destination": "/tyk-cloud"
+    },
+    {
+      "source": "/advanced-configuration/transform-traffic/response-headers/",
+      "destination": "/api-management/traffic-transformation/response-headers"
+    },
+    {
+      "source": "/tyk-apis/tyk-dashboard-api/basic-authentication/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/tyk-configuration-reference/hot-restart-tyk-gateway-process/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/basic-config-and-security/report-monitor-trigger-events/instrumentation/",
+      "destination": "/api-management/logs-metrics"
+    },
+    {
+      "source": "/tyk-identity-broker/",
+      "destination": "/api-management/external-service-integration"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/getting-started/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/basic-config-and-security/security/mutual-tls/client-mtls/",
+      "destination": "/api-management/implement-tls"
+    },
+    {
+      "source": "/graphql/graphql-playground/",
+      "destination": "/api-management/graphql"
+    },
+    {
+      "source": "/basic-config-and-security/report-monitor-trigger-events/webhooks/",
+      "destination": "/api-management/gateway-events"
+    },
+    {
+      "source": "/basic-config-and-security/control-limit-traffic/request-quotas/",
+      "destination": "/api-management/request-quotas"
+    },
+    {
+      "source": "/basic-config-and-security/security/mutual-tls/upstream-mtls/",
+      "destination": "/api-management/upstream-authentication/mtls"
+    },
+    {
+      "source": "/tyk-apis/tyk-gateway-api/api-definition-objects/graphql/",
+      "destination": "/api-management/gateway-config-tyk-classic"
+    },
+    {
+      "source": "/graphql/complexity-limiting/",
+      "destination": "/api-management/graphql"
+    },
+    {
+      "source": "/tyk-stack/tyk-operator/getting-started-tyk-operator/",
+      "destination": "/api-management/automations/operator"
+    },
+    {
+      "source": "/basic-config-and-security/security/security-policies/policies-guide/",
+      "destination": "/api-management/policies"
+    },
+    {
+      "source": "/tyk-stack/tyk-gateway/configuration/redis-cluster/",
+      "destination": "/tyk-configuration-reference/redis-cluster-sentinel"
+    },
+    {
+      "source": "/transform-traffic/request-body/",
+      "destination": "/api-management/traffic-transformation/request-body"
+    },
+    {
+      "source": "/advanced-configuration/integrate/sso/",
+      "destination": "/api-management/external-service-integration"
+    },
+    {
+      "source": "/advanced-configuration/integrate/3rd-party-identity-providers/",
+      "destination": "/api-management/external-service-integration"
+    },
+    {
+      "source": "/tyk-on-premises/installation/on-aws/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/tyk-stack/tyk-pump/other-data-stores/monitor-apis-prometheus/",
+      "destination": "/api-management/tyk-pump"
+    },
+    {
+      "source": "/universal-data-graph/udg-concepts/",
+      "destination": "/api-management/data-graph"
+    },
+    {
+      "source": "/api-management/manage-apis/tyk-oas-api-definition/tyk-oas-middleware/",
+      "destination": "/api-management/traffic-transformation"
+    },
+    {
+      "source": "/basic-config-and-security/security/dashboard/create-users/",
+      "destination": "/api-management/user-management"
+    },
+    {
+      "source": "/tyk-pump/configuration/",
+      "destination": "/api-management/tyk-pump"
+    },
+    {
+      "source": "/advanced-configuration/opentracing/",
+      "destination": "/api-management/logs-metrics"
+    },
+    {
+      "source": "/basic-config-and-security/control-limit-traffic/",
+      "destination": "/api-management/rate-limit"
+    },
+    {
+      "source": "/tyk-dashboard-analytics/error-overview/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/basic-config-and-security/control-limit-traffic/key-expiry/",
+      "destination": "/api-management/policies"
+    },
+    {
+      "source": "/graphql/",
+      "destination": "/api-management/graphql"
+    },
+    {
+      "source": "/basic-config-and-security/security/owasp-top-ten/",
+      "destination": "/api-management/security-best-practices"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/getting-started-with-enterprise-portal/getting-started-with-enterprise-portal/",
+      "destination": "/portal/overview/getting-started"
+    },
+    {
+      "source": "/advanced-configuration/integrate/3rd-party-identity-providers/social/dashboard-login-with-gplus/",
+      "destination": "/api-management/external-service-integration"
+    },
+    {
+      "source": "/getting-started/using-oas-definitions/mock-response/",
+      "destination": "/api-management/traffic-transformation/mock-response"
+    },
+    {
+      "source": "/apim/open-source/",
+      "destination": "/tyk-open-source"
+    },
+    {
+      "source": "/tyk-developer-portal/tyk-enterprise-developer-portal/",
+      "destination": "/portal/overview/intro"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/customise-enterprise-portal/full-customisation/full-customisation/",
+      "destination": "/portal/customization"
+    },
+    {
+      "source": "/log-data/",
+      "destination": "/api-management/logs-metrics"
+    },
+    {
+      "source": "/tyk-dashboard-analytics/traffic-overview/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/basic-config-and-security/security/authentication-authorization/basic-auth/",
+      "destination": "/api-management/authentication/basic-authentication"
+    },
+    {
+      "source": "/tyk-oss/ce-docker/",
+      "destination": "/apim/open-source/installation"
+    },
+    {
+      "source": "/tyk-dashboard-api/org/permissions/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/tyk-developer-portal/graphql/",
+      "destination": "/tyk-developer-portal/tyk-portal-classic/graphql"
+    },
+    {
+      "source": "/getting-started/import-apis/",
+      "destination": "/api-management/gateway-config-managing-classic"
+    },
+    {
+      "source": "/basic-config-and-security/security/security-policies/",
+      "destination": "/api-management/policies"
+    },
+    {
+      "source": "/deployment-and-operations/tyk-cloud-platform/quick-start/",
+      "destination": "/tyk-cloud"
+    },
+    {
+      "source": "/tyk-multi-data-centre/",
+      "destination": "/api-management/mdcb"
+    },
+    {
+      "source": "/basic-config-and-security/security/mutual-tls/",
+      "destination": "/api-management/implement-tls"
+    },
+    {
+      "source": "/tyk-apis/tyk-dashboard-admin-api/sso/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/plugins/supported-languages/rich-plugins/grpc/tutorial-add-grpc-plugin-api/",
+      "destination": "/api-management/plugins/rich-plugins"
+    },
+    {
+      "source": "/graphql/creating-gql-api/",
+      "destination": "/api-management/graphql"
+    },
+    {
+      "source": "/release-notes/version-2.4/",
+      "destination": "/developer-support/release-notes/archived"
+    },
+    {
+      "source": "/basic-config-and-security/reduce-latency/",
+      "destination": "/api-management/response-caching"
+    },
+    {
+      "source": "/concepts/middleware-execution-order/",
+      "destination": "/api-management/traffic-transformation"
+    },
+    {
+      "source": "/tyk-apis/tyk-gateway-api/api-definition-objects/jwt/",
+      "destination": "/api-management/gateway-config-tyk-classic"
+    },
+    {
+      "source": "/tyk-gateway-api/api-definition-objects/",
+      "destination": "/api-management/gateway-config-tyk-classic"
+    },
+    {
+      "source": "/tyk-developer-portal/curity-dcr/",
+      "destination": "/tyk-developer-portal/tyk-portal-classic/curity-dcr"
+    },
+    {
+      "source": "/plugins/supported-languages/javascript-middleware/middleware-scripting-guide/",
+      "destination": "/api-management/plugins/javascript"
+    },
+    {
+      "source": "/basic-config-and-security/security/tls-and-ssl/",
+      "destination": "/api-management/certificates"
+    },
+    {
+      "source": "/universal-data-graph/getting-started-with-udg/",
+      "destination": "/api-management/data-graph"
+    },
+    {
+      "source": "/universal-data-graph/datasources/rest/",
+      "destination": "/api-management/data-graph"
+    },
+    {
+      "source": "/basic-config-and-security/security/authentication-authorization/oauth-2-0/",
+      "destination": "/api-management/authentication/oauth-2"
+    },
+    {
+      "source": "/frequently-asked-questions/check-current-gateway-version/",
+      "destination": "/developer-support/faq"
+    },
+    {
+      "source": "/plugins/plugin-types/analytics-plugins/",
+      "destination": "/api-management/plugins/plugin-types"
+    },
+    {
+      "source": "/getting-started/key-concepts/graphql-entities/",
+      "destination": "/api-management/graphql"
+    },
+    {
+      "source": "/configure/environment-variables/",
+      "destination": "/tyk-oss-gateway/configuration"
+    },
+    {
+      "source": "/plugins/rich-plugins/grpc/",
+      "destination": "/api-management/plugins/rich-plugins"
+    },
+    {
+      "source": "/universal-data-graph/concepts/arguments/",
+      "destination": "/api-management/data-graph"
+    },
+    {
+      "source": "/tyk-cloud/getting-started-tyk-cloud/setup-team/",
+      "destination": "/tyk-cloud/teams-users"
+    },
+    {
+      "source": "/product-stack/tyk-operator/getting-started/quick-start-graphql/",
+      "destination": "/api-management/automations/operator"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/advanced-configurations/distributed-tracing/open-telemetry/otel_jaeger_k8s/",
+      "destination": "/api-management/logs-metrics"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/references/go-templates/",
+      "destination": "/api-management/traffic-transformation/go-templates"
+    },
+    {
+      "source": "/apim-best-practice/overview/",
+      "destination": "/api-management/security-best-practices"
+    },
+    {
+      "source": "/frequently-asked-questions/change-logging-output-location/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/developer-support/upgrading-tyk/deployment-model/cloud/upgrade-go-plugin/",
+      "destination": "/developer-support/upgrading"
+    },
+    {
+      "source": "/tyk-dashboard-analytics/traffic-per-token/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/getting-started/key-concepts/context-variables/",
+      "destination": "/api-management/traffic-transformation/request-context-variables"
+    },
+    {
+      "source": "/universal-data-graph/udg-getting-started/security/",
+      "destination": "/api-management/data-graph"
+    },
+    {
+      "source": "/tyk-stack/tyk-operator/migration/",
+      "destination": "/api-management/automations/operator"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/managing-access/add-organisations/",
+      "destination": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/managing-access/manage-api-consumer-organisations"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/outputs/mqtt/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/dedupe/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-dashboard/advanced-configurations/open-policy-agent/opa-permissions-example/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/internal-endpoint-middleware/",
+      "destination": "/api-management/traffic-transformation/internal-endpoint"
+    },
+    {
+      "source": "/troubleshooting/tyk-gateway/499-errors/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/plugins/supported-languages/rich-plugins/grpc/performance/",
+      "destination": "/api-management/plugins/rich-plugins"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/install-tyk-enterprise-portal/launching-portal/launching-portal-with-mysql/",
+      "destination": "/portal/install"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/release-notes/version-5.2/",
+      "destination": "/developer-support/release-notes/gateway"
+    },
+    {
+      "source": "/basic-config-and-security/security/dashboard/organisations/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/getting-started/key-concepts/request-validation/",
+      "destination": "/api-management/traffic-transformation/request-validation"
+    },
+    {
+      "source": "/developer-support/upgrading-tyk/deployment-model/self-managed/kubernetes/",
+      "destination": "/developer-support/upgrading"
+    },
+    {
+      "source": "/tyk-on-premises/debian-ubuntu/analytics-pump/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/getting-started/installation/with-tyk-on-premises/on-ubuntu/dashboard/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/tyk-apis/tyk-gateway-api/api-definition-objects/events/",
+      "destination": "/api-management/gateway-config-tyk-classic"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/advanced-configurations/distributed-tracing/open-telemetry/otel_elastic/",
+      "destination": "/api-management/logs-metrics"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/customise-enterprise-portal/full-customisation/content-manager-workflow/",
+      "destination": "/portal/overview/intro"
+    },
+    {
+      "source": "/plugins/supported-languages/rich-plugins/grpc/custom-auth-python/",
+      "destination": "/api-management/plugins/rich-plugins"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/release-notes/portal-1.8.3/",
+      "destination": "/developer-support/release-notes/portal"
+    },
+    {
+      "source": "/getting-started/tutorials/create-security-policy/",
+      "destination": "/api-management/gateway-config-managing-classic"
+    },
+    {
+      "source": "/developer-support/upgrading-tyk/deployment-model/cloud/upgrade-cloud-saas/",
+      "destination": "/developer-support/upgrading"
+    },
+    {
+      "source": "/tyk-on-prem/installation/redhat-rhel-centos/dashboard/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/advanced-configuration/integrate/3rd-party-identity-providers/custom/",
+      "destination": "/api-management/external-service-integration"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/release-notes/portal-1.8.0/",
+      "destination": "/developer-support/release-notes/portal"
+    },
+    {
+      "source": "/tyk-cloud/account-billing/managing-billing-admins/",
+      "destination": "/tyk-cloud/account-billing"
+    },
+    {
+      "source": "/product-stack/tyk-dashboard/release-notes/version-4.2/",
+      "destination": "/developer-support/release-notes/dashboard"
+    },
+    {
+      "source": "/basic-config-and-security/security/authentication-authorization/python-etc-plugin-authentication/",
+      "destination": "/api-management/authentication/custom-auth"
+    },
+    {
+      "source": "/plugins/tutorials/quick-starts/go/quickstart/",
+      "destination": "/api-management/plugins/overview"
+    },
+    {
+      "source": "/developer-support/upgrading-tyk/deployment-model/cloud/upgrade-hybrid/",
+      "destination": "/developer-support/upgrading"
+    },
+    {
+      "source": "/release-notes/mdcb-2.1/",
+      "destination": "/developer-support/release-notes/mdcb"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/scanners/switch/",
+      "destination": "/api-management/stream-config"
+    },
+    {
+      "source": "/basic-config-and-security/security/key-level-security/",
+      "destination": "/api-management/policies"
+    },
+    {
+      "source": "/plugins/rich-plugins/",
+      "destination": "/api-management/plugins/rich-plugins"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/bounds-check/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/getting-started/key-concepts/gateway-api/",
+      "destination": "/api-management/gateway-config-introduction"
+    },
+    {
+      "source": "/advanced-configuration/manage-multiple-environments/with-tyk-cloud-classic/",
+      "destination": "/api-management/multiple-environments"
+    },
+    {
+      "source": "/getting-started/using-oas-definitions/oas-glossary/",
+      "destination": "/api-management/gateway-config-tyk-oas"
+    },
+    {
+      "source": "/getting-started/tyk-components/dashboard/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/product-stack/tyk-operator/release-notes/overview/",
+      "destination": "/developer-support/release-notes/operator"
+    },
+    {
+      "source": "/developer-support/debugging-series/debugging-selfmanaged/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/plugins/supported-languages/rich-plugins/python/tutorial-add-demo-plugin-api/",
+      "destination": "/api-management/plugins/rich-plugins"
+    },
+    {
+      "source": "/plugins/supported-languages/javascript-middleware/waf-js-plugin/",
+      "destination": "/api-management/plugins/javascript"
+    },
+    {
+      "source": "/debugging-series/debugging-series/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/request-header-tyk-classic/",
+      "destination": "/api-management/traffic-transformation/request-headers"
+    },
+    {
+      "source": "/product-stack/tyk-sync/commands/sync-dump/",
+      "destination": "/product-stack/tyk-sync/commands"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/managing-access/manage-api-users/",
+      "destination": "/portal/api-consumer"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/outputs/stdout/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/outputs/http-client/",
+      "destination": "/api-management/stream-config"
+    },
+    {
+      "source": "/product-stack/tyk-dashboard/advanced-configurations/sso/dashboard-login-keycloak-sso/",
+      "destination": "/api-management/external-service-integration"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/log/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/getting-started/using-oas-definitions/moving-to-oas/",
+      "destination": "/api-management/gateway-config-managing-oas"
+    },
+    {
+      "source": "/advanced-configuration/manage-multiple-environments/move-policies-between-environments/",
+      "destination": "/api-management/multiple-environments"
+    },
+    {
+      "source": "/tyk-apis/tyk-dashboard-api/pagination/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/guides/bloblang/methods/timestamps/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/guides/bloblang/methods/overview/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/developer-support/upgrading-tyk/preparations/upgrade-strategies/",
+      "destination": "/developer-support/upgrading"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/bloblang/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-operator/troubleshooting/tyk-operator-changes-not-applied/",
+      "destination": "/api-management/automations/operator"
+    },
+    {
+      "source": "/getting-started/key-concepts/",
+      "destination": "/api-management/gateway-config-introduction"
+    },
+    {
+      "source": "/getting-started/key-concepts/servers/",
+      "destination": "/api-management/gateway-config-tyk-oas"
+    },
+    {
+      "source": "/getting-started/using-oas-definitions/update-an-oas-api/",
+      "destination": "/api-management/gateway-config-managing-oas"
+    },
+    {
+      "source": "/product-stack/tyk-dashboard/release-notes/archived-releases/version-2.7/",
+      "destination": "/developer-support/release-notes/archived"
+    },
+    {
+      "source": "/troubleshooting/tyk-gateway/drl-not-ready/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/product-stack/tyk-charts/release-notes/version-2.0/",
+      "destination": "/developer-support/release-notes/helm-chart"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/getting-started/enterprise-portal-concepts/",
+      "destination": "/portal/overview/getting-started"
+    },
+    {
+      "source": "/troubleshooting/tyk-multi-cloud/token-information-doesnt-appear-dashboard-tyk-multi-cloud-users/",
+      "destination": "/tyk-cloud/troubleshooting-support"
+    },
+    {
+      "source": "/getting-started/key-concepts/oas-versioning/",
+      "destination": "/api-management/api-versioning"
+    },
+    {
+      "source": "/plugins/request-plugins/",
+      "destination": "/api-management/plugins/plugin-types"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/redis/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/advanced-configuration/integrate/3rd-party-identity-providers/social/",
+      "destination": "/api-management/external-service-integration"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/split/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/troubleshooting/tyk-gateway/key-object-validation-failed-error-updating-key/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/inputs/overview/",
+      "destination": "/api-management/stream-config"
+    },
+    {
+      "source": "/plugins/response-plugins/",
+      "destination": "/api-management/plugins/plugin-types"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/outputs/nats/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/getting-started/using-oas-definitions/export-an-oas-api/",
+      "destination": "/api-management/gateway-config-managing-oas"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/release-notes/version-4.3/",
+      "destination": "/developer-support/release-notes/gateway"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/release-notes/archived-releases/version-2.4/",
+      "destination": "/developer-support/release-notes/archived"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-mdcb/release-notes/version-2.4/",
+      "destination": "/developer-support/release-notes/mdcb"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/allow-list-tyk-oas/",
+      "destination": "/api-management/traffic-transformation/allow-list"
+    },
+    {
+      "source": "/release-notes/version-4.3/",
+      "destination": "/developer-support/release-notes/gateway"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/allow-list-tyk-classic/",
+      "destination": "/api-management/traffic-transformation/allow-list"
+    },
+    {
+      "source": "/getting-started/installation/with-tyk-on-premises/redhat-rhel-centos/analytics-pump/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/install-tyk-enterprise-portal/launching-portal/launching-portal/",
+      "destination": "/portal/install"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/release-notes/portal-1.2.0/",
+      "destination": "/developer-support/release-notes/portal"
+    },
+    {
+      "source": "/plugins/supported-languages/rich-plugins/luajit/requirements/",
+      "destination": "/api-management/plugins/rich-plugins"
+    },
+    {
+      "source": "/advanced-configuration/transform-traffic/request-headers/",
+      "destination": "/api-management/traffic-transformation/request-headers"
+    },
+    {
+      "source": "/customise-tyk/plugins/",
+      "destination": "/api-management/plugins/overview"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/select-parts/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/plugins/supported-languages/rich-plugins/python/tyk-python-api-methods/",
+      "destination": "/api-management/plugins/rich-plugins"
+    },
+    {
+      "source": "/product-stack/tyk-dashboard/release-notes/archived-releases/version-2.8/",
+      "destination": "/developer-support/release-notes/archived"
+    },
+    {
+      "source": "/tyk-stack/tyk-pump/useful-debug-modes/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/basic-config-and-security/report-monitor-and-trigger-events/event-webhook-tyk-oas/",
+      "destination": "/api-management/gateway-events"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/advanced-configurations/plugins/golang/go-development-flow/",
+      "destination": "/api-management/plugins/golang"
+    },
+    {
+      "source": "/advanced-configuration/transform-traffic/request-body/",
+      "destination": "/api-management/traffic-transformation/request-body"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/noop/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-dashboard/release-notes/version-5.4/",
+      "destination": "/developer-support/release-notes/dashboard"
+    },
+    {
+      "source": "/troubleshooting/tyk-gateway/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/troubleshooting/tyk-gateway/problem-proxying-request/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/outputs/reject/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/common-configuration/resources/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/tyk-configuration-reference/tyk-gateway-configuration-options/",
+      "destination": "/tyk-oss-gateway/configuration"
+    },
+    {
+      "source": "/tyk-apis/tyk-dashboard-api/user-groups/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/jmes-path/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/common-configuration/field-paths/",
+      "destination": "/api-management/stream-config"
+    },
+    {
+      "source": "/tyk-apis/tyk-dashboard-api/web-hooks/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/release-notes/version-4.2/",
+      "destination": "/developer-support/release-notes/gateway"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/sleep/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/release-notes/version-4.1/",
+      "destination": "/developer-support/release-notes/gateway"
+    },
+    {
+      "source": "/plugins/javascript-middleware/",
+      "destination": "/api-management/plugins/javascript"
+    },
+    {
+      "source": "/plugins/how-to-serve/plugin-bundles/",
+      "destination": "/api-management/plugins/overview"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/release-notes/portal-1.8.5/",
+      "destination": "/developer-support/release-notes/portal"
+    },
+    {
+      "source": "/product-stack/tyk-dashboard/release-notes/version-4.0/",
+      "destination": "/developer-support/release-notes/dashboard"
+    },
+    {
+      "source": "/tyk-apis/tyk-gateway-api/api-definition-objects/custom-analytics/",
+      "destination": "/api-management/gateway-config-tyk-classic"
+    },
+    {
+      "source": "/tyk-cloud/getting-started-tyk-cloud/create-account/",
+      "destination": "/tyk-cloud"
+    },
+    {
+      "source": "/universal-data-graph/concepts/datasources/",
+      "destination": "/api-management/data-graph"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/release-notes/portal-1.7.0/",
+      "destination": "/developer-support/release-notes/portal"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/msgpack/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/tyk-on-premises/microsoft-azure/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/guides/bloblang/methods/json-web-tokens/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/basic-config-and-security/reduce-latency/caching/global-cache/",
+      "destination": "/api-management/response-caching"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/allow-list-middleware/",
+      "destination": "/api-management/traffic-transformation/allow-list"
+    },
+    {
+      "source": "/graphql/introspection/introspection-queries/",
+      "destination": "/api-management/graphql"
+    },
+    {
+      "source": "/tyk-multi-data-centre/setup-worker-data-centres/",
+      "destination": "/api-management/mdcb"
+    },
+    {
+      "source": "/developer-support/long-term-support-releases/",
+      "destination": "/developer-support/release-types/long-term-support"
+    },
+    {
+      "source": "/product-stack/tyk-charts/release-notes/version-2.1/",
+      "destination": "/developer-support/release-notes/helm-chart"
+    },
+    {
+      "source": "/release-notes/",
+      "destination": "/developer-support/release-notes/overview"
+    },
+    {
+      "source": "/plugins/supported-languages/rich-plugins/grpc/getting-started-python/",
+      "destination": "/api-management/plugins/rich-plugins"
+    },
+    {
+      "source": "/getting-started/key-concepts/low-level-concepts/",
+      "destination": "/api-management/gateway-config-tyk-oas"
+    },
+    {
+      "source": "/developer-support/upgrading-tyk/deployment-model/self-managed/helm/",
+      "destination": "/developer-support/upgrading"
+    },
+    {
+      "source": "/plugins/how-to-serve-plugins/plugin-bundles/",
+      "destination": "/api-management/plugins/overview"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/cached/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/basic-config-and-security/security/mutual-tls/concepts/",
+      "destination": "/api-management/implement-tls"
+    },
+    {
+      "source": "/tyk-on-premises/debian-ubuntu/dashboard/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/outputs/broker/",
+      "destination": "/api-management/stream-config"
+    },
+    {
+      "source": "/product-stack/tyk-identity-broker/release-notes/tib-v1.6/",
+      "destination": "/developer-support/release-notes/tib"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/inputs/amqp-0-9/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-operator/getting-started/quick-start-udg/",
+      "destination": "/api-management/automations/operator"
+    },
+    {
+      "source": "/tyk-cloud/account-billing/upgrade-free-trial/",
+      "destination": "/tyk-cloud/account-billing"
+    },
+    {
+      "source": "/advanced-configuration/compose-apis/sample-batch-funtion/",
+      "destination": "/api-management/traffic-transformation"
+    },
+    {
+      "source": "/tyk-cloud/account-billing/plans/",
+      "destination": "/tyk-cloud/account-billing"
+    },
+    {
+      "source": "/basic-config-and-security/security/password-policy/",
+      "destination": "/api-management/user-management"
+    },
+    {
+      "source": "/frequently-asked-questions/how-to-disable-an-api/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/upgrading-v2-3-v2-2/",
+      "destination": "/developer-support/release-notes/archived"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/protobuf/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/advanced-configurations/plugins/api-config/oas/",
+      "destination": "/api-management/plugins/overview"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/release-notes/portal-1.8.2/",
+      "destination": "/developer-support/release-notes/portal"
+    },
+    {
+      "source": "/basic-config-and-security/security/dashboard/dashboard-api-security/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/tyk-developer-portal/customise/custom-developer-portal/",
+      "destination": "/tyk-developer-portal/tyk-portal-classic/customise/custom-developer-portal"
+    },
+    {
+      "source": "/troubleshooting/tyk-dashboard/key-object-validation-failed-most-likely-malformed-input/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/frequently-asked-questions/faq/",
+      "destination": "/developer-support/community"
+    },
+    {
+      "source": "/basic-config-and-security/reduce-latency/caching/optimise-cache/",
+      "destination": "/api-management/response-caching"
+    },
+    {
+      "source": "/tyk-developer-portal/key-requests/",
+      "destination": "/tyk-developer-portal/tyk-portal-classic/key-requests"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/release-notes/version-5.4/",
+      "destination": "/developer-support/release-notes/gateway"
+    },
+    {
+      "source": "/release-notes/mdcb/",
+      "destination": "/developer-support/release-notes/mdcb"
+    },
+    {
+      "source": "/getting-started/tutorials/create-api-key/",
+      "destination": "/api-management/gateway-config-managing-classic"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/ignore-tyk-classic/",
+      "destination": "/api-management/traffic-transformation/ignore-authentication"
+    },
+    {
+      "source": "/developer-support/upgrading-tyk/go-plugins/",
+      "destination": "/developer-support/upgrading"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/outputs/kafka-franz/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/customise-enterprise-portal/full-customisation/edit-manage-page-content/",
+      "destination": "/portal/customization/pages"
+    },
+    {
+      "source": "/basic-config-and-security/security/dashboard/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/apim-best-practice/api-security-best-practice/resource-consumption/",
+      "destination": "/api-management/security-best-practices"
+    },
+    {
+      "source": "/product-stack/tyk-dashboard/advanced-configurations/templates/template-api/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/deployment-and-operations/tyk-self-managed/deployment-lifecycle/installations/kubernetes/tyk-helm-tyk-stack-mongodb/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/getting-started/using-oas-definitions/import-an-oas-api/",
+      "destination": "/api-management/gateway-config-managing-oas"
+    },
+    {
+      "source": "/tyk-apis/tyk-gateway-api/api-definition-objects/authentication/",
+      "destination": "/api-management/gateway-config-tyk-classic"
+    },
+    {
+      "source": "/plugins/get-started-plugins/",
+      "destination": "/api-management/plugins/overview"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/common-configuration/windowed_processing/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/getting-started/tyk-components/gateway/",
+      "destination": "/tyk-oss-gateway"
+    },
+    {
+      "source": "/frequently-asked-questions/using-early-access-features/",
+      "destination": "/developer-support/release-types/early-access-feature"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/response-body-tyk-oas/",
+      "destination": "/api-management/traffic-transformation/response-body"
+    },
+    {
+      "source": "/basic-config-and-security/security/authentication-authorization/go-plugin-authentication/",
+      "destination": "/api-management/authentication/custom-auth"
+    },
+    {
+      "source": "/tyk-multi-data-centre/mdcb-components/",
+      "destination": "/api-management/mdcb"
+    },
+    {
+      "source": "/getting-started/tutorials/create-api/",
+      "destination": "/api-management/gateway-config-managing-classic"
+    },
+    {
+      "source": "/getting-started/using-oas-definitions/oas-reference/",
+      "destination": "/api-management/gateway-config-tyk-oas"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/getting-started-with-enterprise-portal/setup-email-notifications/",
+      "destination": "/product-stack/tyk-enterprise-developer-portal/getting-started/setup-email-notifications"
+    },
+    {
+      "source": "/tyk-dashboard-api/users/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/tyk-dashboard-analytics/traffic-per-api/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/release-notes/version-4.0/",
+      "destination": "/developer-support/release-notes/gateway"
+    },
+    {
+      "source": "/product-stack/tyk-dashboard/release-notes/archived-releases/version-2.5/",
+      "destination": "/developer-support/release-notes/archived"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/release-notes/version-5.1/",
+      "destination": "/developer-support/release-notes/gateway"
+    },
+    {
+      "source": "/tyk-apis/tyk-gateway-api/oas/x-tyk-oas-doc/",
+      "destination": "/api-management/gateway-config-tyk-oas"
+    },
+    {
+      "source": "/plugins/rich-plugins/python/custom-auth-python-tutorial/",
+      "destination": "/api-management/plugins/rich-plugins"
+    },
+    {
+      "source": "/basic-config-and-security/report-monitor-trigger-events/custom-handlers-javascript/",
+      "destination": "/api-management/gateway-events"
+    },
+    {
+      "source": "/security/certificate-pinning/",
+      "destination": "/api-management/upstream-authentication"
+    },
+    {
+      "source": "/basic-config-and-security/control-limit-traffic/request-size-limits/",
+      "destination": "/api-management/traffic-transformation/request-size-limits"
+    },
+    {
+      "source": "/advanced-configuration/integrate/3rd-party-identity-providers/tib-rest-api/",
+      "destination": "/tyk-identity-broker/tib-rest-api"
+    },
+    {
+      "source": "/apim-best-practice/api-security-best-practice/authorisation-levels/",
+      "destination": "/api-management/security-best-practices"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/common-configuration/error-handling/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-mdcb/advanced-configurations/synchroniser/",
+      "destination": "/api-management/mdcb"
+    },
+    {
+      "source": "/tyk-stack/tyk-operator/access-an-api/",
+      "destination": "/api-management/automations/operator"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/getting-started/customize-sign-up-form/",
+      "destination": "/portal/customization/sign-up"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/enterprise-portal-concepts/",
+      "destination": "/portal/overview/concepts"
+    },
+    {
+      "source": "/basic-config-and-security/reduce-latency/caching/invalidate-cache/",
+      "destination": "/api-management/response-caching"
+    },
+    {
+      "source": "/analytics-and-reporting/capping-analytics-data-storage/",
+      "destination": "/api-management/tyk-pump"
+    },
+    {
+      "source": "/product-stack/tyk-operator/advanced-configurations/management-of-api/",
+      "destination": "/api-management/automations/operator"
+    },
+    {
+      "source": "/developer-support/upgrading-tyk/deployment-model/self-managed/overview/",
+      "destination": "/developer-support/upgrading"
+    },
+    {
+      "source": "/developer-support/upgrading-tyk/deployment-model/open-source/",
+      "destination": "/developer-support/upgrading"
+    },
+    {
+      "source": "/universal-data-graph/udg-examples/",
+      "destination": "/api-management/data-graph"
+    },
+    {
+      "source": "/tyk-configuration-reference/import-apis/",
+      "destination": "/api-management/gateway-config-managing-classic"
+    },
+    {
+      "source": "/tyk-on-prem/installation/redhat-rhel-centos/gateway/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/release-notes/portal-1.8.4/",
+      "destination": "/developer-support/release-notes/portal"
+    },
+    {
+      "source": "/developer-support/special-releases-and-features/early-access-features/",
+      "destination": "/developer-support/release-types/early-access-feature"
+    },
+    {
+      "source": "/graphql/syncing-schema/",
+      "destination": "/api-management/graphql"
+    },
+    {
+      "source": "/plugins/auth-plugins/",
+      "destination": "/api-management/plugins/plugin-types"
+    },
+    {
+      "source": "/security/security-policies/",
+      "destination": "/api-management/policies"
+    },
+    {
+      "source": "/product-stack/tyk-dashboard/release-notes/archived-releases/version-2.9/",
+      "destination": "/developer-support/release-notes/archived"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/inputs/broker/",
+      "destination": "/api-management/stream-config"
+    },
+    {
+      "source": "/advanced-configuration/",
+      "destination": "/api-management/traffic-transformation"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/scanners/re-match/",
+      "destination": "/api-management/stream-config"
+    },
+    {
+      "source": "/basic-config-and-security/security/dashboard/dashboard-admin-api/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/tyk-developer-portal/portal-oauth-clients/",
+      "destination": "/tyk-developer-portal/tyk-portal-classic/portal-oauth-clients"
+    },
+    {
+      "source": "/advanced-configuration/compose-apis/",
+      "destination": "/api-management/traffic-transformation"
+    },
+    {
+      "source": "/product-stack/tyk-operator/release-notes/operator-0.16/",
+      "destination": "/developer-support/release-notes/operator"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/basic-config-and-security/logging-api-traffic/detailed-recording/",
+      "destination": "/api-management/logs-metrics"
+    },
+    {
+      "source": "/product-stack/tyk-charts/release-notes/version-1.3/",
+      "destination": "/developer-support/release-notes/helm-chart"
+    },
+    {
+      "source": "/plugins/javascript-middleware/install-middleware/tyk-hybrid/",
+      "destination": "/api-management/plugins/javascript"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/internal-endpoint-tyk-oas/",
+      "destination": "/api-management/traffic-transformation/internal-endpoint"
+    },
+    {
+      "source": "/troubleshooting/tyk-on-premise/tyk-on-premise/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/troubleshooting/tyk-cloud-classic/organisation-quota-exceeded-error-dashboard-api/",
+      "destination": "/tyk-cloud/troubleshooting-support"
+    },
+    {
+      "source": "/planning-for-production/redis-mongodb/",
+      "destination": "/planning-for-production/database-settings"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/release-notes/version-3.0/",
+      "destination": "/developer-support/release-notes/gateway"
+    },
+    {
+      "source": "/troubleshooting/tyk-installation/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/troubleshooting/tyk-pump/data-in-log-browser-no-reports/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/troubleshooting/tyk-dashboard/internal-tib/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/plugins/supported-languages/rich-plugins/",
+      "destination": "/api-management/plugins/rich-plugins"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/getting-started/with-tyk-self-managed-as-provider/",
+      "destination": "/portal/overview/getting-started"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/request-body-tyk-oas/",
+      "destination": "/api-management/traffic-transformation/request-body"
+    },
+    {
+      "source": "/troubleshooting/tyk-dashboard/fatal-dashboard-portal-domains-same/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/getting-started/tyk-components/mdcb/",
+      "destination": "/api-management/mdcb"
+    },
+    {
+      "source": "/plugins/supported-languages/javascript-middleware/install-middleware/tyk-ce/",
+      "destination": "/api-management/plugins/javascript"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/guides/bloblang/methods/strings/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/guides/bloblang/methods/general/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/frequently-asked-questions/api-definition-url-case-sensitive/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/product-stack/tyk-sync/release-notes/sync-1.4/",
+      "destination": "/developer-support/release-notes/sync"
+    },
+    {
+      "source": "/getting-started/key-concepts/session-meta-data/",
+      "destination": "/api-management/policies"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/deploy/install-tyk-enterprise-portal/overview/",
+      "destination": "/portal/install"
+    },
+    {
+      "source": "/tyk-configuration-reference/environment-variables/",
+      "destination": "/tyk-oss-gateway/configuration"
+    },
+    {
+      "source": "/troubleshooting/tyk-dashboard/value-error-no-json-object-decoded-running-dashboard-bootstrap-script/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/deploy/install-tyk-enterprise-portal/install-portal-using-helm/",
+      "destination": "/portal/install"
+    },
+    {
+      "source": "/release-notes/mdcb-2.2/",
+      "destination": "/developer-support/release-notes/mdcb"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/request-size-limit-tyk-classic/",
+      "destination": "/api-management/traffic-transformation/request-size-limits"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/branch/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/getting-started/quick-start/tyk-demo/",
+      "destination": "/deployment-and-operations/tyk-self-managed/tyk-demos-and-pocs/overview"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/release-notes/version-4.1/",
+      "destination": "/developer-support/release-notes/gateway"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/getting-started/getting-started-with-enterprise-portal/",
+      "destination": "/portal/overview/getting-started"
+    },
+    {
+      "source": "/planning-for-production/redis/",
+      "destination": "/planning-for-production/database-settings"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/parse-log/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/release-notes/version-5.6/",
+      "destination": "/developer-support/release-notes/gateway"
+    },
+    {
+      "source": "/universal-data-graph/datasources/kafka/",
+      "destination": "/api-management/data-graph"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/parallel/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/guides/bloblang/methods/regular-expressions/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-dashboard/release-notes/version-5.1/",
+      "destination": "/developer-support/release-notes/dashboard"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/common-configuration/interpolation/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/analytics-and-reporting/useful-debug-modes/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/tyk-cloud/getting-started-tyk-cloud/first-api/",
+      "destination": "/tyk-cloud"
+    },
+    {
+      "source": "/tyk-cloud/reference-docs/user-roles/",
+      "destination": "/tyk-cloud"
+    },
+    {
+      "source": "/getting-started/key-concepts/gitops-with-tyk/",
+      "destination": "/api-management/automations/operator"
+    },
+    {
+      "source": "/tyk-on-prem/kubernetes-ingress/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/troubleshooting/tyk-dashboard/problem-updating-cname-error-dashboard/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/release-notes/version-3.2/",
+      "destination": "/developer-support/release-notes/gateway"
+    },
+    {
+      "source": "/basic-config-and-security/security/authentication--authorization/",
+      "destination": "/api-management/client-authentication"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/api-documentation/list-of-endpoints/portal-1.9.0-list-of-endpoints/",
+      "destination": "/product-stack/tyk-enterprise-developer-portal/api-documentation/list-of-endpoints/portal-api-list-of-endpoints"
+    },
+    {
+      "source": "/tyk-self-managed/tyk-helm-chart-single-dc/",
+      "destination": "/product-stack/tyk-charts/tyk-stack-chart"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/basic-config-and-security/report-monitor-and-trigger-events/event-webhook-tyk-classic/",
+      "destination": "/api-management/gateway-events"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/ignore-tyk-oas/",
+      "destination": "/api-management/traffic-transformation/ignore-authentication"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/url-rewrite-tyk-classic/",
+      "destination": "/transform-traffic/url-rewriting"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/getting-started-with-enterprise-portal/customise-menus/",
+      "destination": "/portal/overview/getting-started"
+    },
+    {
+      "source": "/plugins/supported-languages/rich-plugins/grpc/request-transformation-java/",
+      "destination": "/api-management/plugins/rich-plugins"
+    },
+    {
+      "source": "/tyk-on-premises/on-aws/ec2/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/apim-best-practice/api-security-best-practice/authentication/",
+      "destination": "/api-management/security-best-practices"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/enforced-timeout-tyk-classic/",
+      "destination": "/planning-for-production/ensure-high-availability/enforced-timeouts"
+    },
+    {
+      "source": "/tyk-on-premises/redhat-rhel-centos/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/schema-registry-encode/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/tyk-on-premises/docker/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/dashboard-admin-api/organisations/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/overview/",
+      "destination": "/api-management/stream-config"
+    },
+    {
+      "source": "/getting-started/key-concepts/dashboard-api/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/advanced-configuration/integrate/sso/dashboard-login-okta-tib/",
+      "destination": "/api-management/external-service-integration"
+    },
+    {
+      "source": "/troubleshooting/tyk-dashboard/cant-update-policy-please-ensure-least-one-access-rights-setting-set/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/tyk-cloud/getting-started-tyk-cloud/setup-environment/",
+      "destination": "/tyk-cloud/environments-deployments/managing-environments"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/release-notes/version-5.5/",
+      "destination": "/developer-support/release-notes/gateway"
+    },
+    {
+      "source": "/basic-config-and-security/security/authentication-authorization/json-web-tokens/jwt-auth0/",
+      "destination": "/basic-config-and-security/security/authentication-authorization/json-web-tokens"
+    },
+    {
+      "source": "/tyk-on-premises/google-cloud/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/developer-support/special-releases-and-features/lab-releases/",
+      "destination": "/developer-support/release-types/lab-release"
+    },
+    {
+      "source": "/tyk-apis/tyk-dashboard-admin-api/import/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/developer-support/upgrading-tyk/deployment-model/self-managed/linux-distributions/self-managed-rpm/",
+      "destination": "/developer-support/upgrading"
+    },
+    {
+      "source": "/getting-started/quick-start/tyk-k8s-demo/",
+      "destination": "/deployment-and-operations/tyk-self-managed/tyk-demos-and-pocs/overview"
+    },
+    {
+      "source": "/tyk-apis/tyk-dashboard-api/data-graphs-api/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/outputs/http-server/",
+      "destination": "/api-management/stream-config"
+    },
+    {
+      "source": "/analytics-and-reporting/log-browser/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/product-stack/tyk-operator/getting-started/quick-start-http/",
+      "destination": "/api-management/automations/operator"
+    },
+    {
+      "source": "/security/security-policies/partitioned-policies/",
+      "destination": "/api-management/policies"
+    },
+    {
+      "source": "/getting-started/installation/with-tyk-on-premises/on-ubuntu/analytics-pump/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/getting-started/installation/with-tyk-on-premises/on-ubuntu/gateway/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/tyk-apis/tyk-dashboard-api/dashboard-url-reload/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/product-stack/tyk-charts/release-notes/version-1.4/",
+      "destination": "/developer-support/release-notes/helm-chart"
+    },
+    {
+      "source": "/tyk-oas/",
+      "destination": "/tyk-apis"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/deploy/install-tyk-enterprise-portal/install-portal-using-docker-compose/",
+      "destination": "/portal/install"
+    },
+    {
+      "source": "/troubleshooting/tyk-gateway/context-canceled/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/deployment-and-operations/tyk-self-managed/deployment-lifecycle/installations/kubernetes/tyk-helm-tyk-stack-postgresql/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/guides/bloblang/functions/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/plugins/supported-languages/rich-plugins/grpc/custom-auth-dot-net/",
+      "destination": "/api-management/plugins/rich-plugins"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/advanced-configurations/api-versioning/api-versioning/",
+      "destination": "/api-management/api-versioning"
+    },
+    {
+      "source": "/advanced-configuration/integrate/sso/dashboard-login-ldap-tib/",
+      "destination": "/api-management/external-service-integration"
+    },
+    {
+      "source": "/product-stack/tyk-dashboard/release-notes/version-4.3/",
+      "destination": "/developer-support/release-notes/dashboard"
+    },
+    {
+      "source": "/product-stack/tyk-sync/commands/sync-update/",
+      "destination": "/product-stack/tyk-sync/commands"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/guides/bloblang/methods/geoip/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/key-concepts/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/tyk-configuration-reference/outbound-email-configuration/",
+      "destination": "/configure/outbound-email-configuration"
+    },
+    {
+      "source": "/frequently-asked-questions/rename-or-move-existing-headers/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/plugins/rich-plugins/rich-plugins-work/",
+      "destination": "/api-management/plugins/rich-plugins"
+    },
+    {
+      "source": "/frequently-asked-questions/find-policy-id-created-policy/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/getting-started/installation/with-tyk-on-premises/docker/docker-pro-demo/docker-pro-demo/",
+      "destination": "/deployment-and-operations/tyk-self-managed/tyk-demos-and-pocs/overview"
+    },
+    {
+      "source": "/plugins/rich-plugins/grpc/tutorial-add-grpc-plugin-api/",
+      "destination": "/api-management/plugins/rich-plugins"
+    },
+    {
+      "source": "/basic-config-and-security/security/authentication--authorization/oauth2-0/username-password-grant/",
+      "destination": "/api-management/authentication/oauth-2"
+    },
+    {
+      "source": "/release-notes/pump-1.8/",
+      "destination": "/developer-support/release-notes/pump"
+    },
+    {
+      "source": "/plugins/get-started-selfmanaged/deploy-plugins/",
+      "destination": "/api-management/plugins/advance-config"
+    },
+    {
+      "source": "/plugins/supported-languages/rich-plugins/luajit/tutorial-add-demo-plugin-api/",
+      "destination": "/api-management/plugins/rich-plugins"
+    },
+    {
+      "source": "/tyk-dashboard/database-options/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/portal/settings/",
+      "destination": "/product-stack/tyk-enterprise-developer-portal/getting-started/setup-email-notifications"
+    },
+    {
+      "source": "/developer-support/upgrading-tyk/deployment-model/self-managed/linux-distributions/self-managed-deb/",
+      "destination": "/developer-support/upgrading"
+    },
+    {
+      "source": "/basic-config-and-security/security/authentication-authorization/json-web-tokens/jwt-keycloak/",
+      "destination": "/basic-config-and-security/security/authentication-authorization/json-web-tokens"
+    },
+    {
+      "source": "/frequently-asked-questions/gateway-detected-0-apis/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/advanced-configurations/plugins/bundles/bundle-cli/",
+      "destination": "/api-management/plugins/overview"
+    },
+    {
+      "source": "/plugins/supported-languages/javascript-middleware/install-middleware/tyk-hybrid/",
+      "destination": "/api-management/plugins/javascript"
+    },
+    {
+      "source": "/plugins/auth-plugins/id-extractor/",
+      "destination": "/api-management/plugins/plugin-types"
+    },
+    {
+      "source": "/tyk-developer-portal/tutorials/",
+      "destination": "/getting-started/tutorials/publish-api"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/install-tyk-enterprise-portal/launching-portal/launching-portal-with-sqlite/",
+      "destination": "/portal/install"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/scanners/csv/",
+      "destination": "/api-management/stream-config"
+    },
+    {
+      "source": "/tyk-on-premises/debian-ubuntu/gateway/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/basic-config-and-security/report-monitor-trigger-events/monitors/",
+      "destination": "/api-management/gateway-events"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/release-notes/portal-1.9.0/",
+      "destination": "/developer-support/release-notes/portal"
+    },
+    {
+      "source": "/graphql/gql-headers/",
+      "destination": "/api-management/graphql"
+    },
+    {
+      "source": "/universal-data-graph/udg-getting-started/mutations/",
+      "destination": "/api-management/data-graph"
+    },
+    {
+      "source": "/tyk-dashboard-analytics/traffic-per-oauth-client/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/product-stack/tyk-dashboard/release-notes/version-5.0/",
+      "destination": "/developer-support/release-notes/dashboard"
+    },
+    {
+      "source": "/basic-config-and-security/security/dashboard/search-users/",
+      "destination": "/api-management/user-management"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/release-notes/archived-releases/version-2.8/",
+      "destination": "/developer-support/release-notes/archived"
+    },
+    {
+      "source": "/troubleshooting/tyk-installation/parsing-json-error-from-dashboard-bootstrap/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/troubleshooting/tyk-installation/payload-signature-invalid-error/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/advanced-configuration/integrate/api-auth-mode/oidc-auth0-example/",
+      "destination": "/api-management/client-authentication"
+    },
+    {
+      "source": "/advanced-configuration/integrate/3rd-party-identity-providers/dashboard-login-ldap-tib/",
+      "destination": "/api-management/external-service-integration"
+    },
+    {
+      "source": "/plugins/supported-languages/rich-plugins/rich-plugins-data-structures/",
+      "destination": "/api-management/plugins/rich-plugins"
+    },
+    {
+      "source": "/release-notes/mdcb-2.0/",
+      "destination": "/developer-support/release-notes/mdcb"
+    },
+    {
+      "source": "/release-notes/version-3.2/",
+      "destination": "/developer-support/release-notes/gateway"
+    },
+    {
+      "source": "/troubleshooting/tyk-dashboard/runtime-error-invalid-memory-address-nil-pointer-dereference/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/install-tyk-enterprise-portal/launching-portal/launching-portal-with-postgresql/",
+      "destination": "/portal/install"
+    },
+    {
+      "source": "/graphql/graphql-websockets/",
+      "destination": "/api-management/graphql"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/install-tyk-enterprise-portal/bootstrapping-portal/",
+      "destination": "/portal/install"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/release-notes/archived-releases/version-2.9/",
+      "destination": "/developer-support/release-notes/archived"
+    },
+    {
+      "source": "/troubleshooting/tyk-installation/couldnt-unmarshal-config-error/",
+      "destination": "/developer-support/faq"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/managing-access/managing-access/",
+      "destination": "/portal/api-consumer"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/release-notes/archived-releases/version-2.7/",
+      "destination": "/developer-support/release-notes/archived"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/deploy/bootstrapping-portal/",
+      "destination": "/portal/install"
+    },
+    {
+      "source": "/plugins/supported-languages/javascript-middleware/install-middleware/install-middleware/",
+      "destination": "/api-management/plugins/javascript"
+    },
+    {
+      "source": "/product-stack/tyk-sync/commands/sync-publish/",
+      "destination": "/product-stack/tyk-sync/commands"
+    },
+    {
+      "source": "/troubleshooting/tyk-dashboard/port-5000-errors/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/graphql/persisted-queries/",
+      "destination": "/api-management/graphql"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/circuit-breaker-tyk-oas/",
+      "destination": "/planning-for-production/ensure-high-availability/circuit-breakers"
+    },
+    {
+      "source": "/advanced-configuration/integrate/api-auth-mode/json-web-tokens/",
+      "destination": "/api-management/security-best-practices"
+    },
+    {
+      "source": "/developer-support/special-releases-and-features/long-term-support-releases/",
+      "destination": "/developer-support/release-types/long-term-support"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/upgrading/theme-upgrades/",
+      "destination": "/portal/customization/themes"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/aws-lambda/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/guides/bloblang/methods/type-coercion/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/tyk-rest-api/",
+      "destination": "/tyk-gateway-api"
+    },
+    {
+      "source": "/tyk-cloud/troubleshooting-support/glossary/",
+      "destination": "/tyk-cloud/troubleshooting-support"
+    },
+    {
+      "source": "/analyse/redis-mongodb-sizing/",
+      "destination": "/planning-for-production/database-settings"
+    },
+    {
+      "source": "/basic-config-and-security/reduce-latency/caching/upstream-controlled-cache/",
+      "destination": "/api-management/response-caching"
+    },
+    {
+      "source": "/tyk-on-premises/docker/docker-pro-demo/docker-pro-demo-windows/",
+      "destination": "/deployment-and-operations/tyk-self-managed/tyk-demos-and-pocs/overview"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/getting-started-with-enterprise-portal/with-tyk-self-managed-as-provider/",
+      "destination": "/portal/overview/getting-started"
+    },
+    {
+      "source": "/developer-support/frequently-asked-questions/what_is_the_performance_impact_of_analytics/",
+      "destination": "/api-management/performance-monitoring"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/outputs/amqp-0-9/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/getting-started/installation/tutorials/create-security-policy/",
+      "destination": "/api-management/gateway-config-managing-classic"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/release-notes/version-5.3/",
+      "destination": "/developer-support/release-notes/gateway"
+    },
+    {
+      "source": "/product-stack/tyk-charts/release-notes/version-1.5/",
+      "destination": "/developer-support/release-notes/helm-chart"
+    },
+    {
+      "source": "/tyk-cloud/configuration-options/using-plugins/api-test/",
+      "destination": "/tyk-cloud/using-plugins"
+    },
+    {
+      "source": "/tyk-cloud/getting-started-tyk-cloud/to-conclude/",
+      "destination": "/tyk-cloud"
+    },
+    {
+      "source": "/tyk-stack/tyk-identity-broker/auth-user-for-api-access-github-oauth/",
+      "destination": "/api-management/external-service-integration"
+    },
+    {
+      "source": "/getting-started/key-concepts/what-is-a-session-object/",
+      "destination": "/api-management/policies"
+    },
+    {
+      "source": "/plugins/plugin-types/request-plugins/",
+      "destination": "/api-management/plugins/plugin-types"
+    },
+    {
+      "source": "/tyk-stack/tyk-identity-broker/about-profiles/",
+      "destination": "/api-management/external-service-integration"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/customise-enterprise-portal/full-customisation/email-customization/",
+      "destination": "/portal/customization/email-notifications"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/guides/bloblang/overview/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/basic-config-and-security/report-monitor-and-trigger-events/log-handlers/",
+      "destination": "/api-management/gateway-events"
+    },
+    {
+      "source": "/frequently-asked-questions/run-dashboard-portal-different-ports/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/portal-customisation/configure-webhooks/",
+      "destination": "/portal/customization/webhooks"
+    },
+    {
+      "source": "/basic-config-and-security/security/authentication--authorization/oauth2-0/refresh-token-grant/",
+      "destination": "/api-management/authentication/oauth-2"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/block-list-tyk-oas/",
+      "destination": "/api-management/traffic-transformation/block-list"
+    },
+    {
+      "source": "/universal-data-graph/udg-getting-started/connect-datasource/",
+      "destination": "/api-management/data-graph"
+    },
+    {
+      "source": "/plugins/supported-languages/rich-plugins/rich-plugins-work/",
+      "destination": "/api-management/plugins/rich-plugins"
+    },
+    {
+      "source": "/tyk-cloud/getting-started-tyk-cloud/test-api/",
+      "destination": "/tyk-cloud"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/release-notes/portal-1.12.0/",
+      "destination": "/developer-support/release-notes/portal"
+    },
+    {
+      "source": "/product-stack/tyk-operator/reference/security-policy/",
+      "destination": "/api-management/automations/operator"
+    },
+    {
+      "source": "/getting-started/using-oas-definitions/update-api-with-oas/",
+      "destination": "/api-management/gateway-config-managing-oas"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/release-notes/portal-1.1.0/",
+      "destination": "/developer-support/release-notes/portal"
+    },
+    {
+      "source": "/tyk-apis/tyk-gateway-api/api-definition-objects/other-root-objects/",
+      "destination": "/api-management/gateway-config-tyk-classic"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/schema-registry-decode/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-operator/reference/api-definition/",
+      "destination": "/api-management/automations/operator"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/try/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/mock-response-middleware/",
+      "destination": "/api-management/traffic-transformation/mock-response"
+    },
+    {
+      "source": "/plugins/rich-plugins/plugin-bundles/",
+      "destination": "/api-management/plugins/overview"
+    },
+    {
+      "source": "/basic-config-and-security/reduce-latency/caching/advanced-cache/",
+      "destination": "/api-management/response-caching"
+    },
+    {
+      "source": "/basic-config-and-security/security/authentication--authorization/oauth2-0/auth-code-grant/",
+      "destination": "/api-management/authentication/oauth-2"
+    },
+    {
+      "source": "/product-stack/tyk-dashboard/release-notes/archived-releases/version-2.4/",
+      "destination": "/developer-support/release-notes/archived"
+    },
+    {
+      "source": "/basic-config-and-security/security/dashboard/user-roles/",
+      "destination": "/api-management/user-management"
+    },
+    {
+      "source": "/developer-support/backups/backup-apis-and-policies/",
+      "destination": "/developer-support/upgrading"
+    },
+    {
+      "source": "/try-out-tyk/tutorials/create-security-policy/",
+      "destination": "/api-management/gateway-config-managing-classic"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/endpoint-cache-tyk-oas/",
+      "destination": "/api-management/response-caching"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/outputs/kafka/",
+      "destination": "/api-management/stream-config"
+    },
+    {
+      "source": "/product-stack/tyk-pump/advanced-configurations/configure-data-sinks/logzio/",
+      "destination": "/api-management/tyk-pump"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/customise-enterprise-portal/full-customisation/create-new-page-template/",
+      "destination": "/portal/customization/templates"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/getting-started-with-enterprise-portal/publish-api-products-and-plans/",
+      "destination": "/portal/publish-api-catalog"
+    },
+    {
+      "source": "/tyk-cloud/configuration-options/using-plugins/uploading-bundle/",
+      "destination": "/tyk-cloud/using-plugins"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/release-notes/archived-releases/version-2.5/",
+      "destination": "/developer-support/release-notes/archived"
+    },
+    {
+      "source": "/tyk-stack/tyk-pump/tyk-pump-configuration/graph_mongo_pump/",
+      "destination": "/api-management/tyk-pump"
+    },
+    {
+      "source": "/basic-config-and-security/security/tls-and-ssl/mutual-tls/",
+      "destination": "/api-management/implement-tls"
+    },
+    {
+      "source": "/plugins/supported-languages/rich-plugins/luajit/",
+      "destination": "/api-management/plugins/rich-plugins"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/sync-response/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/release-notes/version-3.1/",
+      "destination": "/developer-support/release-notes/gateway"
+    },
+    {
+      "source": "/product-stack/tyk-sync/tutorials/tutorial-synchronise-api-configurations/",
+      "destination": "/api-management/sync/use-cases"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/advanced-configurations/plugins/bundles/classic/",
+      "destination": "/api-management/plugins/overview"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/advanced-configurations/distributed-tracing/open-telemetry/otel_dynatrace/",
+      "destination": "/api-management/logs-metrics"
+    },
+    {
+      "source": "/tyk-on-premises/docker/docker-pro-demo/docker-pro-wsl/",
+      "destination": "/deployment-and-operations/tyk-self-managed/tyk-demos-and-pocs/overview"
+    },
+    {
+      "source": "/troubleshooting/tyk-cloud/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/request-method-tyk-classic/",
+      "destination": "/api-management/traffic-transformation/request-method"
+    },
+    {
+      "source": "/product-stack/tyk-operator/getting-started/tyk-operator-api-ownership/",
+      "destination": "/api-management/automations/operator"
+    },
+    {
+      "source": "/basic-config-and-security/security/your-apis/oauth20/revoke-oauth-tokens/",
+      "destination": "/api-management/authentication/oauth-2"
+    },
+    {
+      "source": "/planning-for-production/database-settings/mongodb-sizing/",
+      "destination": "/planning-for-production/database-settings"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/customise-enterprise-portal/customise-enterprise-portal/",
+      "destination": "/portal/customization"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/mock-response-tyk-classic/",
+      "destination": "/api-management/traffic-transformation/mock-response"
+    },
+    {
+      "source": "/apim-best-practice/api-security-best-practice/authorisation/",
+      "destination": "/api-management/security-best-practices"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/install-tyk-enterprise-portal/configuration/",
+      "destination": "/portal/install"
+    },
+    {
+      "source": "/product-stack/tyk-dashboard/release-notes/version-5.5/",
+      "destination": "/developer-support/release-notes/dashboard"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/managing-access/invite-codes/",
+      "destination": "/portal/api-consumer"
+    },
+    {
+      "source": "/tyk-apis/tyk-dashboard-api/oauth-key-management/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/troubleshooting/tyk-gateway/index-range-error-logs/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/getting-started/installation/with-tyk-on-premises/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/product-stack/tyk-operator/key-concepts/custom-resources/",
+      "destination": "/api-management/automations/operator"
+    },
+    {
+      "source": "/frequently-asked-questions/import-existing-keys-tyk/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/tyk-on-premises/docker/docker-pro-demo/",
+      "destination": "/deployment-and-operations/tyk-self-managed/tyk-demos-and-pocs/overview"
+    },
+    {
+      "source": "/developer-support/release-notes/special-releases/",
+      "destination": "/developer-support/release-types/long-term-support"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/url-rewrite-tyk-oas/",
+      "destination": "/transform-traffic/url-rewriting"
+    },
+    {
+      "source": "/advanced-configuration/manage-multiple-environments/tyk-sync/",
+      "destination": "/api-management/automations/sync"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/release-notes/portal-1.3.0/",
+      "destination": "/developer-support/release-notes/portal"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/inputs/generate/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/tyk-cloud/account--billing/plans/",
+      "destination": "/tyk-cloud/account-billing"
+    },
+    {
+      "source": "/api-management/oss/gateway-api/",
+      "destination": "/tyk-gateway-api"
+    },
+    {
+      "source": "/release-notes/version-3.1/",
+      "destination": "/developer-support/release-notes/gateway"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/guides/bloblang/methods/object-and-arrays/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/orphan/",
+      "destination": "/tyk-oss-gateway/configuration"
+    },
+    {
+      "source": "/api-management/gateway-optimizations/",
+      "destination": "/api-management/response-caching"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/deploy/install-tyk-enterprise-portal/install-portal-using-docker/",
+      "destination": "/portal/install"
+    },
+    {
+      "source": "/getting-started/using-oas-definitions/get-started-oas/",
+      "destination": "/api-management/gateway-config-managing-oas"
+    },
+    {
+      "source": "/graphql/migration-guide/",
+      "destination": "/api-management/graphql"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/advanced-configurations/plugins/bundles/oas/",
+      "destination": "/api-management/plugins/overview"
+    },
+    {
+      "source": "/tyk-oss/ce-github/",
+      "destination": "/apim/open-source/installation"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/outputs/drop_on/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/advanced-configurations/plugins/golang/go-plugin-examples/",
+      "destination": "/api-management/plugins/golang"
+    },
+    {
+      "source": "/tyk-stack/tyk-operator/tyk-operator-reconciliation/",
+      "destination": "/api-management/automations/operator"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/request-size-limit-tyk-oas/",
+      "destination": "/api-management/traffic-transformation/request-size-limits"
+    },
+    {
+      "source": "/tyk-apis/tyk-gateway-api/api-definition-objects/uptime-tests/",
+      "destination": "/api-management/gateway-config-tyk-classic"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/inputs/kafka-franz/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/ensure-high-availability/load-balancing/",
+      "destination": "/planning-for-production/ensure-high-availability/load-balancing"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/workflow/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/deployment-and-operations/tyk-self-managed/deployment-lifecycle/deployment-to-production/key-value-storage/vault/",
+      "destination": "/tyk-configuration-reference/kv-store"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/jq/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-sync/commands/sync-examples/",
+      "destination": "/product-stack/tyk-sync/commands"
+    },
+    {
+      "source": "/configure/tyk-dashboard-configuration-options/",
+      "destination": "/tyk-dashboard/configuration"
+    },
+    {
+      "source": "/advanced-configuration/distributed-tracing/jaeger/",
+      "destination": "/api-management/logs-metrics"
+    },
+    {
+      "source": "/plugins/supported-languages/rich-plugins/python/performance/",
+      "destination": "/api-management/plugins/rich-plugins"
+    },
+    {
+      "source": "/tyk-on-premises/installation/on-heroku/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/product-stack/tyk-dashboard/release-notes/version-5.2/",
+      "destination": "/developer-support/release-notes/dashboard"
+    },
+    {
+      "source": "/product-stack/tyk-dashboard/release-notes/version-3.0/",
+      "destination": "/developer-support/release-notes/dashboard"
+    },
+    {
+      "source": "/deployment-and-operations/tyk-self-managed/deployment-lifecycle/deployment-to-production/key-value-storage/consul/",
+      "destination": "/tyk-configuration-reference/kv-store"
+    },
+    {
+      "source": "/plugins/supported-languages/javascript-middleware/install-middleware/tyk-pro/",
+      "destination": "/api-management/plugins/javascript"
+    },
+    {
+      "source": "/universal-data-graph/concepts/reusing_response_fields/",
+      "destination": "/api-management/data-graph"
+    },
+    {
+      "source": "/troubleshooting/tyk-pump/pump-overloaded/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/release-notes/version-4.2/",
+      "destination": "/developer-support/release-notes/gateway"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/insert-part/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/customise-enterprise-portal/quick-customisation/",
+      "destination": "/portal/customization"
+    },
+    {
+      "source": "/plugins/how-to-serve-plugins/",
+      "destination": "/api-management/plugins/overview"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/deploy/install-tyk-enterprise-portal/",
+      "destination": "/portal/install"
+    },
+    {
+      "source": "/tyk-configuration-reference/tyk-pump-configuration/splunk/",
+      "destination": "/api-management/tyk-pump"
+    },
+    {
+      "source": "/tyk-dashboard-oas-api/",
+      "destination": "/tyk-dashboard-api"
+    },
+    {
+      "source": "/developer-support/tyk-release-summary/overview/",
+      "destination": "/developer-support/release-notes/overview"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/overview/",
+      "destination": "/api-management/stream-config"
+    },
+    {
+      "source": "/getting-started/installation/with-tyk-on-premises/redhat-rhel-centos/dashboard/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/cache/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/release-notes/version-2.9/",
+      "destination": "/developer-support/release-notes/archived"
+    },
+    {
+      "source": "/universal-data-graph/concepts/header_management/",
+      "destination": "/api-management/data-graph"
+    },
+    {
+      "source": "/getting-started/tyk-components/developer-portal/",
+      "destination": "/portal/overview/getting-started"
+    },
+    {
+      "source": "/tyk-cloud/environments--deployments/hybrid-gateways/",
+      "destination": "/tyk-cloud/environments-deployments/hybrid-gateways"
+    },
+    {
+      "source": "/basic-config-and-security/security/security-policies/secure-apis-method-path/",
+      "destination": "/api-management/policies"
+    },
+    {
+      "source": "/frequently-asked-questions/long-term-support-releases/",
+      "destination": "/developer-support/release-types/long-term-support"
+    },
+    {
+      "source": "/tyk-stack/tyk-manager/analytics/capping-analytics-data-storage/",
+      "destination": "/api-management/tyk-pump"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/request-header-tyk-oas/",
+      "destination": "/api-management/traffic-transformation/request-headers"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/glossary/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/outputs/sync-response/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/tyk-cloud/getting-started-tyk-cloud/view-analytics/",
+      "destination": "/tyk-cloud"
+    },
+    {
+      "source": "/release-notes/version-4.0/",
+      "destination": "/developer-support/release-notes/gateway"
+    },
+    {
+      "source": "/basic-config-and-security/security/authentication-authorization/json-web-tokens/split-token/",
+      "destination": "/basic-config-and-security/security/authentication-authorization/json-web-tokens"
+    },
+    {
+      "source": "/tyk-configuration-reference/tyk-dashboard-configuration-options/",
+      "destination": "/tyk-dashboard/configuration"
+    },
+    {
+      "source": "/product-stack/tyk-operator/key-concepts/operator-user/",
+      "destination": "/api-management/automations/operator"
+    },
+    {
+      "source": "/compose-apis/virtual-endpoints/",
+      "destination": "/api-management/traffic-transformation/virtual-endpoints"
+    },
+    {
+      "source": "/tyk-cloud/what-is-tyk-cloud/",
+      "destination": "/tyk-cloud"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/virtual-endpoint-tyk-classic/",
+      "destination": "/api-management/traffic-transformation/virtual-endpoints"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/advanced-configurations/distributed-tracing/open-tracing/jaeger/",
+      "destination": "/api-management/logs-metrics"
+    },
+    {
+      "source": "/troubleshooting/tyk-cloud-classic/504-gateway-timeout-error/",
+      "destination": "/tyk-cloud/troubleshooting-support"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/release-notes/portal-1.5.0/",
+      "destination": "/developer-support/release-notes/portal"
+    },
+    {
+      "source": "/product-stack/tyk-dashboard/release-notes/version-3.2/",
+      "destination": "/developer-support/release-notes/dashboard"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/rate-limits/overview/",
+      "destination": "/api-management/rate-limit"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/while/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/advanced-configurations/plugins/golang/writing-go-plugins/",
+      "destination": "/api-management/plugins/golang"
+    },
+    {
+      "source": "/troubleshooting/tyk-gateway/invalid-memory-address-nil-pointer-dereference-error/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/plugins/javascript-middleware/middleware-scripting-guide/",
+      "destination": "/api-management/plugins/javascript"
+    },
+    {
+      "source": "/advanced-configuration/manage-multiple-environments/",
+      "destination": "/api-management/multiple-environments"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/response-header-tyk-classic/",
+      "destination": "/api-management/traffic-transformation/response-headers"
+    },
+    {
+      "source": "/developer-support/upgrading-tyk/deployment-model/self-managed/docker/",
+      "destination": "/developer-support/upgrading"
+    },
+    {
+      "source": "/security/tls-and-ssl/",
+      "destination": "/api-management/certificates"
+    },
+    {
+      "source": "/tyk-oss/ce-helm-chart-new/",
+      "destination": "/apim/open-source/installation"
+    },
+    {
+      "source": "/tyk-on-premises/licensing/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/product-stack/tyk-operator/reference/version-compatibility/",
+      "destination": "/api-management/automations/operator"
+    },
+    {
+      "source": "/product-stack/tyk-operator/release-notes/operator-0.17/",
+      "destination": "/developer-support/release-notes/operator"
+    },
+    {
+      "source": "/frequently-asked-questions/two-gateways-with-docker-compose/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/tyk-multi-data-centre/setup-slave-data-centres/",
+      "destination": "/api-management/mdcb"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/inputs/http-server/",
+      "destination": "/api-management/stream-config"
+    },
+    {
+      "source": "/tyk-stack/dependencies/mongodb/x509-client-auth/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/product-stack/tyk-charts/release-notes/version-1.6/",
+      "destination": "/developer-support/release-notes/helm-chart"
+    },
+    {
+      "source": "/tyk-configuration-reference/tyk-pump-configuration/",
+      "destination": "/api-management/tyk-pump"
+    },
+    {
+      "source": "/frequently-asked-questions/how-to-setup-cors/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/catch/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/frequently-asked-questions/custom-domain-for-portal-cloud-multi-cloud/",
+      "destination": "/tyk-cloud/using-custom-domains"
+    },
+    {
+      "source": "//api-management/authentication-authorization/",
+      "destination": "/api-management/client-authentication"
+    },
+    {
+      "source": "/tyk-cloud/environments-deployments/hybrid-gateways-helm/",
+      "destination": "/tyk-cloud/environments-deployments/hybrid-gateways"
+    },
+    {
+      "source": "/graphql-proxy-only/",
+      "destination": "/api-management/graphql"
+    },
+    {
+      "source": "/plugins/plugin-types/plugintypes/",
+      "destination": "/api-management/plugins/plugin-types"
+    },
+    {
+      "source": "/planning-for-production/ensure-high-availability/",
+      "destination": "/tyk-self-managed"
+    },
+    {
+      "source": "/frequently-asked-questions/add-custom-certificates-to-docker-images/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/product-stack/tyk-operator/advanced-configurations/client-authentication/",
+      "destination": "/api-management/automations/operator"
+    },
+    {
+      "source": "/getting-started/installation/with-tyk-on-premises/bootstrapper-cli/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/outputs/amqp-1/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/tyk-cloud/configuration-options/using-plugins/python-code-bundle/",
+      "destination": "/tyk-cloud/using-plugins"
+    },
+    {
+      "source": "/product-stack/tyk-dashboard/advanced-configurations/analytics/audit-log/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/advanced-configuration/integrate/3rd-party-identity-providers/social/app-login-with-gplus/",
+      "destination": "/api-management/external-service-integration"
+    },
+    {
+      "source": "/troubleshooting/tyk-pump/panic-stack-exceeds-1000000000-byte-limit/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/getting-started/customize-products-and-plans/",
+      "destination": "/portal/customization"
+    },
+    {
+      "source": "/tyk-gateway-oas-api/",
+      "destination": "/tyk-gateway-api"
+    },
+    {
+      "source": "/plugins/plugin-types/auth-plugins/id-extractor/",
+      "destination": "/api-management/plugins/plugin-types"
+    },
+    {
+      "source": "/advanced-configuration/manage-multiple-environments/move-apis-between-environments/",
+      "destination": "/api-management/multiple-environments"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/mock-response-openapi/",
+      "destination": "/api-management/traffic-transformation/mock-response"
+    },
+    {
+      "source": "/advanced-configuration/distributed-tracing/newrelic/",
+      "destination": "/api-management/logs-metrics"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/inputs/mqtt/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/transform-traffic/request-headers/",
+      "destination": "/api-management/traffic-transformation/request-headers"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/portal-customisation/customise-user-model/",
+      "destination": "/portal/customization/user-model"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/rate-limits/local/",
+      "destination": "/api-management/rate-limit"
+    },
+    {
+      "source": "/getting-started/installation/with-tyk-on-premises/redhat-rhel-centos/gateway/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-mdcb/release-notes/version-2.7/",
+      "destination": "/developer-support/release-notes/mdcb"
+    },
+    {
+      "source": "/api-management/authentication-authorization/",
+      "destination": "/api-management/client-authentication"
+    },
+    {
+      "source": "/tyk-on-premises/debian-ubuntu/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/product-stack/tyk-dashboard/release-notes/overview/",
+      "destination": "/developer-support/release-notes/dashboard"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/mutation/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-sync/release-notes/sync-1.5/",
+      "destination": "/developer-support/release-notes/sync"
+    },
+    {
+      "source": "/product-stack/tyk-pump/advanced-configurations/setup-prometheus-pump/",
+      "destination": "/api-management/tyk-pump"
+    },
+    {
+      "source": "/product-stack/tyk-operator/key-concepts/operator-context/",
+      "destination": "/api-management/automations/operator"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/avro/",
+      "destination": "/api-management/stream-config"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/guides/sync-responses/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/outputs/fallback/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/tyk-stack/tyk-manager/analytics/geographic-distribution/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/deploy/install-tyk-enterprise-portal/install-portal-using-new-helm/",
+      "destination": "/portal/install"
+    },
+    {
+      "source": "/frequently-asked-questions/how-to-backup-tyk/",
+      "destination": "/developer-support/faq"
+    },
+    {
+      "source": "/product-stack/tyk-dashboard/release-notes/version-4.1/",
+      "destination": "/developer-support/release-notes/dashboard"
+    },
+    {
+      "source": "/troubleshooting/",
+      "destination": "/developer-support/community"
+    },
+    {
+      "source": "/product-stack/tyk-sync/commands/sync-sync/",
+      "destination": "/product-stack/tyk-sync/commands"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/outputs/switch/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-dashboard/release-notes/archived-releases/version-2.6/",
+      "destination": "/developer-support/release-notes/archived"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/deployment-considerations/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/getting-started/create-api-product-and-plan/",
+      "destination": "/portal/publish-api-catalog"
+    },
+    {
+      "source": "/release-notes/version-2.5/",
+      "destination": "/developer-support/release-notes/archived"
+    },
+    {
+      "source": "/tyk-configuration-reference/securing-system-payloads/",
+      "destination": "/api-management/security-best-practices"
+    },
+    {
+      "source": "/tyk-cloud/account-billing/add-payment-method/",
+      "destination": "/tyk-cloud/account-billing"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/retry/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/internal-endpoint-tyk-classic/",
+      "destination": "/api-management/traffic-transformation/internal-endpoint"
+    },
+    {
+      "source": "/tyk-apis/tyk-dashboard-admin-api/export/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/basic-config-and-security/security/authentication-authorization/physical-token-expiry/",
+      "destination": "/api-management/policies"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/do-not-track-middleware/",
+      "destination": "/api-management/logs-metrics"
+    },
+    {
+      "source": "/tyk-dashboard/getting-started/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/tyk-cloud/getting-started-tyk-cloud/setup-org/",
+      "destination": "/tyk-cloud"
+    },
+    {
+      "source": "/planning-for-production/redis-sizing/",
+      "destination": "/planning-for-production/database-settings"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/basic-config-and-security/logging-api-traffic/logging-api-traffic/",
+      "destination": "/api-management/logs-metrics"
+    },
+    {
+      "source": "/frequently-asked-questions/datadog-logs-showup-as-errors/",
+      "destination": "/developer-support/faq"
+    },
+    {
+      "source": "/frequently-asked-questions/capping-analytics-data-storage/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/tyk-apis/tyk-dashboard-admin-api/users/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/request-method-tyk-oas/",
+      "destination": "/api-management/traffic-transformation/request-method"
+    },
+    {
+      "source": "/try-out-tyk/tutorials/create-api-key/",
+      "destination": "/api-management/gateway-config-managing-classic"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/response-body-tyk-classic/",
+      "destination": "/api-management/traffic-transformation/response-body"
+    },
+    {
+      "source": "/tyk-cloud/configuration-options/using-plugins/setup-control-plane/",
+      "destination": "/tyk-cloud/using-plugins"
+    },
+    {
+      "source": "/tyk-apis/tyk-dashboard-admin-api/organisations/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/basic-config-and-security/report-monitor-trigger-events/event-data/",
+      "destination": "/api-management/gateway-events"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/advanced-configurations/plugins/api-config/classic/",
+      "destination": "/api-management/plugins/overview"
+    },
+    {
+      "source": "/tyk-on-prem/kubernetes-on-windows/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/tyk-multi-data-centre/mdcb-example-minimising-latency/",
+      "destination": "/api-management/mdcb"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/release-notes/portal-1.11.0/",
+      "destination": "/developer-support/release-notes/portal"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/group-by/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/tyk-dashboard-api/org/opa/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/tyk-developer-portal/tyk-enterprise-developer-portal/api-consumer-portal/register-portal/",
+      "destination": "/portal/api-consumer"
+    },
+    {
+      "source": "/plugins/supported-languages/rich-plugins/grpc/write-grpc-plugin/",
+      "destination": "/api-management/plugins/rich-plugins"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/common-configuration/batching/",
+      "destination": "/api-management/stream-config"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/customise-enterprise-portal/full-customisation/developer-workflow/",
+      "destination": "/portal/overview/intro"
+    },
+    {
+      "source": "/debugging-series/mongodb-debugging/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/product-stack/tyk-sync/tutorials/tutorial-backup-api-configurations/",
+      "destination": "/api-management/sync/use-cases"
+    },
+    {
+      "source": "/product-stack/tyk-operator/troubleshooting/tyk-operator-reconciliation-troubleshooting/",
+      "destination": "/api-management/automations/operator"
+    },
+    {
+      "source": "/plugins/supported-languages/rich-plugins/python/python/",
+      "destination": "/api-management/plugins/rich-plugins"
+    },
+    {
+      "source": "/release-notes/version-2.7/",
+      "destination": "/developer-support/release-notes/archived"
+    },
+    {
+      "source": "/tyk-developer-portal/gluu-dcr/",
+      "destination": "/tyk-developer-portal/tyk-portal-classic/gluu-dcr"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/release-notes/portal-1.8.1/",
+      "destination": "/developer-support/release-notes/portal"
+    },
+    {
+      "source": "/plugins/supported-languages/rich-plugins/grpc/custom-auth-nodejs/",
+      "destination": "/api-management/plugins/rich-plugins"
+    },
+    {
+      "source": "/tyk-stack/universal-data-graph/concepts/datasources/",
+      "destination": "/api-management/data-graph"
+    },
+    {
+      "source": "/release-notes/version-3.0/",
+      "destination": "/developer-support/release-notes/gateway"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/developer-portal-integration/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/frequently-asked-questions/redis-persistence-using-containers/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/product-stack/tyk-pump/advanced-configurations/configure-data-sinks/elasticsearch/",
+      "destination": "/api-management/tyk-pump"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/managing-access/approve-self-registering-requests/",
+      "destination": "/portal/api-owner"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/release-notes/archived-releases/upgrading-v2-3-v2-2/",
+      "destination": "/developer-support/release-notes/archived"
+    },
+    {
+      "source": "/advanced-configuration/log-data/",
+      "destination": "/api-management/logs-metrics"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/mapping/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/troubleshooting/tyk-dashboard/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/validate-request-tyk-classic/",
+      "destination": "/api-management/traffic-transformation/request-validation"
+    },
+    {
+      "source": "/universal-data-graph/udg-getting-started/header-forwarding/",
+      "destination": "/api-management/data-graph"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/advanced-configurations/distributed-tracing/observability/",
+      "destination": "/api-management/logs-metrics"
+    },
+    {
+      "source": "/basic-config-and-security/security/key-hashing/",
+      "destination": "/api-management/policies"
+    },
+    {
+      "source": "/plugins/rich-plugins/rich-plugins-data-structures/",
+      "destination": "/api-management/plugins/rich-plugins"
+    },
+    {
+      "source": "/product-stack/tyk-dashboard/release-notes/version-5.6/",
+      "destination": "/developer-support/release-notes/dashboard"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/block-list-middleware/",
+      "destination": "/api-management/traffic-transformation/block-list"
+    },
+    {
+      "source": "/tyk-cloud/configuration-options/using-plugins/python-custom-auth/",
+      "destination": "/tyk-cloud/using-plugins"
+    },
+    {
+      "source": "/developer-support/frequently-asked-questions/how-to-reduce-cpu-usage-in-a-redis-cluster/",
+      "destination": "/api-management/performance-monitoring"
+    },
+    {
+      "source": "/product-stack/tyk-sync/release-notes/sync-2.0/",
+      "destination": "/developer-support/release-notes/sync"
+    },
+    {
+      "source": "/tyk-stack/tyk-pump/separated-analytics-storage/",
+      "destination": "/api-management/tyk-pump"
+    },
+    {
+      "source": "/apim-best-practice/api-security-best-practice/configuration/",
+      "destination": "/api-management/security-best-practices"
+    },
+    {
+      "source": "/plugins/plugin-types/response-plugins/",
+      "destination": "/api-management/plugins/plugin-types"
+    },
+    {
+      "source": "/troubleshooting/tyk-pump/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/concepts/context-variables/",
+      "destination": "/api-management/traffic-transformation/request-context-variables"
+    },
+    {
+      "source": "/advanced-configuration/manage-multiple-environments/with-tyk-on-premises/",
+      "destination": "/api-management/multiple-environments"
+    },
+    {
+      "source": "/getting-started/key-concepts/rbac/",
+      "destination": "/api-management/user-management"
+    },
+    {
+      "source": "/basic-config-and-security/security/security-policies/partitioned-policies/",
+      "destination": "/api-management/policies"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/endpoint-rate-limit-oas/",
+      "destination": "/api-management/rate-limit"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/advanced-configurations/plugins/api-config/overview/",
+      "destination": "/api-management/plugins/overview"
+    },
+    {
+      "source": "/error-response-codes/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/customise-enterprise-portal/full-customisation/file-structure-concepts/",
+      "destination": "/portal/customization"
+    },
+    {
+      "source": "/api-management/async-apis/advanced-use-cases/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/endpoint-plugin-tyk-oas/",
+      "destination": "/api-management/plugins/plugin-types"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/inputs/http-client/",
+      "destination": "/api-management/stream-config"
+    },
+    {
+      "source": "/tyk-stack/tyk-operator/secure-an-api/",
+      "destination": "/api-management/automations/operator"
+    },
+    {
+      "source": "/troubleshooting/tyk-pump/connection-dropped-connecting/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/try-out-tyk/tutorials/tutorials/",
+      "destination": "/getting-started/configure-first-api"
+    },
+    {
+      "source": "/frequently-asked-questions/dashboard-bootstrap-error/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/tyk-developer-portal/developer-profiles/",
+      "destination": "/tyk-developer-portal/tyk-portal-classic/developer-profiles"
+    },
+    {
+      "source": "/release-notes/version-2.6/",
+      "destination": "/developer-support/release-notes/archived"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/endpoint-cache-tyk-classic/",
+      "destination": "/api-management/response-caching"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/install-tyk-enterprise-portal/launching-portal/launching-portal-using-helm/",
+      "destination": "/portal/install"
+    },
+    {
+      "source": "/universal-data-graph/datasources/tyk/",
+      "destination": "/api-management/data-graph"
+    },
+    {
+      "source": "/frequently-asked-questions/enable-websockets-cloud/",
+      "destination": "/tyk-cloud/troubleshooting-support"
+    },
+    {
+      "source": "/tyk-oss/ce-kubernetes-ingress/",
+      "destination": "/apim/open-source/installation"
+    },
+    {
+      "source": "/tyk-cloud/account--billing/retirement/",
+      "destination": "/tyk-cloud/account-billing"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/request-body-tyk-classic/",
+      "destination": "/api-management/traffic-transformation/request-body"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/json-schema/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/tyk-apis/tyk-dashboard-api/analytics/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/group-by-value/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/http/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/guides/bloblang/methods/encoding-and-encryption/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/getting-started/create-orgs-and-catalogs/",
+      "destination": "/portal/publish-api-catalog"
+    },
+    {
+      "source": "/frequently-asked-questions/how-to-backup-tyk-cloud-deployment/",
+      "destination": "/developer-support/faq"
+    },
+    {
+      "source": "/product-stack/tyk-dashboard/advanced-configurations/templates/template-designer/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/plugins/rich-plugins/luajit/",
+      "destination": "/api-management/plugins/rich-plugins"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/url-rewrite-middleware/",
+      "destination": "/transform-traffic/url-rewriting"
+    },
+    {
+      "source": "/getting-started/key-concepts/authentication/",
+      "destination": "/api-management/gateway-config-tyk-oas"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/for-each/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/getting-started/key-concepts/graphql-subgraphs/",
+      "destination": "/api-management/graphql"
+    },
+    {
+      "source": "/troubleshooting/tyk-cloud-classic/413-request-entity-large/",
+      "destination": "/tyk-cloud/troubleshooting-support"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/advanced-configurations/distributed-tracing/open-telemetry/otel_datadog/",
+      "destination": "/api-management/logs-metrics"
+    },
+    {
+      "source": "/planning-for-production/database-settings/mongodb/",
+      "destination": "/planning-for-production/database-settings"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/api-access/api-access/",
+      "destination": "/portal/api-provider"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/release-notes/portal-1.4.0/",
+      "destination": "/developer-support/release-notes/portal"
+    },
+    {
+      "source": "/getting-started/tutorials/create-portal-entry/",
+      "destination": "/getting-started/tutorials/publish-api"
+    },
+    {
+      "source": "/troubleshooting/tyk-gateway/support-information/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/tyk-cloud/configuration-options/",
+      "destination": "/tyk-cloud"
+    },
+    {
+      "source": "/product-stack/tyk-operator/release-notes/operator-1.0/",
+      "destination": "/developer-support/release-notes/operator"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/guides/bloblang/methods/parsing/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/getting-started-with-enterprise-portal/create-api-product-and-plan/",
+      "destination": "/portal/publish-api-catalog"
+    },
+    {
+      "source": "/tyk-developer-portal/tyk-enterprise-developer-portal/api-consumer-portal/",
+      "destination": "/portal/api-consumer"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/guides/bloblang/arithmetic/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-operator/release-notes/operator-0.18/",
+      "destination": "/developer-support/release-notes/operator"
+    },
+    {
+      "source": "/product-stack/tyk-sync/tutorials/tutorial-update-api-configurations/",
+      "destination": "/api-management/sync/use-cases"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/scanners/overview/",
+      "destination": "/api-management/stream-config"
+    },
+    {
+      "source": "/tyk-stack/tyk-manager/sso/sso-auth0-tib/",
+      "destination": "/api-management/external-service-integration"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/advanced-configurations/distributed-tracing/open-tracing/newrelic/",
+      "destination": "/api-management/logs-metrics"
+    },
+    {
+      "source": "/tyk-stack/tyk-gateway/configuration/redis-sentinel/",
+      "destination": "/tyk-configuration-reference/redis-cluster-sentinel"
+    },
+    {
+      "source": "/advanced-configuration/distributed-tracing/zipkin/",
+      "destination": "/api-management/logs-metrics"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/advanced-configurations/plugins/golang/go-plugin-compiler/",
+      "destination": "/api-management/plugins/golang"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/advanced-configurations/distributed-tracing/open-telemetry/otel_new_relic/",
+      "destination": "/api-management/logs-metrics"
+    },
+    {
+      "source": "/getting-started/key-concepts/paths/",
+      "destination": "/api-management/gateway-config-tyk-oas"
+    },
+    {
+      "source": "/advanced-configuration/transform-traffic/url-rewriting/",
+      "destination": "/transform-traffic/url-rewriting"
+    },
+    {
+      "source": "/tyk-apis/tyk-dashboard-api/api-definitions/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/release-notes/archived-releases/version-2.6/",
+      "destination": "/developer-support/release-notes/archived"
+    },
+    {
+      "source": "/basic-config-and-security/security/authentication--authorization/oauth2-0/client-credentials-grant/",
+      "destination": "/api-management/authentication/oauth-2"
+    },
+    {
+      "source": "/product-stack/tyk-pump/release-notes/pump-1.11/",
+      "destination": "/developer-support/release-notes/pump"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/outputs/redis-pubsub/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-dashboard/release-notes/version-3.1/",
+      "destination": "/developer-support/release-notes/dashboard"
+    },
+    {
+      "source": "/troubleshooting/tyk-gateway/502-error-tyk-gateway/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/deployment-and-operations/tyk-open-source-api-gateway/setup-multiple-gateways/",
+      "destination": "/tyk-cloud"
+    },
+    {
+      "source": "/plugins/supported-languages/javascript-middleware/javascript-api/",
+      "destination": "/api-management/plugins/javascript"
+    },
+    {
+      "source": "/tyk-on-premises/ansible/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/outputs/overview/",
+      "destination": "/api-management/stream-config"
+    },
+    {
+      "source": "/tyk-apis/tyk-gateway-api/token-session-object-details/",
+      "destination": "/api-management/policies"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/customise-enterprise-portal/full-customisation/menus-customisation/",
+      "destination": "/portal/customization/menus"
+    },
+    {
+      "source": "/customise-tyk/plugins/golang-plugins/golang-plugins/",
+      "destination": "/api-management/plugins/golang"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/enforced-timeout-tyk-oas/",
+      "destination": "/planning-for-production/ensure-high-availability/enforced-timeouts"
+    },
+    {
+      "source": "/tyk-multi-data-centre/setup-master-data-centre/",
+      "destination": "/api-management/mdcb"
+    },
+    {
+      "source": "/product-stack/tyk-pump/release-notes/pump-1.9/",
+      "destination": "/developer-support/release-notes/pump"
+    },
+    {
+      "source": "/tyk-identity-broker/getting-started/",
+      "destination": "/api-management/external-service-integration"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/release-notes/portal-1.6.0/",
+      "destination": "/developer-support/release-notes/portal"
+    },
+    {
+      "source": "/troubleshooting/tyk-gateway/profiling/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/universal-data-graph/udg-getting-started/field-based-permission/",
+      "destination": "/api-management/data-graph"
+    },
+    {
+      "source": "/troubleshooting/tyk-pump/no-elasticsearch-node-available/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/inputs/nsq/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/release-notes/version-5.0/",
+      "destination": "/developer-support/release-notes/gateway"
+    },
+    {
+      "source": "/tyk-developer-portal/keycloak-dcr/",
+      "destination": "/tyk-developer-portal/tyk-portal-classic/keycloak-dcr"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/block-list-tyk-classic/",
+      "destination": "/api-management/traffic-transformation/block-list"
+    },
+    {
+      "source": "/get-started/with-tyk-on-premise/installation/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/universal-data-graph/datasources/graphql/",
+      "destination": "/api-management/data-graph"
+    },
+    {
+      "source": "/tyk-multi-data-centre/setup-controller-data-centre/",
+      "destination": "/api-management/mdcb"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-mdcb/release-notes/version-2.6/",
+      "destination": "/developer-support/release-notes/mdcb"
+    },
+    {
+      "source": "/product-stack/tyk-pump/advanced-configurations/configure-data-sinks/csv/",
+      "destination": "/api-management/tyk-pump"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/advanced-configurations/distributed-tracing/open-tracing/zipkin/",
+      "destination": "/api-management/logs-metrics"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/advanced-configurations/distributed-tracing/open-telemetry/otel_jaeger/",
+      "destination": "/api-management/logs-metrics"
+    },
+    {
+      "source": "/product-stack/tyk-pump/release-notes/pump-1.10/",
+      "destination": "/developer-support/release-notes/pump"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/processors/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-dashboard/advanced-configurations/user-management/api-ownership/",
+      "destination": "/api-management/user-management"
+    },
+    {
+      "source": "/plugins/plugin-types/auth-plugins/auth-plugins/",
+      "destination": "/api-management/plugins/plugin-types"
+    },
+    {
+      "source": "/frequently-asked-questions/find-gateway-logging-output/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/product-stack/tyk-dashboard/advanced-configurations/api-categories/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/getting-started/key-concepts/oas-api-definitions/",
+      "destination": "/api-management/gateway-config-tyk-oas"
+    },
+    {
+      "source": "/basic-config-and-security/report-monitor-trigger-events/",
+      "destination": "/api-management/gateway-events"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-mdcb/release-notes/version-2.5/",
+      "destination": "/developer-support/release-notes/mdcb"
+    },
+    {
+      "source": "/advanced-configuration/integrate/",
+      "destination": "/api-management/api-versioning"
+    },
+    {
+      "source": "/product-stack/tyk-dashboard/advanced-configurations/data-storage-configuration/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/getting-started/installation/with-tyk-on-premises/docker/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/troubleshooting/tyk-installation/404-trying-access-tyk-gateway-repo/",
+      "destination": "/developer-support/community"
+    },
+    {
+      "source": "/product-stack/tyk-dashboard/advanced-configurations/analytics/activity-by-endpoint/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/advanced-configuration/manage-multiple-environments/move-keys-between-environments/",
+      "destination": "/api-management/multiple-environments"
+    },
+    {
+      "source": "/plugins/rich-plugins/python/",
+      "destination": "/api-management/plugins/rich-plugins"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/switch/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-dashboard/release-notes/version-5.3/",
+      "destination": "/developer-support/release-notes/dashboard"
+    },
+    {
+      "source": "/tyk-cloud/account-billing/retirement/",
+      "destination": "/tyk-cloud/account-billing"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/release-notes/portal-1.10.0/",
+      "destination": "/developer-support/release-notes/portal"
+    },
+    {
+      "source": "/tyk-stack/tyk-pump/tyk-pump-configuration/graceful-shutdowm/",
+      "destination": "/planning-for-production/ensure-high-availability/graceful-shutdown"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/circuit-breaker-tyk-classic/",
+      "destination": "/planning-for-production/ensure-high-availability/circuit-breakers"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/ignore-middleware/",
+      "destination": "/api-management/traffic-transformation/ignore-authentication"
+    },
+    {
+      "source": "/tyk-stack/tyk-pump/tyk-dash-analytics/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/frequently-asked-questions/no-token-information-dashboard/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/tyk-pump/tyk-pump-configuration/tyk-pump-dashboard-config/",
+      "destination": "/api-management/tyk-pump"
+    },
+    {
+      "source": "/getting-started/tyk-components/identity-broker/",
+      "destination": "/api-management/external-service-integration"
+    },
+    {
+      "source": "/configure/tyk-gateway-configuration-options/",
+      "destination": "/tyk-oss-gateway/configuration"
+    },
+    {
+      "source": "/tyk-configuration-reference/tyk-pump-configuration/datadog/",
+      "destination": "/api-management/tyk-pump"
+    },
+    {
+      "source": "/basic-config-and-security/security/authentication-authorization/physical-key-expiry/",
+      "destination": "/api-management/policies"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/outputs/retry/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/guides/bloblang/advanced/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/tyk-stack/tyk-developer-portal/enterprise-developer-portal/customise-enterprise-portal/full-customisation/templates/",
+      "destination": "/portal/customization/templates"
+    },
+    {
+      "source": "/tyk-configuration-reference/tyk-pump-configuration/tyk-pump-configuration/",
+      "destination": "/api-management/tyk-pump"
+    },
+    {
+      "source": "/tyk-on-prem/installation/redhat-rhel-centos/analytics-pump/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/product-stack/tyk-enterprise-developer-portal/deploy/install-tyk-enterprise-portal/install-portal-using-rpm/",
+      "destination": "/portal/install"
+    },
+    {
+      "source": "/frequently-asked-questions/how-to-connect-to-documentdb/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/plugins/analytics-plugins/",
+      "destination": "/api-management/plugins/plugin-types"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/endpoint-rate-limit-classic/",
+      "destination": "/api-management/rate-limit"
+    },
+    {
+      "source": "/frequently-asked-questions/cloud-classic-virtual-endpoints-not-working/",
+      "destination": "/tyk-cloud/troubleshooting-support"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/advanced-configurations/plugins/golang/loading-go-plugins/",
+      "destination": "/api-management/plugins/golang"
+    },
+    {
+      "source": "/plugins/rich-plugins/python/tyk-python-api-methods/",
+      "destination": "/api-management/plugins/rich-plugins"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/inputs/redis-pubsub/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/do-not-track-tyk-oas/",
+      "destination": "/api-management/logs-metrics"
+    },
+    {
+      "source": "/getting-started/using-oas-definitions/versioning-an-oas-api/",
+      "destination": "/api-management/gateway-config-managing-oas"
+    },
+    {
+      "source": "/basic-config-and-security/security/gateway/",
+      "destination": "/api-management/gateway-config-introduction"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/virtual-endpoint-tyk-oas/",
+      "destination": "/api-management/traffic-transformation/virtual-endpoints"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/endpoint-plugin-tyk-classic/",
+      "destination": "/api-management/plugins/plugin-types"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/inputs/amqp-1/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/scanners/lines/",
+      "destination": "/api-management/stream-config"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/validate-request-tyk-oas/",
+      "destination": "/api-management/traffic-transformation/request-validation"
+    },
+    {
+      "source": "/try-out-tyk/tutorials/create-api/",
+      "destination": "/api-management/gateway-config-managing-classic"
+    },
+    {
+      "source": "/plugins/rich-plugins/id-extractor/",
+      "destination": "/api-management/plugins/plugin-types"
+    },
+    {
+      "source": "/product-stack/tyk-operator/getting-started/quick-start-tcp/",
+      "destination": "/api-management/automations/operator"
+    },
+    {
+      "source": "/developer-support/upgrading-tyk/preparations/upgrade-guidelines/",
+      "destination": "/developer-support/upgrading"
+    },
+    {
+      "source": "/tyk-on-premises/bootstrapper-cli/",
+      "destination": "/tyk-self-managed/install"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/mock-response-tyk-oas/",
+      "destination": "/api-management/traffic-transformation/mock-response"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/guides/bloblang/methods/numbers/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/advanced-configuration/integrate/api-auth-mode/",
+      "destination": "/api-management/api-versioning"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/response-header-tyk-oas/",
+      "destination": "/api-management/traffic-transformation/response-headers"
+    },
+    {
+      "source": "/frequently-asked-questions/clear-api-cache/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/processors/rate-limit/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/apim-best-practice/api-security-best-practice/overview/",
+      "destination": "/api-management/security-best-practices"
+    },
+    {
+      "source": "/plugins/plugin-hub/",
+      "destination": "/api-management/plugins/overview"
+    },
+    {
+      "source": "/plugins/supported-languages/rich-plugins/python/custom-auth-python-tutorial/",
+      "destination": "/api-management/plugins/rich-plugins"
+    },
+    {
+      "source": "/planning-for-production/ensure-high-availability/service-discovery/examples/",
+      "destination": "/planning-for-production/ensure-high-availability/service-discovery"
+    },
+    {
+      "source": "/analytics-and-reporting/geographic-distribution/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/troubleshooting/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/tyk-stack/tyk-pump/tyk-pump-configuration/graph-pump/",
+      "destination": "/api-management/tyk-pump"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/common-configuration/processing-pipelines/",
+      "destination": "/api-management/stream-config"
+    },
+    {
+      "source": "/troubleshooting/tyk-cloud-classic/301-moved-permanently/",
+      "destination": "/tyk-cloud/troubleshooting-support"
+    },
+    {
+      "source": "/security/tls-and-ssl/mutual-tls/",
+      "destination": "/api-management/implement-tls"
+    },
+    {
+      "source": "/advanced-configuration/compose-apis/demo-virtual-endpoint/",
+      "destination": "/api-management/traffic-transformation/virtual-endpoints"
+    },
+    {
+      "source": "/troubleshooting/tyk-multi-cloud/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/validate-request-middleware/",
+      "destination": "/api-management/traffic-transformation/request-validation"
+    },
+    {
+      "source": "/release-notes/mdcb-2.3/",
+      "destination": "/developer-support/release-notes/mdcb"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/do-not-track-tyk-classic/",
+      "destination": "/api-management/logs-metrics"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/middleware/endpoint-plugin/",
+      "destination": "/api-management/plugins/plugin-types"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/outputs/nsq/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/product-stack/tyk-gateway/advanced-configurations/distributed-tracing/distributed-tracing-overview/",
+      "destination": "/api-management/logs-metrics"
+    },
+    {
+      "source": "/advanced-configuration/integrate/3rd-party-identity-providers/ldap/",
+      "destination": "/api-management/external-service-integration"
+    },
+    {
+      "source": "/universal-data-graph/concepts/field_mappings/",
+      "destination": "/api-management/data-graph"
+    },
+    {
+      "source": "/transform-traffic/endpoint-designer/",
+      "destination": "/api-management/dashboard-configuration"
+    },
+    {
+      "source": "/product-stack/tyk-streaming/configuration/inputs/nats/",
+      "destination": "/api-management/event-driven-apis"
+    },
+    {
+      "source": "/troubleshooting/tyk-dashboard/dashboard-not-showing-analytics-data/",
+      "destination": "/api-management/troubleshooting-debugging"
+    },
+    {
+      "source": "/tyk-dashboard/opa-rules/",
+      "destination": "/api-management/dashboard-configuration"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds **1043 trailing-slash redirect entries** to \`docs.json\` to address two categories of SEO issues found in the crawl audit:

  1. **Broken redirects (25 URLs):** URLs with a trailing slash redirect (308) to the without-slash version which then 404s. The without-slash entries are already present in this branch from the previous redirect batch; this PR adds the with-slash counterparts so the trailing-slash URL resolves directly to the correct page.

  2. **Redirect chains too long (1018 URLs):** URLs with a trailing slash create a 2-hop chain — Mintlify strips the slash (308), then the without-slash URL redirects again (308) to the final page. Adding explicit `source/` → `final-destination` entries collapses each chain to a single hop.

## What changed

`docs.json` — appended 1043 `{ "source": "/old/path/", "destination": "/new/path" }` entries.  No content changes.

## Affected URL patterns (broken redirect examples)
- `/tyk-cloud/environments--deployments/*` → current `environments-deployments` equivalents
- `/tyk-cloud/teams--users/*` → `tyk-cloud/teams-users`
- `/tyk-cloud/account--billing/*` → `tyk-cloud/account-billing`
- `/tyk-cloud/troubleshooting--support/*` → `tyk-cloud/troubleshooting-support`
- `/tyk-stack/tyk-identity-broker/getting-started/` → `/tyk-configuration-reference/tyk-identity-broker-configuration`
- `/basic-config-and-security/security/gateway/gateway-api/` → `/tyk-gateway-api`
- `/release-notes/release-4.2/` → `/developer-support/release-notes/archived`

## Test plan
- [ ] Verify a sample of the with-slash URLs (e.g. `https://tyk.io/docs/tyk-cloud/environments--deployments/monitoring/`) redirects directly to the destination in 1 hop after deploy
- [ ] Confirm no existing without-slash redirects were modified (only additions)
- [ ] JSON lint passes (already confirmed locally)