### PR TITLE
Make the OpenAPI page-slug collision check non-blocking on main (DX-2380)

### DIFF
--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -31,11 +31,14 @@ jobs:
         python scripts/validate_mintlify_docs.py . --validate-redirects --verbose
 
     - name: Check for OpenAPI page-slug collisions
+      continue-on-error: true
       run: |
         echo "🧭 Checking for Mintlify OpenAPI page-slug collisions across specs (DX-2380)..."
         echo "Every spec gets its own api-reference subdirectory, so a collision here means two"
         echo "operations in the SAME spec share a tag+summary. This is no longer auto-fixed at"
         echo "deploy time - give the colliding operations distinct tags/summaries in the source spec."
+        echo "Temporarily non-blocking (continue-on-error) while the per-spec directory split is"
+        echo "reverted on production - still reports collisions, just doesn't fail the PR."
         python scripts/validate_openapi_slugs.py . --fail-on-within-spec
 
     - name: Check anchor fragments


### PR DESCRIPTION
### **User description**
## Why

Per Sharad's instruction, alongside reverting #2539 on production (#2564): this hard-block check (added by #2544) is part of what's currently causing a lot of mess in the pipeline. Making it `continue-on-error` so it still runs and reports every collision it finds on every PR, but doesn't fail the PR - so source-fix PRs like #385 (ai-studio), #5961 (tyk-analytics), #8492 (tyk) aren't gated by it while things settle down.

## What changed

`.github/workflows/validate-docs.yml`: added `continue-on-error: true` to the "Check for OpenAPI page-slug collisions" step. No change to `validate_openapi_slugs.py` itself - it still runs with `--fail-on-within-spec` and still prints every collision, it just no longer turns the job red.

## Related

- #2564 - revert of #2539's per-spec directory split on production (same root cause: repeated deploy failures)
- #2549 - removed the disambiguator safety net from production (still in place; not reverted)

## Follow-up
- [ ] Re-enable hard-fail (`continue-on-error: false`, or remove the line) once the per-spec directory split is redone properly on production and the source collision backlog is cleared


___

### **PR Type**
Enhancement


___

### **Description**
- Make slug-collision check non-blocking

- Keep validator output in PR CI

- Clarify temporary production-related rationale


___

### Diagram Walkthrough


```mermaid
flowchart LR
  workflow["validate-docs workflow"]
  check["OpenAPI slug collision check"]
  advisory["non-blocking PR feedback"]
  workflow -- "runs" --> check
  check -- "continue-on-error" --> advisory
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>validate-docs.yml</strong><dd><code>Make OpenAPI slug check advisory in CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/validate-docs.yml

<ul><li>Adds <code>continue-on-error: true</code> to the OpenAPI slug collision check step<br> <li> Keeps <code>validate_openapi_slugs.py</code> running with <code>--fail-on-within-spec</code><br> <li> Adds log output explaining the check is temporarily advisory-only<br> <li> Documents the production revert context for this CI behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/2565/files#diff-264286149b3faeb6ea04be746ed847bd3ce321f95bbed54f15167ab12ffeaa18">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

