### PR TITLE
Update dashboard.mdx to recommend EDP 1.17.3 rather than 1.17.2

### DIFF
--- a/developer-support/release-notes/dashboard.mdx
+++ b/developer-support/release-notes/dashboard.mdx
@@ -69,7 +69,7 @@ Strict validation can be disabled, if required for existing Policies with incomp
 |        | Operator v1.4.0   | Operator v0.17 |
 |        | Sync v2.1.8       | Sync v2.1.1 |
 |        | Helm Chart v5.2.0   | Helm all versions |
-|        | EDP v1.17.2        | EDP all versions |
+|        | EDP v1.17.3        | EDP all versions |
 |        | Pump v1.15.0       | Pump all versions |
 |        | TIB (if using standalone) v1.7.1 | TIB all versions |
 
@@ -81,7 +81,7 @@ To use MCP Gateway features introduced in this release, upgrade the following Ty
 - **MDCB v2.11.0**: MCP analytics routing in distributed deployments
 - **Operator v1.4.0**: MCP Proxy management via Kubernetes CRDs
 - **Sync v2.1.7**: MCP Proxy support in dump and sync operations
-- **Developer Portal v1.17.2**: filters all MCP Proxy policies from the developer catalogue; v1.17.1 provides a partial mitigation covering policies with TBAC or per-primitive rate limiting configured
+- **Developer Portal v1.17.2 and later**: filter all MCP Proxy policies from the developer catalogue; v1.17.1 provides a partial mitigation covering policies with TBAC or per-primitive rate limiting configured
 </Note>
 
 ##### 3rd Party Dependencies & Tools
@@ -111,7 +111,7 @@ If you are upgrading to 5.13.0, please follow the detailed [upgrade instructions
 If your deployment uses MCP Gateway, additional component ordering applies:
 - In distributed deployments, MDCB 2.11.0 must be deployed before Gateway and Dashboard.
 - Tyk Operator 1.4.0 must be deployed after Gateway and Dashboard are running.
-- Portal 1.17.2 should be deployed before any MCP Proxy policies are created in Dashboard.
+- Portal 1.17.3 or later should be deployed before any MCP Proxy policies are created in Dashboard.
 
 See [MCP Gateway upgrade considerations](/developer-support/upgrading#mcp-upgrade-considerations) for the full sequence.
 
@@ -1684,7 +1684,7 @@ There are no breaking changes in this release.
 |         | Operator v1.4.0 | Operator v0.17 |
 |         | Sync v2.1.8     | Sync v2.1.1 |
 |         | Helm Chart v5.2.0 | Helm all versions |
-|         | EDP v1.17.2     | EDP all versions |
+|         | EDP v1.17.3     | EDP all versions |
 |         | Pump v1.15.0    | Pump all versions |
 |         | TIB (if using standalone) v1.7.1 | TIB all versions |
 
@@ -4453,7 +4453,7 @@ There are no breaking changes in this release.
 |         | Operator v1.4.0  | Operator v0.17 |
 |         | Sync v2.1.6    | Sync v2.1.0 |
 |         | Helm Chart v5.2  | Helm all versions |
-| | EDP v1.17.2 | EDP all versions |
+| | EDP v1.17.3 | EDP all versions |
 | | Pump v1.13.3| Pump all versions |
 | | TIB (if using standalone) v1.7.1 | TIB all versions |
 


### PR DESCRIPTION
EDP 1.17.1 and 1.17.2 contained a critical regression so I've changed the recommended version to 1.17.3 which does not have this issue