### PR TITLE
Revert #2539's per-spec OpenAPI directory split on production

### DIFF
--- a/scripts/merge_docs_configs.py
+++ b/scripts/merge_docs_configs.py
@@ -8,46 +8,6 @@ from typing import Dict, List, Any
 import copy
 import shutil
 
-# Each OpenAPI spec must render under its own Mintlify "directory" namespace.
-# Mintlify builds every API reference page URL as /<directory>/<tag>/<summary>;
-# specs that share a directory share that namespace, so two specs with the same
-# tag+summary (e.g. "Users" / "Create a new user") silently collide and one
-# overwrites the other at build time (DX-2380, DX-2380 follow-up). Keying by
-# swagger filename here keeps every spec in its own subdirectory regardless of
-# which navigation tab it's nested under.
-OPENAPI_SPEC_DIRECTORY_NAMES = {
-    "gateway-swagger.yml": "gateway",
-    "dashboard-swagger.yml": "dashboard",
-    "dashboard-admin-swagger.yml": "dashboard-admin",
-    "mdcb-swagger.yml": "mdcb",
-    "identity-broker-swagger.yml": "identity-broker",
-    "enterprise-developer-portal-swagger.yaml": "portal",
-    "ai-studio-swagger.yml": "ai-studio",
-}
-
-# Giving a spec its own subdirectory changes every one of its generated page URLs for
-# that version -> 404s for anyone with old links/bookmarks unless redirects are added.
-# To minimize that blast radius, default to only fixing "5.14 and above": the version
-# marked isLatest in branches-config.json, plus the isMain (nightly/edge) version since
-# it tracks what ships after 5.14. Older released versions keep their original shared
-# "api-reference" directory (and their original cross-spec collisions) untouched. Flip
-# "all" to True to apply the fix to every version instead. Exactly one should be True.
-OPENAPI_DIRECTORY_PREFIX_CONFIG = {
-    "latest": True,
-    "all": False,
-}
-
-
-def openapi_directory_name(swagger_filename: str) -> str:
-    """Unique subdirectory name for a swagger file's generated API reference pages."""
-    known = OPENAPI_SPEC_DIRECTORY_NAMES.get(swagger_filename)
-    if known:
-        return known
-    # Fallback for a future spec that hasn't been added to the map above yet.
-    fallback = re.sub(r"\.ya?ml$", "", swagger_filename, flags=re.IGNORECASE)
-    return re.sub(r"-swagger$", "", fallback)
-
-
 class DocsMerger:
     def __init__(self, output_file: str = "docs.json", subfolder: str = "", additional_assets: List[str] = None):
         self.output_file = output_file
@@ -839,23 +799,11 @@ class DocsMerger:
                         # No version subdirectory, add it
                         openapi_path = f"swagger/{version}/{swagger_file}"
 
-                    # Convert to object form with source and directory.
-                    base_directory = "api-reference" if is_latest else f"{version}/api-reference"
-
-                    # Give the spec its own subdirectory so cross-spec tag+summary
-                    # collisions can't merge (see OPENAPI_SPEC_DIRECTORY_NAMES above) -
-                    # scoped per OPENAPI_DIRECTORY_PREFIX_CONFIG to limit URL churn.
-                    # "latest" mode covers "5.14 and above": isLatest plus isMain (nightly).
-                    is_in_latest_scope = is_latest or version == self.main_version
-                    apply_spec_prefix = OPENAPI_DIRECTORY_PREFIX_CONFIG["all"] or (
-                        OPENAPI_DIRECTORY_PREFIX_CONFIG["latest"] and is_in_latest_scope
-                    )
-                    if apply_spec_prefix:
-                        spec_dir_name = openapi_directory_name(path_parts[-1])
-                        directory = f"{base_directory}/{spec_dir_name}"
+                    # Convert to object form with source and directory
+                    if is_latest:
+                        directory = "api-reference"
                     else:
-                        directory = base_directory
-
+                        directory = f"{version}/api-reference"
                     result["openapi"] = {"source": openapi_path, "directory": directory}
             
             return result


### PR DESCRIPTION
### **User description**
## Why

Per Sharad's explicit instruction: #2539 (per-spec `api-reference/<spec>` directory split) is "causing a lot of mess" right now and should come out for the time being; the proper fix will be redone later.

Scoped narrowly to just the `merge_docs_configs.py` mechanic #2539 added - every spec goes back to sharing one flat `api-reference` (or `<version>/api-reference`) directory per version, exactly as before #2539. Verified locally: calling `prefix_navigation_paths` for `is_latest=True`, `nightly`, and an older version all now return the shared directory, no per-spec suffix.

Deliberately does **not** touch `disambiguate_openapi_slugs.py` (stays deleted, per #2549) or `validate_openapi_slugs.py`/the `deploy-docs.yml` verify step (already work generically against whatever directory `merge_docs_configs.py` assigns) - so this doesn't re-open anything #2549 already changed on top of #2539.

## ⚠️ Known consequences - flagged to Sharad before making this change, confirmed anyway

- **This does not by itself stop deploys from failing.** #2549's hard-fail step still blocks on every collision it finds - they'll now report as cross-spec again (since specs share a directory again) instead of within-spec. If deploys are still failing after this merges, that's #2549's step, not this one.
- **Brings back the original bug this whole effort started from**: AI Studio operations rendering over Developer Portal's pages (and similar cross-spec collisions) on tyk.io/docs, since the structural fix for that is what's being reverted here.

## Test plan
- [ ] Confirm `merge_docs_configs.py` produces the flat directory structure on the next deploy attempt
- [ ] Separately address #2549's hard-fail step if deploys need to succeed in the near term
- [ ] Track re-doing the per-spec directory split properly as follow-up work


___

### **PR Type**
Bug fix


___

### **Description**
- Restore flat OpenAPI reference directories

- Use versioned directories for older specs

- Remove per-spec directory split behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  spec["OpenAPI navigation entry"]
  latest["Latest docs version"]
  versioned["Versioned docs"]
  sharedLatest["api-reference"]
  sharedVersioned["<version>/api-reference"]
  spec -- "is latest" --> latest
  spec -- "not latest" --> versioned
  latest -- "sets directory" --> sharedLatest
  versioned -- "sets directory" --> sharedVersioned
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>merge_docs_configs.py</strong><dd><code>Restore shared OpenAPI directory assignment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/merge_docs_configs.py

<ul><li>Restores <code>api-reference</code> for latest OpenAPI specs.<br> <li> Restores <code><version>/api-reference</code> for versioned specs.<br> <li> Removes per-spec directory prefix application.<br> <li> Keeps merged <code>openapi</code> entries in object form.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/2564/files#diff-f5b2db15c3142bfe21b7bebeeaa682d62ff451093249866f68ed7071c0188445">+4/-56</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

