### PR TITLE
Disambiguate Identity Broker's health-check summary from MDCB's (DX-2380)

### DIFF
--- a/swagger/identity-broker-swagger.yml
+++ b/swagger/identity-broker-swagger.yml
@@ -511,7 +511,7 @@ paths:
   /health:
     get:
       tags: [Health]
-      summary: Health check
+      summary: Health check (Tyk Identity Broker)
       description: Returns HTTP 200 when TIB is running and ready to serve requests.
       operationId: healthCheck
       responses:


### PR DESCRIPTION
### **User description**
## Summary

tyk-docs' OpenAPI page-slug collision check (DX-2380) flags Tyk Identity Broker's `GET /health` (tag Health, summary "Health check") against MDCB's own `GET /health` (tag Health, summary "Health Check") - both generate the identical Mintlify page URL. Companion to [tyk-sink#838](https://github.com/TykTechnologies/tyk-sink/pull/838).

## Why this is a direct tyk-docs edit, not a source-repo PR

`identity-broker-swagger.yml` has no OpenAPI source repo of its own - it was added directly to tyk-docs via #2304's Tyk Identity Broker documentation rewrite, hand-maintained here rather than generated from `tyk-identity-broker`'s Go source (confirmed: no swagger/OpenAPI file exists anywhere in that repo).

## Investigation

Read both implementations before deciding how to disambiguate: Tyk Identity Broker's `/health` handler (`http_handlers.go`, `HandleHealthCheck`) is a bare `w.WriteHeader(http.StatusOK)`, no dependency checks, despite the description's "ready to serve requests" phrasing. MDCB's `/health` is the same kind of trivially generic liveness ping. Neither is more "canonical" than the other the way, for example, Dashboard is relative to Dashboard Admin - they're two unrelated products whose health checks are both generic boilerplate, so both sides are being disambiguated (see tyk-sink#838) rather than picking one to stay bare.

## Fix

`summary: Health check` → `summary: Health check (Tyk Identity Broker)` in `swagger/identity-broker-swagger.yml`. Editing the unversioned `main` copy only, matching how every other source-of-truth swagger fix in this DX-2380 batch works - versioned copies (5.13/5.14/nightly) pick this up via the existing branch-merge sync into `production`.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('swagger/identity-broker-swagger.yml'))"` - valid YAML
- [x] Confirmed exactly 1 line changed


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Disambiguate TIB `/health` endpoint summary

- Prevent generated docs page collisions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  a["TIB /health summary"]
  b["Unique Mintlify page slug"]
  a -- "made product-specific" --> b
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>identity-broker-swagger.yml</strong><dd><code>Clarify health check summary for TIB Swagger</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

swagger/identity-broker-swagger.yml

<ul><li>Changed the <code>/health</code> endpoint <code>summary</code><br> <li> Added <code>Tyk Identity Broker</code> to disambiguate docs<br> <li> Helps avoid generated page slug collisions</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/2570/files#diff-f6c59c126253b129e7dfe0c927a9bb47a215ca5c9b68c1d0f27d2a215a13e8a2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

