### PR TITLE
Re-introduce per-spec OpenAPI directory split, scoped to nightly only (DX-2380)

### DIFF
--- a/scripts/merge_docs_configs.py
+++ b/scripts/merge_docs_configs.py
@@ -8,6 +8,34 @@ from typing import Dict, List, Any
 import copy
 import shutil
 
+# Each OpenAPI spec must render under its own Mintlify "directory" namespace.
+# Mintlify builds every API reference page URL as /<directory>/<tag>/<summary>;
+# specs that share a directory share that namespace, so two specs with the same
+# tag+summary (for example "Users" / "Create a new user") silently collide and one
+# overwrites the other at build time (DX-2380). Keying by swagger filename here
+# keeps every spec in its own subdirectory regardless of which navigation tab
+# it's nested under.
+OPENAPI_SPEC_DIRECTORY_NAMES = {
+    "gateway-swagger.yml": "gateway",
+    "dashboard-swagger.yml": "dashboard",
+    "dashboard-admin-swagger.yml": "dashboard-admin",
+    "mdcb-swagger.yml": "mdcb",
+    "identity-broker-swagger.yml": "identity-broker",
+    "enterprise-developer-portal-swagger.yaml": "portal",
+    "ai-studio-swagger.yml": "ai-studio",
+}
+
+
+def openapi_directory_name(swagger_filename: str) -> str:
+    """Unique subdirectory name for a swagger file's generated API reference pages."""
+    known = OPENAPI_SPEC_DIRECTORY_NAMES.get(swagger_filename)
+    if known:
+        return known
+    # Fallback for a future spec that hasn't been added to the map above yet.
+    fallback = re.sub(r"\.ya?ml$", "", swagger_filename, flags=re.IGNORECASE)
+    return re.sub(r"-swagger$", "", fallback)
+
+
 class DocsMerger:
     def __init__(self, output_file: str = "docs.json", subfolder: str = "", additional_assets: List[str] = None):
         self.output_file = output_file
@@ -799,11 +827,24 @@ class DocsMerger:
                         # No version subdirectory, add it
                         openapi_path = f"swagger/{version}/{swagger_file}"
 
-                    # Convert to object form with source and directory
-                    if is_latest:
-                        directory = "api-reference"
+                    # Convert to object form with source and directory.
+                    base_directory = "api-reference" if is_latest else f"{version}/api-reference"
+
+                    # Give the spec its own subdirectory so cross-spec tag+summary
+                    # collisions can't merge (see OPENAPI_SPEC_DIRECTORY_NAMES above).
+                    # Scoped to the main/nightly version ONLY: nightly has never been
+                    # published under a stable URL, so splitting it needs no redirects.
+                    # isLatest and every older version keep their original shared
+                    # "api-reference" directory - those URLs are already live and
+                    # indexed, and changing them would need redirects we don't want to
+                    # introduce. Once nightly promotes to the next release, it carries
+                    # the per-spec split forward as that release's URLs from day one.
+                    if version == self.main_version:
+                        spec_dir_name = openapi_directory_name(path_parts[-1])
+                        directory = f"{base_directory}/{spec_dir_name}"
                     else:
-                        directory = f"{version}/api-reference"
+                        directory = base_directory
+
                     result["openapi"] = {"source": openapi_path, "directory": directory}
             
             return result


### PR DESCRIPTION
### **User description**
## Why

#2539 originally gave every OpenAPI spec its own `api-reference/<spec>` directory to stop cross-spec tag+summary collisions, scoped to `isLatest` (5.14) + `nightly` to limit URL churn. But `isLatest` was already a live, indexed version at the time - so that scoping still meant every one of 5.14's API reference URLs changed the moment the split deployed. That caused real breakage, and #2564 reverted the split entirely (back to one shared directory everywhere), landing us back at the original DX-2380 problem: cross-spec collisions silently overwriting docs pages, now on every version including 5.14.

## What changed

Restores the same per-spec directory split mechanism (`OPENAPI_SPEC_DIRECTORY_NAMES` / `openapi_directory_name()` in `scripts/merge_docs_configs.py`), but scoped this time to **the main/nightly version only**:

- `nightly` gets `<base>/api-reference/<spec>` (for example `nightly/api-reference/gateway`, `nightly/api-reference/dashboard-admin`).
- `isLatest` (currently 5.14) and every older version (5.8-5.13) keep the original shared `api-reference` directory, completely unchanged.

Nightly has no stable published URL to protect - it's the unreleased edge channel, nobody bookmarks or gets a search-indexed link into it - so splitting it needs no redirects. When nightly is promoted to the next real release, that release ships with the split URLs from day one, since it never had old flat URLs published to redirect away from.

## Deliberate limitation (not fixed by this PR)

This does **not** retroactively fix the cross-spec collisions currently live on 5.8-5.14 (273 reported, see #2567's non-blocking check for the live count). Those need content-level disambiguation at the source instead - tracked via [tyk#8492](https://github.com/TykTechnologies/tyk/pull/8492), [tyk-analytics#5961](https://github.com/TykTechnologies/tyk-analytics/pull/5961), [tyk-analytics#5976](https://github.com/TykTechnologies/tyk-analytics/pull/5976), [ai-studio#385](https://github.com/TykTechnologies/ai-studio/pull/385), and others not yet filed (`apis`, `oauth`, `organisations`, `single-sign-on`, `users`, `catalogues`, `tags`, `sso-profiles`, `health`, `mcp-proxies`). A future, separate change could apply this same per-spec split to whatever version is `isLatest` at the point it's still `nightly` - so it inherits split URLs from day one instead of needing to migrate later.

This PR only stops the bleeding going forward on nightly; it does not touch `deploy-docs.yml`'s `continue-on-error` (#2567) since the 5.8-5.14 backlog this PR doesn't address would still hard-fail every deploy if that were removed now.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('scripts/merge_docs_configs.py').read())"` - valid syntax
- [x] Called `prefix_navigation_paths()` directly with real config values (`latest_version="5.14"`, `main_version="nightly"`) against `gateway-swagger.yml` and `dashboard-admin-swagger.yml`: nightly correctly gets `nightly/api-reference/gateway` / `nightly/api-reference/dashboard-admin`; 5.14 and 5.13 both stay on the shared `api-reference` / `5.13/api-reference` directory
- [ ] CI / next `workflow_dispatch` deploy - confirm nightly's OpenAPI pages render under the new per-spec paths and 5.8-5.14 URLs are byte-identical to before this PR


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add per-spec OpenAPI directories

- Scope split to nightly only

- Preserve released version URLs

- Add fallback spec directory naming


___

### Diagram Walkthrough


```mermaid
flowchart LR
  nav["OpenAPI navigation entry"]
  main["Main nightly version"]
  released["Latest and older releases"]
  split["api-reference/<spec>"]
  shared["api-reference or <version>/api-reference"]
  nav -- "version matches main" --> main
  nav -- "other versions" --> released
  main -- "assigns" --> split
  released -- "keeps" --> shared
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>merge_docs_configs.py</strong><dd><code>Scope OpenAPI directory split to nightly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/merge_docs_configs.py

<ul><li>Adds <code>OPENAPI_SPEC_DIRECTORY_NAMES</code> for known specs.<br> <li> Adds <code>openapi_directory_name()</code> with fallback slugging.<br> <li> Assigns per-spec <code>api-reference/<spec></code> directories only for <br><code>self.main_version</code>.<br> <li> Keeps latest and older released versions on shared API reference <br>directories.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/2569/files#diff-f5b2db15c3142bfe21b7bebeeaa682d62ff451093249866f68ed7071c0188445">+45/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

