### PR TITLE
Remove Security Fixes section from release notes

### DIFF
--- a/developer-support/release-notes/mdcb.mdx
+++ b/developer-support/release-notes/mdcb.mdx
@@ -244,22 +244,6 @@ MDCB now releases memory between updates and only reprocesses what has actually 
 
 </AccordionGroup>
 
-##### Security Fixes
-
-<AccordionGroup>
-
-<Accordion title='Resolved CVEs'>
-
-Addressed the following CVE, providing increased protection against security 
-vulnerabilities, including, but not limited to:
-
-- <a href="https://nvd.nist.gov/vuln/detail/CVE-2026-32286" target="_blank">CVE-2026-32286</a>
-
-</Accordion>
-
-</AccordionGroup>
-
-
 ### 2.9.0 Release Notes
 
 #### Release Date 6 March 2026


### PR DESCRIPTION
Removed the 'Security Fixes' section and related CVE information from the release notes.