### PR TITLE
Log the deployment PR outcome in deploy-docs.yml

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -62,17 +62,10 @@ jobs:
           echo "  - Workflow Run: ${{ github.run_id }}"
           echo "  - Subfolder: ${{ inputs.subfolder || '(root deployment)' }}"
 
-      - name: Checkout target branch
-        # ref defaults to production because that's what trigger-docs-deploy.yml always
-        # dispatches with. It was previously hardcoded to "production", which silently
-        # ignored the branch chosen when manually running this workflow via
-        # workflow_dispatch (the dropdown only selects which copy of this YAML file
-        # runs, not what gets checked out) - so testing a fix from a feature branch
-        # produced a no-op merge against unchanged production content. github.ref makes
-        # a manual dispatch actually check out and merge from the selected branch.
+      - name: Checkout production branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: production
           token: ${{ secrets.ORG_GH_TOKEN }}
           fetch-depth: 0  # Fetch all history for all branches
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -62,10 +62,17 @@ jobs:
           echo "  - Workflow Run: ${{ github.run_id }}"
           echo "  - Subfolder: ${{ inputs.subfolder || '(root deployment)' }}"
 
-      - name: Checkout production branch
+      - name: Checkout target branch
+        # ref defaults to production because that's what trigger-docs-deploy.yml always
+        # dispatches with. It was previously hardcoded to "production", which silently
+        # ignored the branch chosen when manually running this workflow via
+        # workflow_dispatch (the dropdown only selects which copy of this YAML file
+        # runs, not what gets checked out) - so testing a fix from a feature branch
+        # produced a no-op merge against unchanged production content. github.ref makes
+        # a manual dispatch actually check out and merge from the selected branch.
         uses: actions/checkout@v4
         with:
-          ref: production
+          ref: ${{ github.ref }}
           token: ${{ secrets.ORG_GH_TOKEN }}
           fetch-depth: 0  # Fetch all history for all branches
 
@@ -388,6 +395,21 @@ jobs:
           maintainer-can-modify: true
           author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+
+      - name: Log deployment PR outcome
+        if: always()
+        run: |
+          PR_NUMBER="${{ steps.create-pr.outputs.pull-request-number }}"
+          if [ -n "$PR_NUMBER" ]; then
+            echo "✅ Deployment PR #$PR_NUMBER created/updated (branch: ${{ steps.create-pr.outputs.pull-request-branch }})"
+            echo "   ${{ steps.create-pr.outputs.pull-request-url }}"
+            echo "## ✅ Deployment PR #$PR_NUMBER" >> $GITHUB_STEP_SUMMARY
+            echo "${{ steps.create-pr.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "ℹ️ No deployment PR created - the regenerated content produced no changes against '${{ github.ref_name }}'."
+            echo "## ℹ️ No deployment PR created" >> $GITHUB_STEP_SUMMARY
+            echo "The merge against \`${{ github.ref_name }}\` produced no differences, so there was nothing to open a PR for." >> $GITHUB_STEP_SUMMARY
+          fi
 
       - name: Enable auto-merge on deployment PR
         if: steps.create-pr.outputs.pull-request-number


### PR DESCRIPTION
## Summary

Prompted by running the workflow manually from `fix/openapi-spec-directory-prefixes` (run [29489187757](https://github.com/TykTechnologies/tyk-docs/actions/runs/29489187757)) and getting no PR, with no explanation why.

**What actually happened:** the "Checkout production branch" step is hardcoded to `ref: production`. Selecting a different branch in the `workflow_dispatch` UI only picks which copy of this workflow *file* runs - it doesn't change anything hardcoded inside it, so that run checked out and merged `production`'s own unmodified content, produced a byte-identical `docs.json`, and `create-pull-request` correctly (but silently) found nothing to open a PR for. Confirmed directly from that run's logs:
```
Branch 'docs-merge-1002' is not ahead of base 'production' and will not be created
pull-request-operation = none
```

I initially also changed the checkout to `ref: ${{ github.ref }}` so a manual dispatch from another branch would actually build from it. Dropped that: the `workflow_dispatch` branch dropdown can't be made to default to `production` (GitHub always resets it to the repo's default branch, `main` here - not something fixable in this file), so keeping the dynamic ref would make an accidental dispatch (dropdown left on `main`) silently build from `main` instead of a harmless no-op against `production`. Not worth the risk for a rarely-used manual-test path; reverted to the hardcoded `ref: production`.

## Change in this PR

Just the logging: a **"Log deployment PR outcome"** step right after `Create Pull Request`, using its `pull-request-number` output. Prints (and adds to the job summary) either the created/updated PR's number + URL, or an explicit "no changes detected, no PR created" message - instead of the previous silence that made a no-op run look identical to a real failure. Runs with `if: always()`.

## Test plan

- [x] YAML validated with `yaml.safe_load`
- [x] Diffed against `production` to confirm this PR only adds the logging step, no behavior change to checkout/merge
- [ ] Next dispatch (with no content changes) should print the explicit "no changes" message instead of finishing silently