### PR TITLE
TT-17611: document IAM auth for cloud-managed Redis

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -157,6 +157,7 @@
                       "tyk-configuration-reference/kv-store",
                       "planning-for-production/monitoring/tyk-components",
                       "tyk-configuration-reference/redis-cluster-sentinel",
+                      "tyk-configuration-reference/redis-iam-auth",
                       "planning-for-production/ensure-high-availability/graceful-shutdown",
                       "deployment-and-operations/container-runtimes"
                     ]

--- a/planning-for-production/database-settings.mdx
+++ b/planning-for-production/database-settings.mdx
@@ -19,8 +19,13 @@ Please consult the [data storage configuration](/api-management/dashboard-config
 ## Redis
 
 **Supported Versions**
-- Tyk 5.3 and later supports Redis 6.2.x, 7.0.x, and 7.2.x
-- Tyk 5.2.x and earlier supports Redis 6.0.x and Redis 6.2.x only.
+
+Tyk supports Redis and, as a drop-in alternative, Valkey. For the authoritative list of supported Redis versions by Tyk release, see [Redis version compatibility](/tyk-self-managed/install#redis).
+
+- Redis: from Tyk 5.0.x, Redis 6.2.x and 7.x (including 7.4.x from Tyk 5.9). Tyk 5.2.x and earlier supports Redis 6.0.x and 6.2.x only.
+- Valkey: 7.2.x, 8.0.x, and 8.1.x, supported for fresh environments. Migration from Redis to Valkey is not supported.
+
+For cloud-managed Redis or Valkey using IAM access tokens instead of a static password, see [IAM Authentication for Cloud-Managed Redis](/tyk-configuration-reference/redis-iam-auth).
 
 
 **Split out Your Databases**
@@ -69,6 +74,11 @@ You must ensure that Redis is persisted, or at least in a configuration where it
 **Redis Encryption**
 
 Redis supports [SSL/TLS encryption](https://redis.io/topics/encryption) from version 6 as an optional feature, enhancing the security of data in transit. To configure TLS or mTLS connections between an application and Redis, consider the following settings in Tyk's configuration files:
+
+<Note>
+If you authenticate to a cloud-managed Redis or Valkey instance with IAM access tokens, enable `use_ssl` as well. See [IAM Authentication for Cloud-Managed Redis](/tyk-configuration-reference/redis-iam-auth).
+</Note>
+
 
 - `storage.use_ssl`: Set this to true to enable TLS encryption for the connection.
 

--- a/tyk-configuration-reference/redis-cluster-sentinel.mdx
+++ b/tyk-configuration-reference/redis-cluster-sentinel.mdx
@@ -16,8 +16,13 @@ Redis Cluster operates differently from a Redis setup where one instance serves 
 
 
 ### Supported Versions
-- Tyk 5.3 supports Redis 6.2.x, 7.0.x, and 7.2.x
-- Tyk 5.2.x and earlier supports Redis 6.0.x and Redis 6.2.x only.
+
+Tyk supports Redis and, as a drop-in alternative, Valkey. For the authoritative list of supported Redis versions by Tyk release, see [Redis version compatibility](/tyk-self-managed/install#redis).
+
+- Redis: from Tyk 5.0.x, Redis 6.2.x and 7.x (including 7.4.x from Tyk 5.9). Tyk 5.2.x and earlier supports Redis 6.0.x and 6.2.x only.
+- Valkey: 7.2.x, 8.0.x, and 8.1.x, supported for fresh environments. Migration from Redis to Valkey is not supported.
+
+To authenticate to a cloud-managed Redis or Valkey instance with IAM access tokens instead of a static password, see [IAM Authentication for Cloud-Managed Redis](/tyk-configuration-reference/redis-iam-auth).
 
 
 ### Redis Cluster and Tyk Gateway 
@@ -205,8 +210,13 @@ Similar to Redis Cluster, our Gateway, Dashboard and Pump all support integratio
 To configure Tyk to work with Redis Sentinel, list your servers under `addrs` and set the master name in your Gateway, Dashboard, Pump and MDCB config. Unlike Redis Cluster, `enable_cluster` should **not** be set.  Indicative config snippets as follows:
 
 ### Supported Versions
-- Tyk 5.3 supports Redis 6.2.x, 7.0.x, and 7.2.x
-- Tyk 5.2.x and earlier supports Redis 6.0.x and Redis 6.2.x only.
+
+Tyk supports Redis and, as a drop-in alternative, Valkey. For the authoritative list of supported Redis versions by Tyk release, see [Redis version compatibility](/tyk-self-managed/install#redis).
+
+- Redis: from Tyk 5.0.x, Redis 6.2.x and 7.x (including 7.4.x from Tyk 5.9). Tyk 5.2.x and earlier supports Redis 6.0.x and 6.2.x only.
+- Valkey: 7.2.x, 8.0.x, and 8.1.x, supported for fresh environments. Migration from Redis to Valkey is not supported.
+
+To authenticate to a cloud-managed Redis or Valkey instance with IAM access tokens instead of a static password, see [IAM Authentication for Cloud-Managed Redis](/tyk-configuration-reference/redis-iam-auth).
 
 
 ### Redis Sentinel and Gateway

--- a/tyk-configuration-reference/redis-iam-auth.mdx
+++ b/tyk-configuration-reference/redis-iam-auth.mdx
@@ -1,0 +1,113 @@
+---
+title: "IAM Authentication for Cloud-Managed Redis"
+description: "Configure Tyk to authenticate to GCP Memorystore for Valkey and Redis Cluster using IAM access tokens instead of a static password."
+keywords: "configuration, redis, valkey, memorystore, iam, gcp, authentication, tyk-gateway"
+sidebarTitle: "Redis IAM Auth"
+---
+
+<Note>
+IAM authentication for cloud-managed Redis is a new capability. Confirm the exact Tyk Gateway release version with the team before publishing this page.
+</Note>
+
+## Overview
+
+Cloud-managed Redis services support authenticating with short-lived Identity and Access Management (IAM) tokens instead of a static password. This removes the need to store a long-lived Redis password in your Tyk configuration: Tyk mints a token from the identity of the workload it runs as, presents it when connecting, and refreshes it automatically before it expires.
+
+Tyk supports IAM authentication for:
+
+- Google Cloud Memorystore for Valkey
+- Google Cloud Memorystore for Redis Cluster
+
+Both use the same mechanism, so a single configuration covers either service. The only difference is the IAM role you grant, which is described below.
+
+<Note>
+Amazon ElastiCache IAM authentication is not yet supported. Use a static password for ElastiCache.
+</Note>
+
+## How It Works
+
+When IAM authentication is enabled, Tyk:
+
+1. Obtains a Google OAuth2 access token from the workload's identity, using Application Default Credentials (ADC).
+2. Connects to the instance and authenticates with the user `default` and the access token as the password.
+3. Caches the token and refreshes it before it expires, so new connections always use a valid token.
+
+Access tokens are valid for approximately one hour. Existing connections continue to work after a token expires; only new connections need a fresh token.
+
+## Prerequisites
+
+### Grant the Connection Role
+
+Grant the identity that Tyk runs as the role that permits connecting to the instance:
+
+- Memorystore for Valkey: `roles/memorystore.dbConnectionUser`
+- Memorystore for Redis Cluster: `roles/redis.dbConnectionUser`
+
+### Provide the Workload Identity
+
+Tyk resolves its identity through Application Default Credentials:
+
+- On Google Kubernetes Engine, enable Workload Identity so the Kubernetes service account maps to a Google service account that holds the connection role.
+- Elsewhere, set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to a service account key file, or run on a Compute Engine instance with an attached service account.
+
+### Enable In-Transit Encryption
+
+Enable in-transit encryption on the instance and set `use_ssl` to `true` in Tyk. IAM authentication does not require Transport Layer Security (TLS), but Google strongly recommends it because the token is sent over the connection. If IAM authentication is enabled while `use_ssl` is `false`, Tyk connects and logs a warning.
+
+## Configuration
+
+Add an `iam_auth` block to the `storage` section of your `tyk.conf`. Leave `username` and `password` empty: they are ignored when IAM authentication is enabled.
+
+```json
+"storage": {
+  "type": "redis",
+  "host": "10.0.0.3",
+  "port": 6379,
+  "enable_cluster": true,
+  "use_ssl": true,
+  "username": "",
+  "password": "",
+  "iam_auth": {
+    "enabled": true,
+    "provider": "gcp"
+  }
+}
+```
+
+Set `enable_cluster` to `true` for Memorystore for Redis Cluster and for Valkey running in cluster mode. Leave it `false` for a standalone Valkey instance.
+
+The same `iam_auth` block applies to the separate cache and analytics storage sections (`cache_storage` and `analytics_storage`) if you use them, so you can enable IAM authentication independently for each store.
+
+### Configuration Options
+
+| Field | Description |
+|-------|-------------|
+| `enabled` | Set to `true` to use IAM authentication for this storage connection. |
+| `provider` | The cloud IAM provider. Currently supported: `gcp`. |
+| `service_account` | Optional. A Google service account to impersonate when minting tokens, instead of the workload's own identity. Leave empty to use Application Default Credentials directly. |
+| `token_refresh_before_expiry` | Optional. How far ahead of expiry to refresh the token, as a Go duration string, for example `5m`. Defaults to `5m`. |
+
+### Impersonating a Service Account
+
+If the workload cannot use the connection-role identity directly, grant the workload's identity permission to impersonate a service account that holds the connection role, then set `service_account`:
+
+```json
+"iam_auth": {
+  "enabled": true,
+  "provider": "gcp",
+  "service_account": "tyk-redis@my-project.iam.gserviceaccount.com"
+}
+```
+
+## Verify the Connection
+
+On startup, Tyk attempts to connect to the configured storage. If IAM authentication succeeds, the gateway logs that it has connected to Redis. If authentication fails, for example because the connection role is missing or the token cannot be minted, Tyk logs a connection error and retries.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|--------------|
+| Connection error mentioning credentials or default credentials | The workload has no resolvable identity. Confirm Workload Identity or `GOOGLE_APPLICATION_CREDENTIALS` is configured. |
+| Authentication is rejected by the server | The identity does not hold the connection role, or holds the wrong one (Valkey and Redis Cluster use different roles). |
+| Connection times out | A network or Private Service Connect issue, not authentication. Confirm Tyk runs inside a network that can reach the instance. |
+| Warning that IAM is enabled without TLS | `use_ssl` is `false`. Enable in-transit encryption on the instance and set `use_ssl` to `true`. |

--- a/tyk-self-managed/install.mdx
+++ b/tyk-self-managed/install.mdx
@@ -58,6 +58,10 @@ See [Database Options](/api-management/dashboard-configuration#supported-databas
 | From 5.0.x to 5.8.x | 6.2.x, 7.x |
 | From 5.9.x onwards | 6.2.x, 7.x, 7.4.x |
 
+Valkey is supported as a drop-in alternative to Redis (7.2.x, 8.0.x, and 8.1.x) for fresh environments. Migration from Redis to Valkey is not supported.
+
+To authenticate to a cloud-managed Redis or Valkey instance, such as Google Cloud Memorystore, with IAM access tokens instead of a static password, see [IAM Authentication for Cloud-Managed Redis](/tyk-configuration-reference/redis-iam-auth).
+
 Visit the [Redis page](/planning-for-production/database-settings#redis) for more info.
 
 ## Recommended Installation: Docker


### PR DESCRIPTION
## What

New configuration reference page: **IAM Authentication for Cloud-Managed Redis** (`tyk-configuration-reference/redis-iam-auth.mdx`), added to the Self-Managed → Configuration nav after the Redis Cluster/Sentinel page.

Documents IAM-based authentication to **GCP Memorystore for Valkey** and **Redis Cluster** using short-lived access tokens instead of a static password. Supports the storage-library and Gateway work in [TT-17611](https://tyktech.atlassian.net/browse/TT-17611) (relates to [TT-16107](https://tyktech.atlassian.net/browse/TT-16107)).

## Contents

- Overview and how it works (ADC token minted from workload identity, used as the AUTH password, cached and refreshed).
- Prerequisites: connection roles (`memorystore.dbConnectionUser` for Valkey, `redis.dbConnectionUser` for Redis Cluster), Workload Identity / `GOOGLE_APPLICATION_CREDENTIALS`, in-transit encryption.
- The `iam_auth` config block, options table, and service-account impersonation.
- Verify and troubleshooting sections.

## Scope and accuracy

- Documents only what is implemented and validated today: **GCP, Tyk Gateway**. Explicit note that ElastiCache IAM is not yet supported.
- Did not touch the auto-generated config-reference pages (the `iam_auth` field docs there come from source struct comments).
- Followed the repo style rules (Title Case headings, American English, no em/en-dashes, full product names).

## Reviewer action needed

- A `<Note>` at the top of the page flags the **release version** as unconfirmed. Replace it with the actual Tyk Gateway release before publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TT-17611]: https://tyktech.atlassian.net/browse/TT-17611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TT-16107]: https://tyktech.atlassian.net/browse/TT-16107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ