### PR TITLE
Fix multiple H1 tags (demote duplicate in-content H1s to H2)

### DIFF
--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -44,6 +44,11 @@ jobs:
         echo "🔒 Checking for insecure http:// links to tyk.io..."
         python scripts/validate_mintlify_docs.py . --check-insecure-links --links-only
 
+    - name: Check for multiple H1 tags
+      run: |
+        echo "🔠 Checking for pages with multiple H1 tags..."
+        python scripts/validate_mintlify_docs.py . --check-multiple-h1 --links-only
+
     - name: Check for relative markdown links
       run: |
         echo "Checking for relative markdown links (must start with /)..."

--- a/ai-management/ai-studio/chat-interface.mdx
+++ b/ai-management/ai-studio/chat-interface.mdx
@@ -11,7 +11,7 @@ sidebarTitle: "Chat Interface"
 | :------------- | :---------------------- |
 | [Community](/ai-management/ai-studio/overview#community-edition) & [Enterprise](/ai-management/ai-studio/overview#enterprise-edition) | Self-Managed, Hybrid |
 
-# Chat Interface
+## Chat Interface
 
 Tyk AI Studio's Chat Interface provides a secure and interactive environment for users to engage with Large Language Models (LLMs), leveraging integrated tools and data sources. It serves as the primary front-end for conversational AI interactions within the platform.
 

--- a/ai-management/ai-studio/plugins/object-hooks.mdx
+++ b/ai-management/ai-studio/plugins/object-hooks.mdx
@@ -11,7 +11,7 @@ sidebarTitle: "Object Hooks"
 | :------------- | :---------------------- |
 | [Community](/ai-management/ai-studio/overview#community-edition) & [Enterprise](/ai-management/ai-studio/overview#enterprise-edition) | Self-Managed, Hybrid |
 
-# Object Hooks Plugin Guide
+## Object Hooks Plugin Guide
 
 
 ```mermaid

--- a/scripts/validate_mintlify_docs.py
+++ b/scripts/validate_mintlify_docs.py
@@ -1032,6 +1032,73 @@ def check_insecure_links(base_dir: str) -> Dict[str, List[Tuple[str, str]]]:
     return results
 
 
+_FENCE_OPEN = re.compile(r'^\s*(`{3,}|~{3,})(.*)$')
+_FENCE_CLOSE = re.compile(r'^\s*(`{3,}|~{3,})\s*$')
+
+
+def find_content_h1s(mdx_content: str) -> List[str]:
+    """Return in-content H1s (markdown '# ' and raw <h1>) that render outside code and comments.
+
+    Uses CommonMark fence rules (a closing fence is bare, same char, length >= opening) so
+    that '#' shell comments and <h1> examples inside code blocks - including blocks that show
+    other ``` fences - are not miscounted. Inline code spans are also stripped.
+    """
+    text = re.sub(r'\{/\*.*?\*/\}', '', mdx_content, flags=re.DOTALL)
+    text = re.sub(r'<!--.*?-->', '', text, flags=re.DOTALL)
+
+    found: List[str] = []
+    in_fence = False
+    fence_char = ''
+    fence_len = 0
+    for line in text.splitlines():
+        if in_fence:
+            close = _FENCE_CLOSE.match(line)
+            if close and close.group(1)[0] == fence_char and len(close.group(1)) >= fence_len:
+                in_fence = False
+            continue
+        opener = _FENCE_OPEN.match(line)
+        if opener:
+            in_fence = True
+            fence_char = opener.group(1)[0]
+            fence_len = len(opener.group(1))
+            continue
+        if re.match(r'^# \S', line):
+            found.append(line.strip())
+        if re.search(r'<h1[ >]', re.sub(r'`[^`]*`', '', line), re.IGNORECASE):
+            found.append('<h1>')
+    return found
+
+
+def has_frontmatter_title(mdx_content: str) -> bool:
+    """True if the MDX frontmatter defines a non-empty title (which Mintlify renders as the H1)."""
+    m = re.match(r'^---\n(.*?)\n---', mdx_content, re.DOTALL)
+    return bool(m and re.search(r'^title:\s*\S', m.group(1), re.MULTILINE))
+
+
+def check_multiple_h1(base_dir: str) -> Dict[str, Tuple[int, List[str]]]:
+    """Flag pages that render more than one H1.
+
+    In Mintlify the frontmatter title is the page H1, so any in-content H1 (or two or more
+    when there is no title) means the page has multiple H1s. Snippet fragments are skipped.
+    Returns {file_path: (total_h1_count, [in_content_h1s])}.
+    """
+    results: Dict[str, Tuple[int, List[str]]] = {}
+    for file_path in glob.glob(os.path.join(base_dir, '**', '*.mdx'), recursive=True):
+        norm = file_path.replace(os.sep, '/')
+        if norm.startswith('snippets/') or '/snippets/' in norm:
+            continue
+        try:
+            with open(file_path, 'r', encoding='utf-8') as fh:
+                content = fh.read()
+        except (OSError, UnicodeDecodeError):
+            continue
+        h1s = find_content_h1s(content)
+        total = len(h1s) + (1 if has_frontmatter_title(content) else 0)
+        if total > 1:
+            results[file_path] = (total, h1s)
+    return results
+
+
 def main():
     parser = argparse.ArgumentParser(description='Check for broken links in converted documentation')
     parser.add_argument('directory', nargs='?', default='converted', help='Directory to scan (default: converted)')
@@ -1051,6 +1118,8 @@ def main():
                         help='Flag internal links that hit a 3xx redirect (trailing slashes and links to docs.json redirect sources)')
     parser.add_argument('--check-insecure-links', action='store_true',
                         help='Flag insecure http:// links to first-party (tyk.io) domains that should use https')
+    parser.add_argument('--check-multiple-h1', action='store_true',
+                        help='Flag pages that render more than one H1 (frontmatter title + in-content # / <h1>)')
 
     args = parser.parse_args()
 
@@ -1082,6 +1151,11 @@ def main():
     insecure_links = None
     if args.check_insecure_links:
         insecure_links = check_insecure_links(args.directory)
+
+    # Check for pages with multiple H1 tags
+    multiple_h1 = None
+    if args.check_multiple_h1:
+        multiple_h1 = check_multiple_h1(args.directory)
     
     # Report results
     print(f"\n{'='*60}")
@@ -1272,6 +1346,17 @@ def main():
         else:
             print("✅ No insecure first-party http:// links found!")
 
+    if args.check_multiple_h1:
+        if multiple_h1:
+            print(f"\n🔠 PAGES WITH MULTIPLE H1 TAGS ({len(multiple_h1)}):")
+            for file_path, (total, h1s) in sorted(multiple_h1.items()):
+                print(f"\n  📄 {file_path}  (H1 count: {total})")
+                for h in h1s:
+                    print(f"    - {h}")
+            print("\n  Fix: the frontmatter title is the page H1 - demote in-content '# ' headings to '##' (or wrap example <h1> in a code block).")
+        else:
+            print("✅ No pages with multiple H1 tags found!")
+
     if validation_results and 'error' not in validation_results:
         total_issues = (len(validation_results['self_referencing_redirects']) +
                        len(validation_results['navigation_redirect_conflicts']) +
@@ -1291,6 +1376,7 @@ def main():
     has_broken_anchors = bool(broken_anchors) and args.check_anchors
     has_redirecting_links = bool(redirecting_links) and args.check_redirecting_links
     has_insecure_links = bool(insecure_links) and args.check_insecure_links
+    has_multiple_h1 = bool(multiple_h1) and args.check_multiple_h1
     has_broken_external = bool(external_results) and any(
         not result['accessible']
         for results in external_results.values()
@@ -1303,7 +1389,7 @@ def main():
                             validation_results['missing_navigation_files'] or
                             validation_results['missing_redirect_destinations']))
 
-    return 1 if (has_broken_links or has_broken_images or has_broken_anchors or has_broken_external or has_validation_issues or has_redirecting_links or has_insecure_links) else 0
+    return 1 if (has_broken_links or has_broken_images or has_broken_anchors or has_broken_external or has_validation_issues or has_redirecting_links or has_insecure_links or has_multiple_h1) else 0
 
 if __name__ == '__main__':
     exit(main())

--- a/tyk-components.mdx
+++ b/tyk-components.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Tyk Components"
 
 import { ResponsiveGrid } from '/snippets/ResponsiveGrid.mdx';
 
-# Understanding Tyk’s API Management Components
+## Understanding Tyk’s API Management Components
 
 Tyk offers a full ecosystem of API management tools, supporting every stage of the API lifecycle—from development and deployment to monitoring and scaling. With Tyk’s components, teams can seamlessly integrate, secure, and scale APIs across different environments, facilitating robust and reliable API operations.
 
@@ -216,7 +216,7 @@ Tyk’s components create a unified API management ecosystem, covering all aspec
 - **Unified Access**: UDG and Tyk Streams unify API Management by enabling seamless, multi-protocol data integration and delivery.
 - **Kubernetes Deployment**: Tyk Helm Charts simplifies deployment of Tyk on Kubernetes.
 
-# Conclusion
+## Conclusion
 
 Now that you’ve been introduced to the Tyk suite, you have a strong foundation in understanding how each component fits into a complete API management ecosystem. Whether you’re ready to start deploying APIs, securing them, or scaling across multiple environments, Tyk provides the tools and flexibility to bring your API projects to life.
 


### PR DESCRIPTION
## Problem

SEO audit flagged pages rendering with more than one `<h1>`. In Mintlify the frontmatter `title:` is the page H1, so any `# ` heading in the body becomes a second/third H1.

## Fix (3 files with genuine live duplicate H1s)

Demote the in-content H1s to `##` (title remains the sole H1; all content preserved):

| File | Demoted heading(s) |
|---|---|
| `tyk-components.mdx` | `# Understanding Tyk's API Management Components`, `# Conclusion` |
| `ai-management/ai-studio/chat-interface.mdx` | `# Chat Interface` |
| `ai-management/ai-studio/plugins/object-hooks.mdx` | `# Object Hooks Plugin Guide` |

Verified with a code-fence-aware check: each of these now has **0** in-content H1s (only the title H1).

## Audited pages deliberately NOT changed

These were flagged but have **no live duplicate H1** in current source:

- `api-management/plugins/javascript` — the "Forbidden" H1 is example output of a **403 error page** inside a ```` ```html ```` block; the crawl row even shows a transient `403 Forbidden` title. Inert.
- `portal/customization/pages`, `portal/customization/templates` — the `<h1>{{ .page.Title }}` / `<h1>{{ .post.Title }}` etc. are inside fenced ```` ```html/go ```` template examples. Inert.
- `ai-management/ai-studio/plugins/studio-ui` — the `<h1>…Dashboard</h1>` are inside ```` ```javascript ```` examples. Inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)