### PR TITLE
fix(docs): resolve Multiple H1 tags on 5.6 (tyk-components & portal templates) [SEO audit]

### DIFF
--- a/tyk-components.mdx
+++ b/tyk-components.mdx
@@ -8,7 +8,7 @@ order: 5
 
 import { ResponsiveGrid } from '/snippets/ResponsiveGrid.mdx';
 
-# Understanding Tyk’s API Management Components
+## Understanding Tyk’s API Management Components
 
 Tyk offers a full ecosystem of API management tools, supporting every stage of the API lifecycle—from development and deployment to monitoring and scaling. With Tyk’s components, teams can seamlessly integrate, secure, and scale APIs across different environments, facilitating robust and reliable API operations.
 
@@ -216,7 +216,7 @@ Tyk’s components create a unified API management ecosystem, covering all aspec
 - **Unified Access**: UDG and Tyk Streams unify API Management by enabling seamless, multi-protocol data integration and delivery.
 - **Kubernetes Deployment**: Tyk Helm Charts simplifies deployment of Tyk on Kubernetes.
 
-# Conclusion
+## Conclusion
 
 Now that you’ve been introduced to the Tyk suite, you have a strong foundation in understanding how each component fits into a complete API management ecosystem. Whether you’re ready to start deploying APIs, securing them, or scaling across multiple environments, Tyk provides the tools and flexibility to bring your API projects to life.
 

--- a/tyk-stack/tyk-developer-portal/enterprise-developer-portal/customise-enterprise-portal/full-customisation/templates.mdx
+++ b/tyk-stack/tyk-developer-portal/enterprise-developer-portal/customise-enterprise-portal/full-customisation/templates.mdx
@@ -7,7 +7,7 @@ sidebarTitle: "Templates"
 tags: ['Tyk Developer Portal', 'Enterprise Portal', 'Templates', 'Customization']
 ---
 
-# Overview
+## Overview
 
 Templates are a fundamental component of the Tyk Enterprise Developer Portal, enabling dynamic content generation and
 customization. The portal uses Golang templates to render the live portal views, allowing you to generate dynamic HTML
@@ -47,7 +47,7 @@ Portal templates:
 manipulate and display data.
 - [Email Templates](#email-templates): Information about email-specific templates and their available data.
 
-# Template Data
+## Template Data
 
 This section outlines the Tyk Enterprise Developer Portal templates that have access to specific template data. 
 It's important to note that data availability varies between templates, depending on their context and purpose.
@@ -828,7 +828,7 @@ ReDoc versions are available.
 ```
 </Expandable>
 
-# Global Helper Functions
+## Global Helper Functions
 
 This section provides a detailed overview of the global helper functions available in the Tyk Enterprise Developer
 Portal templates. These functions are accessible across the public and private templates and allow you to perform
@@ -1491,7 +1491,7 @@ Returns the credential type ("oAuth2.0" or "authToken") given the credential.
 ```
 
 
-# Email Templates
+## Email Templates
 
 This section provides a detailed overview of the email template data available in the Tyk Enterprise Developer Portal. 
 The Tyk Enterprise Developer Portal uses a variety of email templates for different purposes, such as user registration


### PR DESCRIPTION
## What
Demotes stray body `#` headings to `##` on two 5.6 pages so each page has a single `<h1>` (the frontmatter title):
- `tyk-components.mdx` — *Understanding…*, *Conclusion*
- `…/full-customisation/templates.mdx` — *Overview*, *Template Data*, *Global Helper Functions*, *Email Templates*

## Why
Flagged by the docs SEO audit under **Multiple H1 tags**. These pages were migrated from the (now-archived) Hugo repo, where the page title is auto-rendered as H1; the body headings authored as `#` created additional `<h1>` tags. Same structure already shipped on `main`/5.8+.

## Scope
Heading-level change only — no content/wording changes. Diff is 6 lines.

> **Jira:** _not created this session per request — to be added before merge._