### PR TITLE
[DX-2207] Add Pagination section to Developer Portal API overview

### DIFF
--- a/product-stack/tyk-enterprise-developer-portal/api-documentation/tyk-edp-api.mdx
+++ b/product-stack/tyk-enterprise-developer-portal/api-documentation/tyk-edp-api.mdx
@@ -27,7 +27,7 @@ users of the portal in the profile page.
 
 ## Pagination
 
-Most list endpoints in the Tyk Developer Portal Management API return their results in pages. Control pagination with the following query parameters:
+List endpoints in the Tyk Developer Portal Management API return their results in pages. Control pagination with the following query parameters:
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|

--- a/product-stack/tyk-enterprise-developer-portal/api-documentation/tyk-edp-api.mdx
+++ b/product-stack/tyk-enterprise-developer-portal/api-documentation/tyk-edp-api.mdx
@@ -24,3 +24,27 @@ such as billings, CRMs, ITSM systems and other software.
 
 This API requires an admin authorisation token that is available for admin
 users of the portal in the profile page.
+
+## Pagination
+
+Most list endpoints in the Tyk Developer Portal Management API return their results in pages. Control pagination with the following query parameters:
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `page` | The page number to return. Pages are numbered from 1. | `1` |
+| `per_page` | The number of items to return per page. | `20` |
+| `limit` | The maximum number of records to return for the request. When set, it overrides `per_page` as the number of records returned. | Value of `per_page` |
+
+For example, to return the second page of products with 50 products per page:
+
+```
+GET /products?page=2&per_page=50
+```
+
+To page through an entire collection, start at `page=1` and increase `page` until a response returns fewer items than `per_page`, or an empty list.
+
+<Note>
+The Tyk Developer Portal Management API uses `page` for the page number. The Tyk Dashboard API uses `p` for the same purpose, so check the parameter name when you move between the two APIs.
+</Note>
+
+A few endpoints that return fixed collections, such as listing themes, return all results and ignore these parameters.

--- a/product-stack/tyk-enterprise-developer-portal/api-documentation/tyk-edp-api.mdx
+++ b/product-stack/tyk-enterprise-developer-portal/api-documentation/tyk-edp-api.mdx
@@ -33,7 +33,7 @@ Most list endpoints in the Tyk Developer Portal Management API return their resu
 |-----------|-------------|---------|
 | `page` | The page number to return. Pages are numbered from 1. | `1` |
 | `per_page` | The number of items to return per page. | `20` |
-| `limit` | The maximum number of records to return for the request. When set, it overrides `per_page` as the number of records returned. | Value of `per_page` |
+| `limit` | The maximum number of records to return for this request. It overrides the row count only, not the page offset, so use `per_page` for paging rather than `limit`. | Value of `per_page` |
 
 For example, to return the second page of products with 50 products per page:
 

--- a/swagger/enterprise-developer-portal-swagger.yaml
+++ b/swagger/enterprise-developer-portal-swagger.yaml
@@ -73,6 +73,10 @@ paths:
     get:
       description: List all access requests that exist in the portal
       operationId: list-access-requests
+      parameters:
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           content:
@@ -208,7 +212,10 @@ paths:
     get:
       description: List all developer applications
       operationId: list-apps
-      parameters: []
+      parameters:
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           content:
@@ -347,6 +354,9 @@ paths:
           schema:
             type: integer
             example: 1
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           content:
@@ -454,6 +464,9 @@ paths:
           schema:
             type: integer
             example: 1
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           content:
@@ -636,7 +649,10 @@ paths:
     get:
       description: List all catalogues that exist in the portal
       operationId: list-catalogues
-      parameters: []
+      parameters:
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           content:
@@ -767,6 +783,9 @@ paths:
           schema:
             type: integer
             example: 1
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           content:
@@ -911,7 +930,10 @@ paths:
     get:
       description: List all developer organisations
       operationId: list-organisations
-      parameters: []
+      parameters:
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           content:
@@ -1044,6 +1066,9 @@ paths:
           schema:
             type: integer
             example: 2
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           content:
@@ -1195,7 +1220,10 @@ paths:
     get:
       description: List all content pages. This doesn't include blog posts and API Products
       operationId: list-pages
-      parameters: []
+      parameters:
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           content:
@@ -1328,6 +1356,9 @@ paths:
           schema:
             type: integer
             example: 1
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           content:
@@ -1492,6 +1523,10 @@ paths:
     get:
       description: List all plans that exist in the portal
       operationId: list-plans
+      parameters:
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           content:
@@ -1631,26 +1666,9 @@ paths:
       description: List all products available in the portal
       operationId: list-products
       parameters:
-        - name: limit
-          in: query
-          required: false
-          description: Maximum number of records to return for this request. Defaults to per_page query parameter value
-          schema:
-            type: integer
-        - name: per_page
-          in: query
-          required: false
-          description: Items per page. Defaults to the resource-specific page count if configured, otherwise 20
-          schema:
-            type: integer
-            default: 20
-        - name: page
-          in: query
-          required: false
-          description: Page number. Defaults to 1 when omitted
-          schema:
-            type: integer
-            default: 1
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           content:
@@ -1865,6 +1883,9 @@ paths:
           schema:
             type: integer
             example: 1
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           content:
@@ -1889,6 +1910,9 @@ paths:
           schema:
             type: integer
             example: 1
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           content:
@@ -2026,6 +2050,9 @@ paths:
           schema:
             type: integer
             example: 1
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           content:
@@ -2328,6 +2355,9 @@ paths:
           schema:
             type: integer
             example: 1
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           content:
@@ -2459,6 +2489,9 @@ paths:
           schema:
             type: integer
             example: 1
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           content:
@@ -2772,7 +2805,10 @@ paths:
     get:
       description: List all tags
       operationId: list-tags
-      parameters: []
+      parameters:
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           content:
@@ -2897,7 +2933,10 @@ paths:
     get:
       description: List all API Providers connected to this portal instance
       operationId: list-providers
-      parameters: []
+      parameters:
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           content:
@@ -3210,7 +3249,10 @@ paths:
     get:
       description: List all admin users and developers
       operationId: list-users
-      parameters: []
+      parameters:
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           content:
@@ -3362,6 +3404,9 @@ paths:
           schema:
             type: integer
             example: 1
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           content:
@@ -3492,7 +3537,10 @@ paths:
     get:
       description: List all extended models for custom attributes
       operationId: list-extended-attributes
-      parameters: []
+      parameters:
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           content:
@@ -3547,6 +3595,9 @@ paths:
           schema:
             type: integer
             example: 1
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           content:
@@ -3713,6 +3764,9 @@ paths:
           schema:
             type: integer
             example: 1
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           content:
@@ -3809,7 +3863,10 @@ paths:
     get:
       description: List all OAuth2.0 providers
       operationId: list-oauth-providers
-      parameters: []
+      parameters:
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           content:
@@ -3991,6 +4048,9 @@ paths:
           schema:
             type: integer
             example: 1
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           content:
@@ -4206,6 +4266,10 @@ paths:
       operationId: list-webhooks
       tags:
         - Webhooks
+      parameters:
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           description: A list of webhooks.
@@ -4335,6 +4399,9 @@ paths:
           required: true
           schema:
             type: string
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           description: A list of headers for the specified webhook.
@@ -4490,7 +4557,10 @@ paths:
     get:
       description: List all posts in the portal.
       operationId: list-posts
-      parameters: []
+      parameters:
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           description: OK
@@ -4616,6 +4686,9 @@ paths:
             type: integer
             example: 1
           description: UID of a post
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           description: OK
@@ -4711,6 +4784,9 @@ paths:
             type: integer
             example: 1
           description: UID of a post
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           description: OK
@@ -4798,6 +4874,7 @@ paths:
   /apps/{app_id}/custom_credentials:
     get:
       summary: List Custom Credentials
+      operationId: list-custom-credentials
       description: Retrieve a list of custom credentials for a specific application.
       tags:
         - Applications and credentials
@@ -4808,6 +4885,9 @@ paths:
           description: The ID of the application.
           schema:
             type: string
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         '200':
           description: A list of custom credentials
@@ -4954,6 +5034,10 @@ paths:
     get:
       description: List all SSO profiles
       operationId: list-sso-profiles
+      parameters:
+        - $ref: "#/components/parameters/PaginationLimitParam"
+        - $ref: "#/components/parameters/PaginationPerPageParam"
+        - $ref: "#/components/parameters/PaginationPageParam"
       responses:
         "200":
           content:
@@ -5604,6 +5688,30 @@ paths:
       tags:
         - API documentation for API Products
 components:
+  parameters:
+    PaginationLimitParam:
+      name: limit
+      in: query
+      required: false
+      description: Maximum number of records to return for this request. Defaults to per_page query parameter value
+      schema:
+        type: integer
+    PaginationPerPageParam:
+      name: per_page
+      in: query
+      required: false
+      description: Items per page. Defaults to the resource-specific page count if configured, otherwise 20
+      schema:
+        type: integer
+        default: 20
+    PaginationPageParam:
+      name: page
+      in: query
+      required: false
+      description: Page number. Defaults to 1 when omitted
+      schema:
+        type: integer
+        default: 1
   schemas:
     Product-APIDetail-index:
       properties:

--- a/swagger/enterprise-developer-portal-swagger.yaml
+++ b/swagger/enterprise-developer-portal-swagger.yaml
@@ -5693,7 +5693,7 @@ components:
       name: limit
       in: query
       required: false
-      description: Maximum number of records to return for this request. Defaults to per_page query parameter value
+      description: Maximum number of records to return for this request. Overrides the row count only, not the page offset (which is always based on per_page), so use per_page for pagination rather than combining limit with page. Defaults to the per_page value.
       schema:
         type: integer
     PaginationPerPageParam:


### PR DESCRIPTION
## What

Adds a **Pagination** section to the Tyk Developer Portal API overview page (`product-stack/tyk-enterprise-developer-portal/api-documentation/tyk-edp-api.mdx`), immediately after the Authentication section.

## Why

Jira: https://tyktech.atlassian.net/browse/DX-2207

The Developer Portal Management API paginates its list endpoints with `page` / `per_page` / `limit`, but this was not explained anywhere at the page level. The section adds a parameter table, an example request, and a callout clarifying that the Developer Portal API uses `page` while the Tyk Dashboard API uses `p` (the original source of confusion in the ticket).

## Related

Companion PR documenting these parameters per-endpoint in the Developer Portal OpenAPI spec: TykTechnologies/portal#1919