### PR TITLE
Make the OpenAPI page-slug collision check non-blocking on production

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -279,6 +279,7 @@ jobs:
           echo "✅ Canonical URL update completed."
 
       - name: Verify no OpenAPI page-slug collisions (DX-2380)
+        continue-on-error: true
         run: |
           echo "🧭 Verifying no Mintlify OpenAPI page-slug collisions in the merged output..."
           echo "Mintlify builds every API page URL as <directory>/<tag>/<summary>; identical"
@@ -286,6 +287,9 @@ jobs:
           echo "There is no PR-time gate for already-published version folders, so this deploy-time"
           echo "check is the only backstop - it hard-fails on ANY collision, cross-spec or within-spec,"
           echo "instead of silently auto-rewriting summaries like the old disambiguator did."
+          echo "Temporarily non-blocking (continue-on-error) while the per-spec directory split"
+          echo "(#2539) is reverted and the source collision backlog is worked through - still"
+          echo "reports every collision, just doesn't block the deploy PR from being created."
           python3 scripts/validate_openapi_slugs.py . --fail-on-within-spec
           echo "✅ OpenAPI page slugs are collision-free."
 


### PR DESCRIPTION
### **User description**
## Why

Following up on #2564 (reverted the per-spec directory split) and #2565 (same non-blocking change on main): every production deploy has been failing on the "Verify no OpenAPI page-slug collisions" step that #2549 added. Sharad initially asked to just remove `--fail-on-within-spec`, but I checked `validate_openapi_slugs.py`'s logic first - cross-spec collisions are **always** hard-failed regardless of that flag, and cross-spec is most of what's failing now that #2564 put every spec back under one shared directory. Removing just the flag wouldn't have stopped the failures, so going with the fully non-blocking option instead.

## What changed

`.github/workflows/deploy-docs.yml`: added `continue-on-error: true` to the "Verify no OpenAPI page-slug collisions (DX-2380)" step. The check still runs and prints every collision found (same as before), it just no longer blocks the deployment PR from being created.

## Related
- #2564 - revert of #2539's per-spec directory split on production
- #2565 - same non-blocking change on main's PR-time check
- #2549 - originally added this hard-fail step

## Follow-up
- [ ] Remove `continue-on-error` once the per-spec directory split is redone properly and the source collision backlog (#385, #5961, #8492, and others) is cleared


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Make production slug validation non-blocking

- Preserve collision reporting during deploys

- Document temporary workflow behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  deploy["Production deploy workflow"]
  check["OpenAPI slug collision check"]
  report["Collision reports remain visible"]
  pr["Deploy PR creation unblocked"]
  deploy -- "runs" --> check
  check -- "continue-on-error" --> report
  check -- "does not block" --> pr
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy-docs.yml</strong><dd><code>Make deploy slug check non-blocking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/deploy-docs.yml

<ul><li>Adds <code>continue-on-error: true</code> to slug collision verification.<br> <li> Keeps <code>validate_openapi_slugs.py . --fail-on-within-spec</code> unchanged.<br> <li> Adds log messages explaining temporary non-blocking behavior.<br> <li> Preserves collision reporting while deploy PR creation proceeds.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/2567/files#diff-87e860af4b9db6c503ed680b6edb6333c6f8d7659f7d1a779a2487466bbc50f6">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

