### PR TITLE
Add missing alt text to swagger API overview images (5.11)

### DIFF
--- a/dashboard-admin-api.mdx
+++ b/dashboard-admin-api.mdx
@@ -7,7 +7,7 @@ sidebarTitle: "Overview"
 
 import { ButtonLeft } from '/snippets/ButtonLeft.mdx';
 
-<img src="https://tyk.io/docs/img/dashboard_admin_swagger_image.png" width="963" height="250" alt=""/>
+<img src="https://tyk.io/docs/img/dashboard_admin_swagger_image.png" width="963" height="250" alt="Tyk Dashboard Admin APIs"/>
 
 <ButtonLeft href="https://raw.githubusercontent.com/TykTechnologies/tyk-docs/refs/heads/production/swagger/nightly/dashboard-admin-swagger.yml" color="green" content="Download Swagger" />
 

--- a/dashboard-admin-api.mdx
+++ b/dashboard-admin-api.mdx
@@ -7,7 +7,7 @@ sidebarTitle: "Overview"
 
 import { ButtonLeft } from '/snippets/ButtonLeft.mdx';
 
-<img src="https://tyk.io/docs/img/dashboard_admin_swagger_image.png" width="963" height="250"/>
+<img src="https://tyk.io/docs/img/dashboard_admin_swagger_image.png" width="963" height="250" alt=""/>
 
 <ButtonLeft href="https://raw.githubusercontent.com/TykTechnologies/tyk-docs/refs/heads/production/swagger/nightly/dashboard-admin-swagger.yml" color="green" content="Download Swagger" />
 

--- a/product-stack/tyk-enterprise-developer-portal/api-documentation/tyk-edp-api.mdx
+++ b/product-stack/tyk-enterprise-developer-portal/api-documentation/tyk-edp-api.mdx
@@ -7,7 +7,7 @@ sidebarTitle: "Overview"
 
 import { ButtonLeft } from '/snippets/ButtonLeft.mdx';
 
-<img src="https://tyk.io/docs/img/developer_portal_swagger_image.png" width="963" height="250"/>
+<img src="https://tyk.io/docs/img/developer_portal_swagger_image.png" width="963" height="250" alt=""/>
 
 <ButtonLeft href="https://raw.githubusercontent.com/TykTechnologies/tyk-docs/refs/heads/production/swagger/nightly/enterprise-developer-portal-swagger.yaml" color="green" content="Download Swagger" />
 

--- a/product-stack/tyk-enterprise-developer-portal/api-documentation/tyk-edp-api.mdx
+++ b/product-stack/tyk-enterprise-developer-portal/api-documentation/tyk-edp-api.mdx
@@ -7,7 +7,7 @@ sidebarTitle: "Overview"
 
 import { ButtonLeft } from '/snippets/ButtonLeft.mdx';
 
-<img src="https://tyk.io/docs/img/developer_portal_swagger_image.png" width="963" height="250" alt=""/>
+<img src="https://tyk.io/docs/img/developer_portal_swagger_image.png" width="963" height="250" alt="Tyk Developer Portal"/>
 
 <ButtonLeft href="https://raw.githubusercontent.com/TykTechnologies/tyk-docs/refs/heads/production/swagger/nightly/enterprise-developer-portal-swagger.yaml" color="green" content="Download Swagger" />
 

--- a/tyk-dashboard-api.mdx
+++ b/tyk-dashboard-api.mdx
@@ -7,7 +7,7 @@ sidebarTitle: "Overview"
 
 import { ButtonLeft } from '/snippets/ButtonLeft.mdx';
 
-<img src="https://tyk.io/docs/img/swagger_dashboard_image.png" width="963" height="250" alt=""/>
+<img src="https://tyk.io/docs/img/swagger_dashboard_image.png" width="963" height="250" alt="Tyk Dashboard API"/>
 
 <ButtonLeft href="https://raw.githubusercontent.com/TykTechnologies/tyk-docs/refs/heads/production/swagger/nightly/dashboard-swagger.yml" color="green" content="Download Swagger" />
 

--- a/tyk-dashboard-api.mdx
+++ b/tyk-dashboard-api.mdx
@@ -7,7 +7,7 @@ sidebarTitle: "Overview"
 
 import { ButtonLeft } from '/snippets/ButtonLeft.mdx';
 
-<img src="https://tyk.io/docs/img/swagger_dashboard_image.png" width="963" height="250"/>
+<img src="https://tyk.io/docs/img/swagger_dashboard_image.png" width="963" height="250" alt=""/>
 
 <ButtonLeft href="https://raw.githubusercontent.com/TykTechnologies/tyk-docs/refs/heads/production/swagger/nightly/dashboard-swagger.yml" color="green" content="Download Swagger" />
 

--- a/tyk-gateway-api.mdx
+++ b/tyk-gateway-api.mdx
@@ -8,8 +8,8 @@ sidebarTitle: "Overview"
 
 import { ButtonLeft } from '/snippets/ButtonLeft.mdx';
 
-<img src="https://tyk.io/docs/img/swagger_gateway_image.png" width="963" height="250"/>
-<img src="https://tyk.io/docs/img/swagger_gateway_direction_image.png" width="946" height="392"/>
+<img src="https://tyk.io/docs/img/swagger_gateway_image.png" width="963" height="250" alt=""/>
+<img src="https://tyk.io/docs/img/swagger_gateway_direction_image.png" width="946" height="392" alt="Diagram showing traffic flow between Tyk Admin (using Curl, Postman, or httpie clients), Tyk Gateway backed by Redis, and the upstream API Server"/>
 
 <ButtonLeft href="https://raw.githubusercontent.com/TykTechnologies/tyk-docs/refs/heads/production/swagger/nightly/gateway-swagger.yml" color="green" content="Download Swagger" />
 

--- a/tyk-gateway-api.mdx
+++ b/tyk-gateway-api.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Overview"
 
 import { ButtonLeft } from '/snippets/ButtonLeft.mdx';
 
-<img src="https://tyk.io/docs/img/swagger_gateway_image.png" width="963" height="250" alt=""/>
+<img src="https://tyk.io/docs/img/swagger_gateway_image.png" width="963" height="250" alt="Tyk Gateway API"/>
 <img src="https://tyk.io/docs/img/swagger_gateway_direction_image.png" width="946" height="392" alt="Diagram showing traffic flow between Tyk Admin (using Curl, Postman, or httpie clients), Tyk Gateway backed by Redis, and the upstream API Server"/>
 
 <ButtonLeft href="https://raw.githubusercontent.com/TykTechnologies/tyk-docs/refs/heads/production/swagger/nightly/gateway-swagger.yml" color="green" content="Download Swagger" />


### PR DESCRIPTION
### **User description**
## Summary
- Adds missing `alt` attributes to 5 `<img>` tags across the swagger/API overview pages, fixing an SEO/accessibility audit finding on `release-5.11`.
- Four decorative title-banner images (Gateway, Dashboard, Dashboard Admin, Developer Portal) get `alt=""` since they're purely redundant title graphics (already conveyed by the page's own H1) — empty alt is correct a11y practice for decorative images.
- The one genuinely informative diagram (`swagger_gateway_direction_image.png`, showing the Tyk Admin → Tyk Gateway → API Server request flow) gets a real descriptive alt text.

## Files changed
- `tyk-gateway-api.mdx` (2 images: 1 decorative banner, 1 informative diagram)
- `tyk-dashboard-api.mdx` (1 decorative banner)
- `dashboard-admin-api.mdx` (1 decorative banner)
- `product-stack/tyk-enterprise-developer-portal/api-documentation/tyk-edp-api.mdx` (1 decorative banner)

No other content was touched.

## Test plan
- [ ] Confirm the 5 images still render correctly on each page
- [ ] Confirm no other content in these 4 files was modified (see diff)
- [ ] Re-run accessibility/SEO audit against `release-5.11` to confirm the missing-alt-text finding is resolved for these pages


___

### **PR Type**
Documentation


___

### **Description**
- Add missing image alt attributes

- Mark decorative banners as empty alt

- Describe Gateway traffic-flow diagram


___

### Diagram Walkthrough


```mermaid
flowchart LR
  docs["Swagger API overview pages"]
  banners["Decorative banner images"]
  diagram["Gateway flow diagram"]
  accessibility["Improved accessibility metadata"]
  docs -- "adds empty alt" --> banners
  docs -- "adds descriptive alt" --> diagram
  banners -- "supports" --> accessibility
  diagram -- "supports" --> accessibility
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashboard-admin-api.mdx</strong><dd><code>Add decorative alt to admin banner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard-admin-api.mdx

<ul><li>Adds an empty <code>alt</code> attribute to the Dashboard Admin Swagger banner <br>image.<br> <li> Marks the image as decorative for accessibility tools.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/2509/files#diff-9d9b703c7aeccba3fce34e1df2a5181be9b460d0cc5ece6e9aedee8f6aba379f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tyk-edp-api.mdx</strong><dd><code>Add decorative alt to portal banner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

product-stack/tyk-enterprise-developer-portal/api-documentation/tyk-edp-api.mdx

<ul><li>Adds an empty <code>alt</code> attribute to the Developer Portal Swagger banner <br>image.<br> <li> Treats the redundant title graphic as decorative content.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/2509/files#diff-293b2994eaa7842a06a4c83dc4099909266a3ae1207b8c924ecbf0917e63d4b9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tyk-dashboard-api.mdx</strong><dd><code>Add decorative alt to dashboard banner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-dashboard-api.mdx

<ul><li>Adds an empty <code>alt</code> attribute to the Dashboard Swagger banner image.<br> <li> Improves image accessibility metadata without changing page content.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/2509/files#diff-ac6285440e9e162b25ceb994d09ce29a098cd0292b065776fc3c8009887ac08a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tyk-gateway-api.mdx</strong><dd><code>Add Gateway image accessibility text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tyk-gateway-api.mdx

<ul><li>Adds an empty <code>alt</code> attribute to the Gateway Swagger banner image.<br> <li> Adds descriptive alt text for the Gateway traffic-flow diagram.<br> <li> Describes Tyk Admin clients, Tyk Gateway, Redis, and upstream API <br>Server flow.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/2509/files#diff-1d5120189c39d739c4f43591d3aae9e3bac1d98cf6ca8fbbf8aa0c1149e71437">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

