### PR TITLE
[DX-2380]: Fix & guard Mintlify OpenAPI page-slug collisions (Dashboard API keys render Admin endpoint)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -90,6 +90,7 @@ jobs:
         run: |
           python -m pip install --upgrade 'pip>=23.0,<25'
           # Add any additional dependencies if needed
+          pip install 'pyyaml>=6.0,<7' 'ruamel.yaml>=0.18,<0.19'
 
       - name: Read branches config
         id: config
@@ -288,6 +289,16 @@ jobs:
           echo "🧩 Running canonical URL update script..."
           python3 scripts/add-canonical-urls/index.py || { echo "❌ Canonical script failed"; exit 1; }
           echo "✅ Canonical URL update completed."
+
+      - name: Disambiguate OpenAPI page slugs (DX-2380)
+        run: |
+          echo "🧭 Disambiguating Mintlify OpenAPI page-slug collisions in the merged output..."
+          echo "Mintlify builds every API page URL as /api-reference/<tag>/<summary>; identical"
+          echo "tag+summary across specs collide and silently render the wrong endpoint."
+          python3 scripts/disambiguate_openapi_slugs.py .
+          echo "🔎 Verifying no collisions remain (this hard-fails the deploy if any slip through)..."
+          python3 scripts/validate_openapi_slugs.py .
+          echo "✅ OpenAPI page slugs are collision-free."
 
       - name: Verify output
         run: |

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -23,11 +23,19 @@ jobs:
       run: |
         python -m pip install --upgrade 'pip>=23.0,<25'
         pip install 'requests>=2.31.0,<3'
-        
+        pip install 'pyyaml>=6.0,<7'
+
     - name: Validate documentation
       run: |
         echo "🔍 Running documentation validation..."
         python scripts/validate_mintlify_docs.py . --validate-redirects --verbose
+
+    - name: Check for OpenAPI page-slug collisions (informational)
+      run: |
+        echo "🧭 Checking for Mintlify OpenAPI page-slug collisions across specs (DX-2380)..."
+        echo "These are auto-resolved at deploy time by disambiguate_openapi_slugs.py; this is an"
+        echo "early heads-up so spec authors can give colliding operations unique tags/summaries."
+        python scripts/validate_openapi_slugs.py . --warn-only
 
     - name: Check anchor fragments
       run: |

--- a/scripts/disambiguate_openapi_slugs.py
+++ b/scripts/disambiguate_openapi_slugs.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""
+Disambiguate Mintlify OpenAPI page-slug collisions by suffixing operation summaries.
+
+WHY: Mintlify builds every API reference page URL as
+        /api-reference/<slug(first-tag)>/<slug(summary or operationId)>
+in one global, flat namespace shared by ALL specs in docs.json. When two operations
+(in the same or different specs) produce the same slug, Mintlify keeps one at the clean
+URL and silently suffixes/drops the rest — so a page can render the wrong endpoint.
+This is DX-2380 (Dashboard "Create a key" rendered the Admin /admin/org/keys endpoint).
+
+WHAT THIS DOES: detects every colliding slug, keeps the first occurrence (discovery order:
+docs.json spec order, then path, then method) at its clean slug, and appends an incrementing
+integer to the *summary* of each subsequent colliding operation ("Create a key" -> "Create a
+key 2"). That makes every slug unique (create-a-key, create-a-key-2, create-a-key-3 ...), so
+every API group's nav links to its own correct page. Summaries (not tags) are suffixed so the
+tag-based navigation grouping is preserved.
+
+WHERE THIS RUNS: as a deploy-time step in .github/workflows/deploy-docs.yml, AFTER the docs
+merger and BEFORE the deployment PR is created. It rewrites the swagger that gets deployed to
+the `production` branch only — it never edits the auto-synced swagger/*.yml on `main`, so it is
+compatible with the "do not edit auto-generated files" rule and re-applies on every deploy.
+
+Editing is surgical: ruamel.yaml is used only to locate each target operation's `summary:`
+line; the raw file text is then rewritten one line at a time so nothing else in the spec
+changes (no reformatting, no re-wrapping of descriptions, no block-scalar normalisation).
+"""
+import argparse
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+
+from ruamel.yaml import YAML
+
+HTTP_METHODS = {"get", "post", "put", "delete", "patch", "options", "head", "trace"}
+
+
+def slugify(text):
+    text = (text or "").strip().lower()
+    return re.sub(r"[^a-z0-9]+", "-", text).strip("-")
+
+
+def find_openapi_specs(docs_json_path):
+    with open(docs_json_path, encoding="utf-8") as f:
+        config = json.load(f)
+    specs = []
+
+    def walk(node):
+        if isinstance(node, dict):
+            spec = node.get("openapi")
+            if isinstance(spec, str) and spec not in specs:
+                specs.append(spec)
+            for value in node.values():
+                walk(value)
+        elif isinstance(node, list):
+            for value in node:
+                walk(value)
+
+    walk(config)
+    return specs
+
+
+def label_of(operation):
+    return operation.get("summary") or operation.get("operationId") or ""
+
+
+def slug_of(operation):
+    tag = (operation.get("tags") or ["untagged"])[0]
+    return f"{slugify(tag)}/{slugify(label_of(operation))}"
+
+
+def rewrite_summary_line(line, new_value):
+    """Rewrite a single 'summary: ...' line to new_value, preserving indentation and quote style.
+
+    Returns the line unchanged if it isn't a simple single-line summary (e.g. a block scalar),
+    so we never corrupt multi-line values.
+    """
+    newline = "\n" if line.endswith("\n") else ""
+    body = line[:-1] if newline else line
+    m = re.match(r"^(\s*summary:[ \t]+)(.*)$", body)
+    if not m:
+        return line
+    prefix, raw = m.group(1), m.group(2).rstrip()
+    if raw in (">", "|", "") or raw[0] in (">", "|", "&", "*"):
+        return line  # block scalar / anchor — leave it alone
+    if len(raw) >= 2 and raw[0] == "'" and raw[-1] == "'":
+        rebuilt = "'" + new_value.replace("'", "''") + "'"
+    elif len(raw) >= 2 and raw[0] == '"' and raw[-1] == '"':
+        rebuilt = '"' + new_value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+    else:
+        rebuilt = new_value
+    return prefix + rebuilt + newline
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("directory", nargs="?", default=".", help="Repo root containing docs.json (default: .)")
+    parser.add_argument("--dry-run", action="store_true", help="Report changes without writing files")
+    args = parser.parse_args()
+
+    docs_json_path = os.path.join(args.directory, "docs.json")
+    if not os.path.isfile(docs_json_path):
+        print(f"ERROR: docs.json not found in {args.directory}")
+        return 2
+
+    yaml = YAML()
+    yaml.preserve_quotes = True
+
+    specs = find_openapi_specs(docs_json_path)
+    # discovery order: list of (spec_rel, path, method, operation)
+    operations = []
+    for spec_rel in specs:
+        spec_path = os.path.join(args.directory, spec_rel)
+        if not os.path.isfile(spec_path):
+            print(f"  WARNING: spec referenced in docs.json not found: {spec_rel}")
+            continue
+        with open(spec_path, encoding="utf-8") as f:
+            doc = yaml.load(f)
+        for path, methods in (doc.get("paths") or {}).items():
+            if not isinstance(methods, dict):
+                continue
+            for method, operation in methods.items():
+                if method.lower() in HTTP_METHODS and isinstance(operation, dict):
+                    operations.append((spec_rel, path, method, operation))
+
+    groups = defaultdict(list)
+    for entry in operations:
+        groups[slug_of(entry[3])].append(entry)
+
+    # Decide the new summary for each colliding operation (keep entries[0] clean).
+    # edits_by_spec[spec_rel] = list of (line_index, new_summary_value)
+    edits_by_spec = defaultdict(list)
+    changed = []
+    for slug, entries in groups.items():
+        if len(entries) < 2:
+            continue
+        for n, (spec_rel, path, method, operation) in enumerate(entries[1:], start=2):
+            old_label = label_of(operation)
+            new_label = f"{old_label} {n}".strip()
+            lc = operation.lc.data.get("summary")
+            if lc is None:
+                print(f"  WARNING: cannot locate 'summary:' line for {method.upper()} {path} "
+                      f"in {spec_rel} (operationId-only); skipping.")
+                continue
+            value_line = lc[2]  # 0-indexed line of the summary value
+            edits_by_spec[spec_rel].append((value_line, new_label))
+            changed.append((spec_rel, method.upper(), path, slug, f"{slugify((operation.get('tags') or ['untagged'])[0])}/{slugify(new_label)}"))
+
+    if not changed:
+        print("✅ No colliding slugs — nothing to disambiguate.")
+        return 0
+
+    print(f"Disambiguated {len(changed)} colliding operation(s) across {len(edits_by_spec)} spec(s):")
+    for spec_rel, method, path, old_slug, new_slug in changed:
+        print(f"  [{spec_rel}] {method:6} {path}")
+        print(f"      /api-reference/{old_slug}  ->  /api-reference/{new_slug}")
+
+    if args.dry_run:
+        print("\n(--dry-run: no files written)")
+        return 0
+
+    for spec_rel, edits in edits_by_spec.items():
+        spec_path = os.path.join(args.directory, spec_rel)
+        with open(spec_path, encoding="utf-8") as f:
+            lines = f.readlines()
+        for value_line, new_value in edits:
+            lines[value_line] = rewrite_summary_line(lines[value_line], new_value)
+        with open(spec_path, "w", encoding="utf-8") as f:
+            f.writelines(lines)
+    print(f"\nWrote {len(edits_by_spec)} updated spec file(s) (only summary lines changed).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_openapi_slugs.py
+++ b/scripts/validate_openapi_slugs.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""
+Detect Mintlify OpenAPI page-slug collisions across all specs referenced in docs.json.
+
+Mintlify auto-generates one API reference page per OpenAPI operation. The page URL is
+derived from the operation's *first tag* and its *summary* (falling back to operationId),
+slugified as:  api-reference/<slug(tag)>/<slug(summary)>
+
+All specs share a single flat /api-reference/ namespace, so two operations in *different*
+specs that share a tag (case-insensitively) AND a summary collide to the same URL. At build
+time one silently overwrites the other, so a page can render the wrong endpoint.
+
+This is the root cause of DX-2380: the Dashboard API "Create a key." (tag "Keys") and the
+Dashboard Admin API "Create a key." (tag "keys") both resolve to api-reference/keys/create-a-key.
+
+Exit code 1 if any cross-spec collision is found (CI-failing). Within-spec duplicates are
+reported as warnings (Mintlify resolves them, but they signal latent ambiguity).
+"""
+import argparse
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+
+import yaml
+
+HTTP_METHODS = {"get", "post", "put", "delete", "patch", "options", "head", "trace"}
+
+
+def slugify(text):
+    """Mirror Mintlify's slug rule: lowercase, non-alphanumerics to hyphens, trim."""
+    text = (text or "").strip().lower()
+    text = re.sub(r"[^a-z0-9]+", "-", text)
+    return text.strip("-")
+
+
+def find_openapi_specs(docs_json_path):
+    """Walk docs.json and return every distinct value of an "openapi" key (in order)."""
+    with open(docs_json_path, encoding="utf-8") as f:
+        config = json.load(f)
+
+    specs = []
+
+    def walk(node):
+        if isinstance(node, dict):
+            spec = node.get("openapi")
+            if isinstance(spec, str) and spec not in specs:
+                specs.append(spec)
+            for value in node.values():
+                walk(value)
+        elif isinstance(node, list):
+            for value in node:
+                walk(value)
+
+    walk(config)
+    return specs
+
+
+def operation_slug(tag, operation):
+    """api-reference page slug Mintlify assigns: <slug(tag)>/<slug(summary or operationId)>."""
+    label = operation.get("summary") or operation.get("operationId") or ""
+    return f"{slugify(tag)}/{slugify(label)}"
+
+
+def collect_slugs(root, specs):
+    """Return slug -> list of {spec, method, path, tag, summary} occurrences."""
+    slug_map = defaultdict(list)
+    for spec_rel in specs:
+        spec_path = os.path.join(root, spec_rel)
+        if not os.path.isfile(spec_path):
+            print(f"  WARNING: spec referenced in docs.json not found: {spec_rel}")
+            continue
+        with open(spec_path, encoding="utf-8") as f:
+            spec = yaml.safe_load(f)
+        for path, methods in (spec.get("paths") or {}).items():
+            if not isinstance(methods, dict):
+                continue
+            for method, operation in methods.items():
+                if method.lower() not in HTTP_METHODS or not isinstance(operation, dict):
+                    continue
+                # Mintlify groups an operation under its FIRST tag (that drives the URL).
+                tags = operation.get("tags") or ["untagged"]
+                tag = tags[0]
+                slug_map[operation_slug(tag, operation)].append({
+                    "spec": spec_rel,
+                    "method": method.upper(),
+                    "path": path,
+                    "tag": tag,
+                    "summary": operation.get("summary") or operation.get("operationId") or "",
+                })
+    return slug_map
+
+
+def load_baseline(path):
+    """Load a baseline file of known/accepted colliding slugs (one slug per line, # comments ok)."""
+    if not path or not os.path.isfile(path):
+        return set()
+    allowed = set()
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.split("#", 1)[0].strip()
+            if line:
+                allowed.add(line.lstrip("/").removeprefix("api-reference/"))
+    return allowed
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("directory", nargs="?", default=".", help="Repo root containing docs.json (default: .)")
+    parser.add_argument("--baseline", metavar="FILE",
+                        help="File of already-known colliding slugs to ignore (ratchet: fail only on NEW collisions)")
+    parser.add_argument("--write-baseline", metavar="FILE",
+                        help="Write all current cross-spec collisions to FILE as a baseline and exit 0")
+    parser.add_argument("--warn-only", action="store_true",
+                        help="Report collisions but always exit 0 (for staged rollout)")
+    args = parser.parse_args()
+
+    docs_json_path = os.path.join(args.directory, "docs.json")
+    if not os.path.isfile(docs_json_path):
+        print(f"ERROR: docs.json not found in {args.directory}")
+        return 2
+
+    specs = find_openapi_specs(docs_json_path)
+    print(f"Found {len(specs)} OpenAPI spec(s) referenced in docs.json:")
+    for s in specs:
+        print(f"  - {s}")
+
+    slug_map = collect_slugs(args.directory, specs)
+
+    cross_spec = {}
+    within_spec = {}
+    for slug, occ in slug_map.items():
+        distinct_specs = {o["spec"] for o in occ}
+        if len(distinct_specs) > 1:
+            cross_spec[slug] = occ
+        elif len(occ) > 1:
+            within_spec[slug] = occ
+
+    if args.write_baseline:
+        with open(args.write_baseline, "w", encoding="utf-8") as f:
+            f.write("# Known OpenAPI page-slug collisions accepted as a baseline (DX-2380).\n")
+            f.write("# New collisions outside this list fail CI. Drive this list down to zero.\n")
+            for slug in sorted(cross_spec):
+                f.write(f"api-reference/{slug}\n")
+        print(f"Wrote {len(cross_spec)} baseline collision(s) to {args.write_baseline}")
+        return 0
+
+    baseline = load_baseline(args.baseline)
+    new_collisions = {s: o for s, o in cross_spec.items() if s not in baseline}
+    grandfathered = len(cross_spec) - len(new_collisions)
+
+    if within_spec:
+        print(f"\n⚠️  {len(within_spec)} within-spec duplicate slug(s) (Mintlify resolves these, but they are ambiguous):")
+        for slug, occ in sorted(within_spec.items()):
+            print(f"  /api-reference/{slug}")
+            for o in occ:
+                print(f"      {o['method']:6} {o['path']}  (tag: {o['tag']}, summary: {o['summary']!r})")
+
+    if grandfathered:
+        print(f"\nℹ️  {grandfathered} cross-spec collision(s) ignored via baseline ({args.baseline}).")
+
+    report = new_collisions if baseline else cross_spec
+    if report:
+        kind = "NEW " if baseline else ""
+        print(f"\n❌ {len(report)} {kind}cross-spec slug collision(s) — these silently overwrite each other at build time:")
+        for slug, occ in sorted(report.items()):
+            print(f"\n  /api-reference/{slug}")
+            for o in occ:
+                print(f"      [{o['spec']}]  {o['method']:6} {o['path']}  (tag: {o['tag']}, summary: {o['summary']!r})")
+        print("\nFix: make the tag and/or summary unique per spec in the SOURCE OpenAPI spec")
+        print("(e.g. tag the Admin spec's key operations 'Org Keys', or rename summaries like")
+        print("'Create an organisation key.'). Tags differing only by case still collide.")
+        print("Do NOT edit swagger/*.yml directly in tyk-docs — they are auto-synced and overwritten.")
+        if args.warn_only:
+            print("\n(--warn-only: not failing the build)")
+            return 0
+        return 1
+
+    print("\n✅ No cross-spec OpenAPI page-slug collisions found"
+          + (" beyond the baseline." if baseline else "."))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What & why

Fixes **[DX-2380](https://tyktech.atlassian.net/browse/DX-2380)** — the Dashboard API Key pages (`api-reference/keys/create-a-key`, `get-key-details`, `update-key`) render the **Dashboard Admin** endpoint `/admin/org/keys/{keyId}` instead of `/api/keys/{keyId}`.

### Root cause
Mintlify auto-generates every API reference page from the OpenAPI specs in `docs.json` and builds each URL as `/api-reference/{slug(first-tag)}/{slug(summary)}` in **one global, flat namespace shared by all specs** (there is no `gateway`/`dashboard`/`admin` segment — confirmed: `api-reference` does not appear in `docs.json`, and all 738 API URLs in the live sitemap are flat).

The key operations in different specs produce **identical slugs** because their tags slugify the same (`Keys` vs `keys`) and their summaries are byte-identical:

| Slug | Specs colliding |
|---|---|
| `keys/create-a-key` | Gateway (`/tyk/keys` ×2), Dashboard (`/api/keys`), Admin (`/admin/org/keys`) |
| `keys/get-key-details` | Dashboard, Admin |
| `keys/update-key` | Gateway, Dashboard, Admin |
| `keys/delete-key`, `keys/list-keys-by-api` | Dashboard, Admin |

Mintlify keeps one operation at the clean URL and silently suffixes/drops the rest (you can see both `keys/create-a-key` **and** `keys/create-a-key-1` live in the sitemap). Which one wins is build-order dependent, so the Dashboard "Keys" nav lands on the Admin page.

This is **systemic**: the detector finds **33 cross-spec + 12 within-spec collisions** today (keys, users, oauth, apis, organisations, single-sign-on, mcp-proxies, plus EDP↔AI-Studio on catalogues/tags/sso-profiles).

## Approach

`swagger/*.yml` is auto-synced from source repos and must not be edited here (per `CLAUDE.md`), so the fix runs at **deploy time** against the production-bound merged output — it never touches the source specs on `main`, and re-applies on every deploy.

- **`scripts/validate_openapi_slugs.py`** — parses `docs.json`, enumerates every spec's operations, computes the Mintlify slug, and reports cross-spec collisions (hard-fail; `--warn-only` and `--baseline` modes available).
- **`scripts/disambiguate_openapi_slugs.py`** — keeps the first occurrence of each slug clean and appends an incrementing integer to the **summary** of subsequent colliding operations (`Create a key.` → `Create a key. 2`), so every operation gets a unique slug. Edits are **surgical line rewrites** (only `summary:` value lines change; descriptions/structure untouched).
- **`deploy-docs.yml`** — runs the disambiguator on the merged tree (after the docs merger + canonical-URL step), then hard-fail verifies. Verified locally: **33 → 0 collisions**.
- **`validate-docs.yml`** — warn-only collision report on PRs, so spec authors get an early heads-up.

## Notes / follow-ups
- The integer suffix makes the secondary page title read e.g. "Create a key. 2". The durable upstream fix is to give colliding operations **unique tags/summaries in the source specs** (tyk-analytics for dashboard/admin, tyk for gateway) — tracked as a follow-up; this PR stops the user-facing breakage now and prevents regressions.
- No source swagger is modified in this PR (only `scripts/` + workflows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DX-2380]: https://tyktech.atlassian.net/browse/DX-2380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ