### PR TITLE
fix(docs): resolve Multiple H1 tags on 5.7 tyk-components [SEO audit]

### DIFF
--- a/tyk-components.mdx
+++ b/tyk-components.mdx
@@ -8,7 +8,7 @@ order: 5
 
 import { ResponsiveGrid } from '/snippets/ResponsiveGrid.mdx';
 
-# Understanding Tyk’s API Management Components
+## Understanding Tyk’s API Management Components
 
 Tyk offers a full ecosystem of API management tools, supporting every stage of the API lifecycle—from development and deployment to monitoring and scaling. With Tyk’s components, teams can seamlessly integrate, secure, and scale APIs across different environments, facilitating robust and reliable API operations.
 
@@ -216,7 +216,7 @@ Tyk’s components create a unified API management ecosystem, covering all aspec
 - **Unified Access**: UDG and Tyk Streams unify API Management by enabling seamless, multi-protocol data integration and delivery.
 - **Kubernetes Deployment**: Tyk Helm Charts simplifies deployment of Tyk on Kubernetes.
 
-# Conclusion
+## Conclusion
 
 Now that you’ve been introduced to the Tyk suite, you have a strong foundation in understanding how each component fits into a complete API management ecosystem. Whether you’re ready to start deploying APIs, securing them, or scaling across multiple environments, Tyk provides the tools and flexibility to bring your API projects to life.
 


### PR DESCRIPTION
### **User description**
## What
Demotes stray body `#` headings (*Understanding…*, *Conclusion*) to `##` on `tyk-components.mdx` so the page has a single `<h1>` (the frontmatter title).

## Why
Flagged by the docs SEO audit under **Multiple H1 tags**. Migrated from the archived Hugo repo; same fix already on `main`/5.8+. Heading-level change only — 2 lines.

> **Jira:** _not created this session per request — to be added before merge._


___

### **PR Type**
Documentation


___

### **Description**
- Demotes duplicate page H1 headings

- Preserves single frontmatter-driven H1

- Improves SEO heading hierarchy


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tyk-components.mdx</strong><dd><code>Demote duplicate H1 documentation headings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-components.mdx

<ul><li>Changes <code>Understanding Tyk’s API Management Components</code> from H1 to H2.<br> <li> Changes <code>Conclusion</code> from H1 to H2.<br> <li> Keeps the document hierarchy aligned with the frontmatter title as the <br>single H1.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/2485/files#diff-94581af69723a441ade247e045e03b56f2d931d961ae15e4fffa7846082a50f2">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

