### PR TITLE
[DX-2383] Promote storage options to h3 headers

### DIFF
--- a/tyk-configuration-reference/kv-store.mdx
+++ b/tyk-configuration-reference/kv-store.mdx
@@ -56,12 +56,12 @@ HashiCorp [Consul](https://www.consul.io) is a service networking solution that 
 [Vault](https://vaultproject.io) from Hashicorp is a tool for securely accessing secrets. It provides a unified interface to any secret while providing tight access control and recording a detailed audit log. Tyk Gateway can use Vault to manage and retrieve sensitive secrets such as API keys and passwords.
 - to retrieve the value assigned to a `KEY` in Vault you will use `vault://KEY` or `$secret_vault.KEY` notation depending on the [location](#how-to-access-the-externally-stored-data) of the reference
 
-**Tyk Gateway config file**
+### Tyk Gateway config file
 
 The `secrets` section in the [Tyk Gateway configuration file](/tyk-oss-gateway/configuration#secrets) allows you to store settings that are specific to a single Tyk Gateway instance. This is useful for storing instance-specific configuration to be injected into API middleware or if you prefer using configuration files.
 - to retrieve the value assigned to a `KEY` in the `secrets` config you will use `secrets://KEY` or `$secret_conf.KEY` notation depending on the [location](/tyk-oss-gateway/configuration#secrets) of the reference
 
-**Environment variables**
+### Environment variables
 
 Tyk Gateway can access data declared in environment variables. This is a simple and straightforward way to manage secrets, especially in containerised environments like Docker or Kubernetes.
 - if you want to set the local "secrets" section (equivalent to the `secrets` section in the [Gateway config file](#how-to-access-the-externally-stored-data)) using environment variables, you should use the following notation: `TYK_GW_SECRETS=key:value,key2:value2`


### PR DESCRIPTION
Only Consul and Vault options were displayed as h3 headers, env vars and Tyk config secrets were only bold headers and so not visible in the menu.