### PR TITLE
Update portal.mdx to recommend 1.17.2 or later when upgrading

### DIFF
--- a/developer-support/release-notes/portal.mdx
+++ b/developer-support/release-notes/portal.mdx
@@ -91,7 +91,7 @@ There are no deprecations in this release.
 If you are upgrading to 1.17.2, please follow the detailed [upgrade instructions](#upgrading-tyk).
 
 <Note>
-**If you are upgrading Tyk Dashboard to v5.13.0, we strongly recommend that you upgrade to Developer Portal v1.17.2 at the same time.**
+**If you are upgrading Tyk Dashboard to v5.13.0, we strongly recommend that you upgrade to Developer Portal v1.17.2 or later at the same time.**
 
 Tyk Dashboard v5.13.0 introduces [MCP Proxy](/ai-management/mcp-gateway/managing-proxies) support. Products granting access to MCP Proxies are not currently supported from Developer Portal.
 


### PR DESCRIPTION
Since 1.17.1 and 1.17.2 contain a critical environment variable regression, I've change the comment in 1.17.2's release notes to include it or later versions.