### PR TITLE
[IA] Sidebar title fixes and navigation group tidy-up

### DIFF
--- a/advanced-configuration/websockets.mdx
+++ b/advanced-configuration/websockets.mdx
@@ -2,7 +2,7 @@
 title: "Websockets"
 description: "Learn how to configure and use WebSockets with Tyk"
 keywords: "websockets, Other Protocol"
-sidebarTitle: "Websockets"
+sidebarTitle: "WebSockets"
 ---
 
 As from Tyk gateway v2.2, Tyk supports transparent WebSocket connection upgrades. To enable this feature, set the `enable_websockets` value to `true` in your `tyk.conf` file.

--- a/ai-management/ai-studio/call-settings.mdx
+++ b/ai-management/ai-studio/call-settings.mdx
@@ -2,6 +2,7 @@
 title: "Manage LLM Call Settings in Tyk AI Studio"
 description: "How to configure default call settings for Large Language Models (LLMs) in Tyk AI Studio, including parameters like temperature, max tokens, and more."
 keywords: "AI Studio, AI Management, LLMs, Large Language Models, LLM Call Settings"
+sidebarTitle: "Call Settings"
 ---
 
 ## Availability

--- a/ai-management/ai-studio/call-settings.mdx
+++ b/ai-management/ai-studio/call-settings.mdx
@@ -2,7 +2,7 @@
 title: "Manage LLM Call Settings in Tyk AI Studio"
 description: "How to configure default call settings for Large Language Models (LLMs) in Tyk AI Studio, including parameters like temperature, max tokens, and more."
 keywords: "AI Studio, AI Management, LLMs, Large Language Models, LLM Call Settings"
-sidebarTitle: "Call Settings"
+sidebarTitle: "LLM Call Settings"
 ---
 
 ## Availability

--- a/ai-management/ai-studio/manage-edge-gateway.mdx
+++ b/ai-management/ai-studio/manage-edge-gateway.mdx
@@ -2,7 +2,7 @@
 title: "Manage Edge Gateway for Tyk AI Studio"
 description: "Understand how to manage and monitor Edge Gateways in Tyk AI Studio, including configuration synchronization and admin actions."
 keywords: "AI Studio, AI Management, Edge Gateway, Configuration Sync"
-sidebarTitle: "Edge Gateway"
+sidebarTitle: "Manage Edge Gateway"
 ---
 
 ## Availability

--- a/ai-management/mcp-gateway/managing-proxies.mdx
+++ b/ai-management/mcp-gateway/managing-proxies.mdx
@@ -2,7 +2,7 @@
 title: "Managing MCP proxies using the Dashboard"
 description: "How to create, view, edit, and delete MCP proxies using the Tyk Dashboard UI, covering the proxy list, the creation wizard, the Settings and Primitives tabs, proxy-level middleware, per-primitive middleware, the full definition editor, and permissions."
 keywords: "MCP, Model Context Protocol, MCP proxy, create MCP, update MCP, delete MCP, Tyk Dashboard, MCP wizard, listen path, permissions, MCP middleware, primitives tab, settings tab"
-sidebarTitle: "Create and Manage (Dashboard)"
+sidebarTitle: "Manage MCP Proxies"
 ---
 
 The **MCP** section of the Tyk Dashboard is the central registry of all MCP servers in your organization. Each proxy entry records the upstream server address, the listen path clients use to connect, the tools and resources the server exposes, and the access policies that govern it. Teams have a single authoritative place to see what MCP capabilities are available, onboard new servers, and control who can access them.

--- a/ai-management/mcp-gateway/mcp-proxy-definitions.mdx
+++ b/ai-management/mcp-gateway/mcp-proxy-definitions.mdx
@@ -2,7 +2,7 @@
 title: "MCP OAS definition"
 description: "How Tyk represents MCP servers as OpenAPI definitions: the OpenAPI specification structure, MCP primitives and JSON-RPC methods, and the x-tyk-api-gateway extensions that configure gateway behavior for MCP traffic."
 keywords: "MCP, Model Context Protocol, MCP API definition, x-tyk-api-gateway, JSON-RPC, primitives, tools, resources, prompts, operations, Tyk OAS, Streamable HTTP"
-sidebarTitle: "MCP OAS definition"
+sidebarTitle: "MCP Proxy Definition"
 ---
 
 An MCP proxy definition is the configuration object that tells Tyk how to proxy an MCP server. It is built on the **[Tyk OAS API definition](/api-management/gateway-config-tyk-oas)** format (an OpenAPI 3.0 document extended with the `x-tyk-api-gateway` vendor extension) and adds the MCP-specific structures that allow Tyk to inspect JSON-RPC traffic and apply middleware at the method and primitive level. This page explains the structure of an MCP API definition, how MCP concepts (primitives, methods, operations) map to it, and which parts of the extension are specific to MCP.

--- a/api-management/gateway-config-managing-classic.mdx
+++ b/api-management/gateway-config-managing-classic.mdx
@@ -2,7 +2,7 @@
 title: "Managing Tyk Classic API Definition"
 description: "A guide to managing Tyk Classic API definitions"
 keywords: "Tyk Classic API, Create, Update, Import, API Key, Security Policy"
-sidebarTitle: "Tyk Classic APIs"
+sidebarTitle: "Working with Tyk Classic"
 ---
 
 import { ButtonLeft } from '/snippets/ButtonLeft.mdx';

--- a/api-management/gateway-config-managing-oas.mdx
+++ b/api-management/gateway-config-managing-oas.mdx
@@ -2,7 +2,7 @@
 title: "Working with Tyk OAS APIs"
 description: "A guide to working with and managing Tyk OAS API definitions"
 keywords: "Tyk OAS API, Create, Update, Import, Export, Versioning, API Key, Security Policy"
-sidebarTitle: "Tyk OAS APIs"
+sidebarTitle: "Working with Tyk OAS"
 ---
 
 ## Overview

--- a/api-management/gateway-config-tyk-classic.mdx
+++ b/api-management/gateway-config-tyk-classic.mdx
@@ -2,7 +2,7 @@
 title: "Tyk Classic API Definition"
 description: "Learn how to configure Tyk Classic API Definitions for your API management needs"
 keywords: "Gateway, Configuration, Tyk Classic, Tyk Classic API Definition, Tyk Classic API Definition Object"
-sidebarTitle: "Tyk Classic"
+sidebarTitle: "Tyk Classic Reference"
 ---
 
 import ApiDefGraphql from '/snippets/api-def-graphql.mdx';

--- a/api-management/gateway-config-tyk-oas.mdx
+++ b/api-management/gateway-config-tyk-oas.mdx
@@ -2,7 +2,7 @@
 title: "Tyk OAS"
 description: "Learn how to configure Tyk OAS API Definitions to manage your APIs using the OpenAPI Specification"
 keywords: "Gateway, Configuration, Tyk OAS, Tyk OAS API Definition, Tyk OAS API Definition Object"
-sidebarTitle: "Tyk OAS"
+sidebarTitle: "Tyk OAS Reference"
 ---
 
 import XTykGateway from '/snippets/x-tyk-gateway.mdx';

--- a/api-management/plugins/advance-config.mdx
+++ b/api-management/plugins/advance-config.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Custom Plugins Advance Configuration"
 description: "Explore advanced configuration options for custom plugins in Tyk, including CICD automation, OpenTelemetry instrumentation, and gRPC server health checks in Kubernetes."
-sidebarTitle: "Advance Configuration"
+sidebarTitle: "Advanced Configuration"
 ---
 
 ## CICD - Automating Your Plugin Builds

--- a/api-management/plugins/javascript.mdx
+++ b/api-management/plugins/javascript.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Javascript Plugins"
 description: "Learn how to script custom middleware, dynamic event handlers, and virtual endpoints in Tyk using JavaScript"
-sidebarTitle: "Javscript Plugins"
+sidebarTitle: "JavaScript Plugins"
 ---
 
 ## Introduction

--- a/api-management/traffic-transformation/request-headers.mdx
+++ b/api-management/traffic-transformation/request-headers.mdx
@@ -2,7 +2,7 @@
 title: "Request Headers"
 description: "Learn how to modify API request headers"
 keywords: "Traffic Transformation, Request Headers"
-sidebarTitle: "Request Headers "
+sidebarTitle: "Request Headers"
 ---
 
 ## Overview

--- a/api-management/traffic-transformation/request-method.mdx
+++ b/api-management/traffic-transformation/request-method.mdx
@@ -2,7 +2,7 @@
 title: "Request Method"
 description: "Learn how to modify the API request method"
 keywords: "Traffic Transformation, Request Method"
-sidebarTitle: "Request Method "
+sidebarTitle: "Request Method"
 ---
 
 ## Overview

--- a/developer-support/release-types/early-access-feature.mdx
+++ b/developer-support/release-types/early-access-feature.mdx
@@ -2,7 +2,7 @@
 title: "Early Access Features"
 description: "Explain what Early Access Features means and what to expect"
 keywords: "Release FAQ, Early access\""
-sidebarTitle: "Early access feature"
+sidebarTitle: "Early Access Feature"
 ---
 
 Early Access features are fully tested Tyk features. However, please note that your access to these features is on an "early access" basis and as a result they may not support the functionality of similar features or functionality that you would otherwise expect. 

--- a/docs.json
+++ b/docs.json
@@ -158,8 +158,7 @@
                       "planning-for-production/monitoring/tyk-components",
                       "tyk-configuration-reference/redis-cluster-sentinel",
                       "planning-for-production/ensure-high-availability/graceful-shutdown",
-                      "deployment-and-operations/container-runtimes",
-                      "api-management/performance-monitoring"
+                      "deployment-and-operations/container-runtimes"
                     ]
                   }
                 ]
@@ -468,14 +467,9 @@
             ]
           },
           {
-            "group": "Use Cases",
-            "pages": [
-              "use-cases/open-banking"
-            ]
-          },
-          {
             "group": "Guides",
             "pages": [
+              "use-cases/open-banking",
               "api-management/enable-audit-logs-dashboard",
               "api-management/collecting-gateway-logs-otel-kubernetes",
               "api-management/air-gapped-deployment"
@@ -499,28 +493,28 @@
                 "pages": [
                   "tyk-apis",
                   {
-                    "group": "Gateway",
+                    "group": "Gateway API",
                     "pages": [
                       "tyk-gateway-api"
                     ],
                     "openapi": "swagger/gateway-swagger.yml"
                   },
                   {
-                    "group": "Dashboard",
+                    "group": "Dashboard API",
                     "pages": [
                       "tyk-dashboard-api"
                     ],
                     "openapi": "swagger/dashboard-swagger.yml"
                   },
                   {
-                    "group": "Dashboard Admin",
+                    "group": "Dashboard Admin API",
                     "pages": [
                       "dashboard-admin-api"
                     ],
                     "openapi": "swagger/dashboard-admin-swagger.yml"
                   },
                   {
-                    "group": "MDCB",
+                    "group": "MDCB API",
                     "pages": [
                       "tyk-mdcb-api"
                     ],
@@ -774,7 +768,7 @@
         "tab": "AI Management",
         "groups": [
           {
-            "group": "General",
+            "group": "Overview",
             "pages": [
               "ai-management/overview"
             ]
@@ -801,7 +795,7 @@
               },
               "ai-management/mcp-gateway/faq",
               {
-                "group": "How-to guides",
+                "group": "Guides",
                 "pages": [
                   "ai-management/mcp-gateway/how-to-proxy-remote-mcp",
                   "ai-management/mcp-gateway/how-to-mcp-rbac",
@@ -954,7 +948,7 @@
                     ]
                   },
                   {
-                    "group": "API Documentation",
+                    "group": "AI Studio API",
                     "pages": [
                       "ai-management/ai-studio/ai-studio-swagger"
                     ],
@@ -1114,7 +1108,7 @@
             "blank": true
           },
           {
-            "label": "\u00a9 Tyk Technologies 2025",
+            "label": "© Tyk Technologies 2025",
             "href": "https://tyk.io/terms-conditions/",
             "blank": true
           },


### PR DESCRIPTION
## What

Mechanical navigation quick wins from the full-docs IA review. No content changes - only sidebar titles (page frontmatter) and `docs.json` group labels/placement.

### Sidebar title fixes

| Page | Before | After |
|---|---|---|
| `api-management/plugins/javascript` | Javscript Plugins | JavaScript Plugins |
| `api-management/plugins/advance-config` | Advance Configuration | Advanced Configuration |
| `api-management/traffic-transformation/request-method` | `Request Method ` (trailing space) | Request Method |
| `api-management/traffic-transformation/request-headers` | `Request Headers ` (trailing space) | Request Headers |
| `developer-support/release-types/early-access-feature` | Early access feature | Early Access Feature |
| `advanced-configuration/websockets` | Websockets | WebSockets |
| `ai-management/ai-studio/manage-edge-gateway` | Edge Gateway (duplicate label in tab) | Manage Edge Gateway |
| `ai-management/mcp-gateway/managing-proxies` | Create and Manage (Dashboard) | Manage MCP Proxies |
| `ai-management/mcp-gateway/mcp-proxy-definitions` | MCP OAS definition | MCP Proxy Definition |
| `ai-management/ai-studio/call-settings` | (none - long page title shown) | Call Settings |
| `api-management/gateway-config-tyk-oas` | Tyk OAS | Tyk OAS Reference |
| `api-management/gateway-config-managing-oas` | Tyk OAS APIs | Working with Tyk OAS |
| `api-management/gateway-config-tyk-classic` | Tyk Classic | Tyk Classic Reference |
| `api-management/gateway-config-managing-classic` | Tyk Classic APIs | Working with Tyk Classic |

The API Definitions renames fix the hardest-to-scan pair in the sidebar: "Tyk OAS" vs "Tyk OAS APIs" gave no hint which was the reference and which the how-to.

### Navigation group changes (docs.json)

- Removed duplicate nav entry: `api-management/performance-monitoring` appeared under both *Deploy Tyk > Tyk Self Managed > Configuration* and *Observe APIs*; kept the Observe APIs entry.
- Folded the single-page *Use Cases* group (Open Banking) into *Guides*.
- AI Management: *General* renamed to *Overview*; *How-to guides* renamed to *Guides* (consistency with other tabs).
- OpenAPI reference group labels standardized to `<Component> API`: Gateway API, Dashboard API, Dashboard Admin API, MDCB API, AI Studio API.

## Validation

- `validate_mintlify_docs.py --check-anchors --links-only` passes (no broken links/anchors).
- All 407 nav entries resolve to files; no duplicate nav entries remain.

## Note

`docs.json` will conflict with #2331 (Platform Management restructure) on the Dashboard/Dashboard Admin OpenAPI group labels - whichever merges second needs a trivial rebase.