### PR TITLE
fix(docs): add nofollow to legacy Classic Portal noindex pages on 5.9 [SEO audit]

### DIFF
--- a/configure/outbound-email-configuration.mdx
+++ b/configure/outbound-email-configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Outbound Email Configuration"
 order: 6
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Outbound Email Configuration"
 ---
 

--- a/frequently-asked-questions/add-list-delete-developer-using-api.mdx
+++ b/frequently-asked-questions/add-list-delete-developer-using-api.mdx
@@ -1,7 +1,7 @@
 ---
 title: "How to add, list or delete a developer using the API"
 order: 0
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "How to add, list or delete a developer using the API"
 ---
 

--- a/frequently-asked-questions/alerts-new-developer-key-requests.mdx
+++ b/frequently-asked-questions/alerts-new-developer-key-requests.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Alerts on new developer key requests"
 order: 0
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Alerts on new developer key requests"
 ---
 

--- a/frequently-asked-questions/custom-developer-portal-options.mdx
+++ b/frequently-asked-questions/custom-developer-portal-options.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Custom Developer Portal Options"
 order: 0
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Custom Developer Portal Options"
 ---
 

--- a/getting-started/key-concepts/api-catalogue.mdx
+++ b/getting-started/key-concepts/api-catalogue.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Portal API Catalog"
 order: 90
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Portal API Catalogue"
 ---
 

--- a/getting-started/tutorials/publish-api.mdx
+++ b/getting-started/tutorials/publish-api.mdx
@@ -3,7 +3,7 @@ title: "Publish an API"
 description: "Publishing your API in the Tyk Developer Portal"
 keywords: "Tyk Tutorials, Getting Started, Publish API, Tyk Cloud, Tyk Self-Managed, Developer Portal"
 order: 6
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Publish an API"
 ---
 

--- a/troubleshooting/tyk-dashboard/api-catalogue-not-found-error-developer-portal.mdx
+++ b/troubleshooting/tyk-dashboard/api-catalogue-not-found-error-developer-portal.mdx
@@ -1,7 +1,7 @@
 ---
 title: "“API catalog not found“ error in the Developer Portal"
 order: 5
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "“API catalogue not found“ error in the Developer Portal"
 ---
 

--- a/troubleshooting/tyk-dashboard/cors-issues-on-developer-portal.mdx
+++ b/troubleshooting/tyk-dashboard/cors-issues-on-developer-portal.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CORS issues on developer portal"
 order: 6
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "CORS issues on developer portal"
 ---
 

--- a/troubleshooting/tyk-dashboard/not-found-error-developer-portal.mdx
+++ b/troubleshooting/tyk-dashboard/not-found-error-developer-portal.mdx
@@ -1,7 +1,7 @@
 ---
 title: "“Not Found” error in the Developer Portal"
 order: 5
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "“Not Found“ error in the Developer Portal"
 ---
 

--- a/troubleshooting/tyk-dashboard/receive-csrf-error-developer-portal.mdx
+++ b/troubleshooting/tyk-dashboard/receive-csrf-error-developer-portal.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Receive a CSRF error in the Developer Portal"
 order: 5
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Receive a CSRF error in the Developer Portal"
 ---
 

--- a/tyk-apis/tyk-dashboard-api/manage-key-requests.mdx
+++ b/tyk-apis/tyk-dashboard-api/manage-key-requests.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Manage Key Requests"
 order: 9
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Portal Key Requests"
 ---
 

--- a/tyk-apis/tyk-dashboard-api/portal-policies.mdx
+++ b/tyk-apis/tyk-dashboard-api/portal-policies.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Portal Policies"
 order: 2
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Portal Policies"
 ---
 

--- a/tyk-apis/tyk-portal-api/portal-configuration.mdx
+++ b/tyk-apis/tyk-portal-api/portal-configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Portal Configuration"
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Configuration"
 ---
 

--- a/tyk-apis/tyk-portal-api/portal-developers.mdx
+++ b/tyk-apis/tyk-portal-api/portal-developers.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Portal Developers"
 order: 3
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Developers"
 ---
 

--- a/tyk-apis/tyk-portal-api/portal-documentation.mdx
+++ b/tyk-apis/tyk-portal-api/portal-documentation.mdx
@@ -2,7 +2,7 @@
 title: "API Publishing Endpoints"
 description: "This page details the API endpoint used for publishing APIs to Tyk classic Dev Portal. API platform teams and API owners can use this endpoint to integrate their APIs, making them visible and accessible to developers."
 keywords: "Tyk Classic Portal API Publishing Endpoints, Classic Portal API"
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "API Publishing"
 ---
 

--- a/tyk-apis/tyk-portal-api/portal-keys.mdx
+++ b/tyk-apis/tyk-portal-api/portal-keys.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Portal Keys"
 order: 1
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Key Requests"
 ---
 

--- a/tyk-developer-portal/customise.mdx
+++ b/tyk-developer-portal/customise.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Portal Customization Overview"
 order: 12
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Overview"
 ---
 

--- a/tyk-developer-portal/customise/customize-api-visibility.mdx
+++ b/tyk-developer-portal/customise/customize-api-visibility.mdx
@@ -2,7 +2,7 @@
 title: "Customizing API Visibility"
 description: "A walk through how you can use custom Page Templates to control the visibility of your APIs so it can only be seen by specific group of developers."
 keywords: "customizing EDP, EDP, customizing APIs EDP"
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Customising API Visibility"
 ---
 

--- a/tyk-developer-portal/tyk-portal-classic.mdx
+++ b/tyk-developer-portal/tyk-portal-classic.mdx
@@ -2,7 +2,7 @@
 title: "Tyk Classic Developer Portal"
 keywords: ""
 order: 1
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Overview"
 ---
 

--- a/tyk-developer-portal/tyk-portal-classic/curity-dcr.mdx
+++ b/tyk-developer-portal/tyk-portal-classic/curity-dcr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Step by step guide using Curity"
 order: 4
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Step by step guide using Curity"
 ---
 

--- a/tyk-developer-portal/tyk-portal-classic/customise/changing-the-navigation.mdx
+++ b/tyk-developer-portal/tyk-portal-classic/customise/changing-the-navigation.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Customize the Portal Menus"
 order: 1
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Customise the Portal Menus"
 ---
 

--- a/tyk-developer-portal/tyk-portal-classic/customise/custom-developer-portal.mdx
+++ b/tyk-developer-portal/tyk-portal-classic/customise/custom-developer-portal.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Creating a Custom Developer Portal"
 order: 5
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Creating a Custom Developer Portal"
 ---
 

--- a/tyk-developer-portal/tyk-portal-classic/customise/customise-documentation.mdx
+++ b/tyk-developer-portal/tyk-portal-classic/customise/customise-documentation.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Swap out Swagger UI for ReDoc"
 order: 6
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Swap out Swagger UI for ReDoc"
 ---
 

--- a/tyk-developer-portal/tyk-portal-classic/customise/customising-using-dashboard.mdx
+++ b/tyk-developer-portal/tyk-portal-classic/customise/customising-using-dashboard.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Customize Pages with CSS and JavaScript"
 order: 3
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Customise Pages with CSS and JavaScript"
 ---
 

--- a/tyk-developer-portal/tyk-portal-classic/customise/customize-with-jquery.mdx
+++ b/tyk-developer-portal/tyk-portal-classic/customise/customize-with-jquery.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Customizing using jQuery"
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Customising using jQuery"
 ---
 

--- a/tyk-developer-portal/tyk-portal-classic/customise/developer-meta-data.mdx
+++ b/tyk-developer-portal/tyk-portal-classic/customise/developer-meta-data.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Customize the Developer Signup Form"
 order: 4
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Customise the Developer Signup Form"
 ---
 

--- a/tyk-developer-portal/tyk-portal-classic/developer-profiles.mdx
+++ b/tyk-developer-portal/tyk-portal-classic/developer-profiles.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Developer Profiles"
 order: 2
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Developer Profiles"
 ---
 

--- a/tyk-developer-portal/tyk-portal-classic/dynamic-client-registration.mdx
+++ b/tyk-developer-portal/tyk-portal-classic/dynamic-client-registration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Classic Portal - Dynamic Client Registration"
 order: 3
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Overview"
 ---
 

--- a/tyk-developer-portal/tyk-portal-classic/gluu-dcr.mdx
+++ b/tyk-developer-portal/tyk-portal-classic/gluu-dcr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Step by step guide using Gluu"
 order: 3
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Step by step guide using Gluu"
 ---
 

--- a/tyk-developer-portal/tyk-portal-classic/graphql.mdx
+++ b/tyk-developer-portal/tyk-portal-classic/graphql.mdx
@@ -3,7 +3,7 @@ title: "Developer Portal GraphQL"
 description: "How to publish GraphQL APIs to your Tyk Developer Portal"
 keywords: "GraphQL, Playground, CORS, UDG"
 order: 7
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "GraphQL with Classic Portal"
 ---
 

--- a/tyk-developer-portal/tyk-portal-classic/key-requests.mdx
+++ b/tyk-developer-portal/tyk-portal-classic/key-requests.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Key Requests"
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Key Requests"
 ---
 

--- a/tyk-developer-portal/tyk-portal-classic/keycloak-dcr.mdx
+++ b/tyk-developer-portal/tyk-portal-classic/keycloak-dcr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Step by step guide using Keycloak"
 order: 1
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Step by step guide using Keycloak"
 ---
 

--- a/tyk-developer-portal/tyk-portal-classic/monetise.mdx
+++ b/tyk-developer-portal/tyk-portal-classic/monetise.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Monetize"
 order: 11
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Monetising your APIs"
 ---
 

--- a/tyk-developer-portal/tyk-portal-classic/okta-dcr.mdx
+++ b/tyk-developer-portal/tyk-portal-classic/okta-dcr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Step by step guide using Okta"
 order: 2
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Step by step guide using Okta"
 ---
 

--- a/tyk-developer-portal/tyk-portal-classic/portal-concepts.mdx
+++ b/tyk-developer-portal/tyk-portal-classic/portal-concepts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Portal Concepts"
 order: 1
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Portal Concepts"
 ---
 

--- a/tyk-developer-portal/tyk-portal-classic/portal-events-notifications.mdx
+++ b/tyk-developer-portal/tyk-portal-classic/portal-events-notifications.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Portal events and notifications"
 order: 9
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Events and Notifications"
 ---
 

--- a/tyk-developer-portal/tyk-portal-classic/portal-oauth-clients.mdx
+++ b/tyk-developer-portal/tyk-portal-classic/portal-oauth-clients.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Portal OAuth Clients"
 order: 10
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Portal OAuth Clients"
 ---
 

--- a/tyk-developer-portal/tyk-portal-classic/tyk-portal-classic/customise/customise-with-templates.mdx
+++ b/tyk-developer-portal/tyk-portal-classic/tyk-portal-classic/customise/customise-with-templates.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Customize Page Templates"
 order: 2
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Customise Page Templates"
 ---
 

--- a/tyk-portal-api.mdx
+++ b/tyk-portal-api.mdx
@@ -2,7 +2,7 @@
 title: "Classic Portal API"
 description: "Landing page for the Tyk Classic Portal API documentation"
 keywords: "Tyk Classic Portal API, Classic Portal API"
-noindex: True
+robots: "noindex, nofollow"
 sidebarTitle: "Overview"
 ---
 


### PR DESCRIPTION
## What
Same fix as the `main` branch PR (TykTechnologies/tyk-docs#2498): 39 pages covering the legacy Tyk Classic Portal set `noindex: true` in frontmatter, rendered as bare `noindex` (implicitly "follow"). Switched to `robots: "noindex, nofollow"` so crawlers stop following outbound links and passing link equity through deprecated content.

## Why
Flagged by the docs SEO audit under **Noindex follow page**. Per Sharad: Tyk Classic Portal is legacy and should not appear in search.

> **Jira:** _not created this session per request — to be added before merge._