### PR TITLE
[DX-2376] Move Gateway RN "GQL proxyOnly" line item to 5.3.1

### DIFF
--- a/developer-support/release-notes/gateway.mdx
+++ b/developer-support/release-notes/gateway.mdx
@@ -6691,6 +6691,10 @@ In some instances users were noticing gateway panics when using the **Persist GQ
 defined. This issue has been fixed and the gateway will not throw panics in these cases anymore.
 </Accordion>
 
+<Accordion title='Headers for GraphQL headers were not properly forwarded upstream for GQL/UDG subscriptions'>
+Fixed an issue with GraphQL APIs, where [headers](/api-management/graphql#graphql-apis-headers) were not properly forwarded upstream for [GQL/UDG subscriptions](/api-management/graphql#graphql-subscriptions).
+</Accordion>
+
 <Accordion title='Missing GraphQL OTel attributes in spans when requests fail validation'>
 In cases where `detailed_tracing` was set to `false` and the client was sending a malformed request to a GraphQL API,
 the traces were missing GraphQL attributes (operation name, type and document). This has been corrected and debugging
@@ -7613,10 +7617,6 @@ Fixed a memory leak that occurred when enabling the [strict routes option](/tyk-
 
 <Accordion title='High rates of Tyk Gateway reloads were encountered'>
 Fixed a potential performance issue related to high rates of *Tyk Gateway* reloads (when the Gateway is updated due to a change in APIs and/or policies). The gateway uses a timer that ensures there's at least one second between reloads, however in some scenarios this could lead to poor performance (for example overloading Redis). We have introduced a new [configuration option](/tyk-oss-gateway/configuration#reload_interval), `reload_interval` (`TYK_GW_RELOADINTERVAL`), that can be used to adjust the duration between reloads and hence optimize the performance of your Tyk deployment.
-</Accordion>
-
-<Accordion title='Headers for GraphQL headers were not properly forwarded upstream for GQL/UDG subscriptions'>
-Fixed an issue with GraphQL APIs, where [headers](/api-management/graphql#graphql-apis-headers) were not properly forwarded upstream for [GQL/UDG subscriptions](/api-management/graphql#graphql-subscriptions).
 </Accordion>
 
 <Accordion title='Idle upstream connections were incorrectly closed'>


### PR DESCRIPTION
The bug fix for TT-10909 ("GQL proxyOnly does not forward request headers to the upstream") was verified and released as part of the 5.3.x release line (specifically version 5.3.1).