### PR TITLE
Fix sidebar/title fallback for x-mint.href overrides (DX-2380)

### DIFF
--- a/swagger/5.10/dashboard-swagger.yml
+++ b/swagger/5.10/dashboard-swagger.yml
@@ -6340,6 +6340,9 @@ paths:
       operationId: addKey
       x-mint:
         href: /5.10/api-reference/keys/create-a-key-dashboard-add-key
+        metadata:
+          title: Create a key.
+          sidebarTitle: Create a key.
       parameters:
       - description: Set this to true to create a basic user. Note you have to send
           basic_auth_data(user and password) in the request body if this value is

--- a/swagger/5.10/dashboard-swagger.yml
+++ b/swagger/5.10/dashboard-swagger.yml
@@ -6341,7 +6341,6 @@ paths:
       x-mint:
         href: /5.10/api-reference/keys/create-a-key-dashboard-add-key
         metadata:
-          title: Create a key.
           sidebarTitle: Create a key.
       parameters:
       - description: Set this to true to create a basic user. Note you have to send

--- a/swagger/5.10/gateway-swagger.yml
+++ b/swagger/5.10/gateway-swagger.yml
@@ -2003,6 +2003,9 @@ paths:
       operationId: addKey
       x-mint:
         href: /5.10/api-reference/keys/create-a-key-gateway-add-key
+        metadata:
+          title: Create a key.
+          sidebarTitle: Create a key.
       parameters:
       - description: When set to true the key_hash returned will be similar to the
           un-hashed key name.
@@ -2523,6 +2526,9 @@ paths:
       operationId: createKey
       x-mint:
         href: /5.10/api-reference/keys/create-a-key-gateway-create-key
+        metadata:
+          title: Create a key.
+          sidebarTitle: Create a key.
       requestBody:
         content:
           application/json:

--- a/swagger/5.10/gateway-swagger.yml
+++ b/swagger/5.10/gateway-swagger.yml
@@ -2004,7 +2004,6 @@ paths:
       x-mint:
         href: /5.10/api-reference/keys/create-a-key-gateway-add-key
         metadata:
-          title: Create a key.
           sidebarTitle: Create a key.
       parameters:
       - description: When set to true the key_hash returned will be similar to the
@@ -2527,7 +2526,6 @@ paths:
       x-mint:
         href: /5.10/api-reference/keys/create-a-key-gateway-create-key
         metadata:
-          title: Create a key.
           sidebarTitle: Create a key.
       requestBody:
         content:

--- a/swagger/5.11/dashboard-swagger.yml
+++ b/swagger/5.11/dashboard-swagger.yml
@@ -6341,7 +6341,6 @@ paths:
       x-mint:
         href: /5.11/api-reference/keys/create-a-key-dashboard-add-key
         metadata:
-          title: Create a key.
           sidebarTitle: Create a key.
       parameters:
       - description: Set this to true to create a basic user. Note you have to send

--- a/swagger/5.11/dashboard-swagger.yml
+++ b/swagger/5.11/dashboard-swagger.yml
@@ -6340,6 +6340,9 @@ paths:
       operationId: addKey
       x-mint:
         href: /5.11/api-reference/keys/create-a-key-dashboard-add-key
+        metadata:
+          title: Create a key.
+          sidebarTitle: Create a key.
       parameters:
       - description: Set this to true to create a basic user. Note you have to send
           basic_auth_data(user and password) in the request body if this value is

--- a/swagger/5.11/gateway-swagger.yml
+++ b/swagger/5.11/gateway-swagger.yml
@@ -2003,6 +2003,9 @@ paths:
       operationId: addKey
       x-mint:
         href: /5.11/api-reference/keys/create-a-key-gateway-add-key
+        metadata:
+          title: Create a key.
+          sidebarTitle: Create a key.
       parameters:
       - description: When set to true the key_hash returned will be similar to the
           un-hashed key name.
@@ -2523,6 +2526,9 @@ paths:
       operationId: createKey
       x-mint:
         href: /5.11/api-reference/keys/create-a-key-gateway-create-key
+        metadata:
+          title: Create a key.
+          sidebarTitle: Create a key.
       requestBody:
         content:
           application/json:

--- a/swagger/5.11/gateway-swagger.yml
+++ b/swagger/5.11/gateway-swagger.yml
@@ -2004,7 +2004,6 @@ paths:
       x-mint:
         href: /5.11/api-reference/keys/create-a-key-gateway-add-key
         metadata:
-          title: Create a key.
           sidebarTitle: Create a key.
       parameters:
       - description: When set to true the key_hash returned will be similar to the
@@ -2527,7 +2526,6 @@ paths:
       x-mint:
         href: /5.11/api-reference/keys/create-a-key-gateway-create-key
         metadata:
-          title: Create a key.
           sidebarTitle: Create a key.
       requestBody:
         content:

--- a/swagger/5.12/dashboard-swagger.yml
+++ b/swagger/5.12/dashboard-swagger.yml
@@ -6459,6 +6459,9 @@ paths:
       operationId: addKey
       x-mint:
         href: /5.12/api-reference/keys/create-a-key-dashboard-add-key
+        metadata:
+          title: Create a key.
+          sidebarTitle: Create a key.
       parameters:
       - description: Set this to true to create a basic user. Note you have to send
           basic_auth_data(user and password) in the request body if this value is

--- a/swagger/5.12/dashboard-swagger.yml
+++ b/swagger/5.12/dashboard-swagger.yml
@@ -6460,7 +6460,6 @@ paths:
       x-mint:
         href: /5.12/api-reference/keys/create-a-key-dashboard-add-key
         metadata:
-          title: Create a key.
           sidebarTitle: Create a key.
       parameters:
       - description: Set this to true to create a basic user. Note you have to send

--- a/swagger/5.12/gateway-swagger.yml
+++ b/swagger/5.12/gateway-swagger.yml
@@ -2004,7 +2004,6 @@ paths:
       x-mint:
         href: /5.12/api-reference/keys/create-a-key-gateway-add-key
         metadata:
-          title: Create a key.
           sidebarTitle: Create a key.
       parameters:
       - description: When set to true the key_hash returned will be similar to the
@@ -2527,7 +2526,6 @@ paths:
       x-mint:
         href: /5.12/api-reference/keys/create-a-key-gateway-create-key
         metadata:
-          title: Create a key.
           sidebarTitle: Create a key.
       requestBody:
         content:

--- a/swagger/5.12/gateway-swagger.yml
+++ b/swagger/5.12/gateway-swagger.yml
@@ -2003,6 +2003,9 @@ paths:
       operationId: addKey
       x-mint:
         href: /5.12/api-reference/keys/create-a-key-gateway-add-key
+        metadata:
+          title: Create a key.
+          sidebarTitle: Create a key.
       parameters:
       - description: When set to true the key_hash returned will be similar to the
           un-hashed key name.
@@ -2523,6 +2526,9 @@ paths:
       operationId: createKey
       x-mint:
         href: /5.12/api-reference/keys/create-a-key-gateway-create-key
+        metadata:
+          title: Create a key.
+          sidebarTitle: Create a key.
       requestBody:
         content:
           application/json:

--- a/swagger/5.13/dashboard-swagger.yml
+++ b/swagger/5.13/dashboard-swagger.yml
@@ -6765,7 +6765,6 @@ paths:
       x-mint:
         href: /5.13/api-reference/keys/create-a-key-dashboard-add-key
         metadata:
-          title: Create a key.
           sidebarTitle: Create a key.
       parameters:
       - description: Set this to true to create a basic user. Note you have to send

--- a/swagger/5.13/dashboard-swagger.yml
+++ b/swagger/5.13/dashboard-swagger.yml
@@ -6764,6 +6764,9 @@ paths:
       operationId: addKey
       x-mint:
         href: /5.13/api-reference/keys/create-a-key-dashboard-add-key
+        metadata:
+          title: Create a key.
+          sidebarTitle: Create a key.
       parameters:
       - description: Set this to true to create a basic user. Note you have to send
           basic_auth_data(user and password) in the request body if this value is

--- a/swagger/5.13/gateway-swagger.yml
+++ b/swagger/5.13/gateway-swagger.yml
@@ -2224,7 +2224,6 @@ paths:
       x-mint:
         href: /5.13/api-reference/keys/create-a-key-gateway-add-key
         metadata:
-          title: Create a key.
           sidebarTitle: Create a key.
       parameters:
       - description: When set to true the key_hash returned will be similar to the
@@ -2747,7 +2746,6 @@ paths:
       x-mint:
         href: /5.13/api-reference/keys/create-a-key-gateway-create-key
         metadata:
-          title: Create a key.
           sidebarTitle: Create a key.
       requestBody:
         content:

--- a/swagger/5.13/gateway-swagger.yml
+++ b/swagger/5.13/gateway-swagger.yml
@@ -2223,6 +2223,9 @@ paths:
       operationId: addKey
       x-mint:
         href: /5.13/api-reference/keys/create-a-key-gateway-add-key
+        metadata:
+          title: Create a key.
+          sidebarTitle: Create a key.
       parameters:
       - description: When set to true the key_hash returned will be similar to the
           un-hashed key name.
@@ -2743,6 +2746,9 @@ paths:
       operationId: createKey
       x-mint:
         href: /5.13/api-reference/keys/create-a-key-gateway-create-key
+        metadata:
+          title: Create a key.
+          sidebarTitle: Create a key.
       requestBody:
         content:
           application/json:

--- a/swagger/5.14/dashboard-swagger.yml
+++ b/swagger/5.14/dashboard-swagger.yml
@@ -6765,7 +6765,6 @@ paths:
       x-mint:
         href: /api-reference/keys/create-a-key-dashboard-add-key
         metadata:
-          title: Create a key.
           sidebarTitle: Create a key.
       parameters:
       - description: Set this to true to create a basic user. Note you have to send

--- a/swagger/5.14/dashboard-swagger.yml
+++ b/swagger/5.14/dashboard-swagger.yml
@@ -6764,6 +6764,9 @@ paths:
       operationId: addKey
       x-mint:
         href: /api-reference/keys/create-a-key-dashboard-add-key
+        metadata:
+          title: Create a key.
+          sidebarTitle: Create a key.
       parameters:
       - description: Set this to true to create a basic user. Note you have to send
           basic_auth_data(user and password) in the request body if this value is

--- a/swagger/5.14/gateway-swagger.yml
+++ b/swagger/5.14/gateway-swagger.yml
@@ -2223,6 +2223,9 @@ paths:
       operationId: addKey
       x-mint:
         href: /api-reference/keys/create-a-key-gateway-add-key
+        metadata:
+          title: Create a key.
+          sidebarTitle: Create a key.
       parameters:
       - description: When set to true the key_hash returned will be similar to the
           un-hashed key name.
@@ -2743,6 +2746,9 @@ paths:
       operationId: createKey
       x-mint:
         href: /api-reference/keys/create-a-key-gateway-create-key
+        metadata:
+          title: Create a key.
+          sidebarTitle: Create a key.
       requestBody:
         content:
           application/json:

--- a/swagger/5.14/gateway-swagger.yml
+++ b/swagger/5.14/gateway-swagger.yml
@@ -2224,7 +2224,6 @@ paths:
       x-mint:
         href: /api-reference/keys/create-a-key-gateway-add-key
         metadata:
-          title: Create a key.
           sidebarTitle: Create a key.
       parameters:
       - description: When set to true the key_hash returned will be similar to the
@@ -2747,7 +2746,6 @@ paths:
       x-mint:
         href: /api-reference/keys/create-a-key-gateway-create-key
         metadata:
-          title: Create a key.
           sidebarTitle: Create a key.
       requestBody:
         content:

--- a/swagger/5.8/dashboard-swagger.yml
+++ b/swagger/5.8/dashboard-swagger.yml
@@ -6067,6 +6067,9 @@ paths:
       operationId: addKey
       x-mint:
         href: /5.8/api-reference/keys/create-a-key-dashboard-add-key
+        metadata:
+          title: Create a key.
+          sidebarTitle: Create a key.
       parameters:
       - description: Set this to true to create a basic user. Note you have to send
           basic_auth_data(user and password) in the request body if this value is

--- a/swagger/5.8/dashboard-swagger.yml
+++ b/swagger/5.8/dashboard-swagger.yml
@@ -6068,7 +6068,6 @@ paths:
       x-mint:
         href: /5.8/api-reference/keys/create-a-key-dashboard-add-key
         metadata:
-          title: Create a key.
           sidebarTitle: Create a key.
       parameters:
       - description: Set this to true to create a basic user. Note you have to send

--- a/swagger/5.8/gateway-swagger.yml
+++ b/swagger/5.8/gateway-swagger.yml
@@ -1940,6 +1940,9 @@ paths:
       operationId: addKey
       x-mint:
         href: /5.8/api-reference/keys/create-a-key-gateway-add-key
+        metadata:
+          title: Create a key.
+          sidebarTitle: Create a key.
       parameters:
       - description: When set to true the key_hash returned will be similar to the
           un-hashed key name.
@@ -2460,6 +2463,9 @@ paths:
       operationId: createKey
       x-mint:
         href: /5.8/api-reference/keys/create-a-key-gateway-create-key
+        metadata:
+          title: Create a key.
+          sidebarTitle: Create a key.
       requestBody:
         content:
           application/json:

--- a/swagger/5.8/gateway-swagger.yml
+++ b/swagger/5.8/gateway-swagger.yml
@@ -1941,7 +1941,6 @@ paths:
       x-mint:
         href: /5.8/api-reference/keys/create-a-key-gateway-add-key
         metadata:
-          title: Create a key.
           sidebarTitle: Create a key.
       parameters:
       - description: When set to true the key_hash returned will be similar to the
@@ -2464,7 +2463,6 @@ paths:
       x-mint:
         href: /5.8/api-reference/keys/create-a-key-gateway-create-key
         metadata:
-          title: Create a key.
           sidebarTitle: Create a key.
       requestBody:
         content:

--- a/swagger/5.9/dashboard-swagger.yml
+++ b/swagger/5.9/dashboard-swagger.yml
@@ -6076,7 +6076,6 @@ paths:
       x-mint:
         href: /5.9/api-reference/keys/create-a-key-dashboard-add-key
         metadata:
-          title: Create a key.
           sidebarTitle: Create a key.
       parameters:
       - description: Set this to true to create a basic user. Note you have to send

--- a/swagger/5.9/dashboard-swagger.yml
+++ b/swagger/5.9/dashboard-swagger.yml
@@ -6075,6 +6075,9 @@ paths:
       operationId: addKey
       x-mint:
         href: /5.9/api-reference/keys/create-a-key-dashboard-add-key
+        metadata:
+          title: Create a key.
+          sidebarTitle: Create a key.
       parameters:
       - description: Set this to true to create a basic user. Note you have to send
           basic_auth_data(user and password) in the request body if this value is

--- a/swagger/5.9/gateway-swagger.yml
+++ b/swagger/5.9/gateway-swagger.yml
@@ -1944,7 +1944,6 @@ paths:
       x-mint:
         href: /5.9/api-reference/keys/create-a-key-gateway-add-key
         metadata:
-          title: Create a key.
           sidebarTitle: Create a key.
       parameters:
       - description: When set to true the key_hash returned will be similar to the
@@ -2482,7 +2481,6 @@ paths:
       x-mint:
         href: /5.9/api-reference/keys/create-a-key-gateway-create-key
         metadata:
-          title: Create a key.
           sidebarTitle: Create a key.
       requestBody:
         content:

--- a/swagger/5.9/gateway-swagger.yml
+++ b/swagger/5.9/gateway-swagger.yml
@@ -1943,6 +1943,9 @@ paths:
       operationId: addKey
       x-mint:
         href: /5.9/api-reference/keys/create-a-key-gateway-add-key
+        metadata:
+          title: Create a key.
+          sidebarTitle: Create a key.
       parameters:
       - description: When set to true the key_hash returned will be similar to the
           un-hashed key name.
@@ -2478,6 +2481,9 @@ paths:
       operationId: createKey
       x-mint:
         href: /5.9/api-reference/keys/create-a-key-gateway-create-key
+        metadata:
+          title: Create a key.
+          sidebarTitle: Create a key.
       requestBody:
         content:
           application/json:

--- a/swagger/nightly/dashboard-swagger.yml
+++ b/swagger/nightly/dashboard-swagger.yml
@@ -6764,6 +6764,9 @@ paths:
       operationId: addKey
       x-mint:
         href: /nightly/api-reference/keys/create-a-key-dashboard-add-key
+        metadata:
+          title: Create a key.
+          sidebarTitle: Create a key.
       parameters:
       - description: Set this to true to create a basic user. Note you have to send
           basic_auth_data(user and password) in the request body if this value is

--- a/swagger/nightly/dashboard-swagger.yml
+++ b/swagger/nightly/dashboard-swagger.yml
@@ -6765,7 +6765,6 @@ paths:
       x-mint:
         href: /nightly/api-reference/keys/create-a-key-dashboard-add-key
         metadata:
-          title: Create a key.
           sidebarTitle: Create a key.
       parameters:
       - description: Set this to true to create a basic user. Note you have to send

--- a/swagger/nightly/gateway-swagger.yml
+++ b/swagger/nightly/gateway-swagger.yml
@@ -2224,7 +2224,6 @@ paths:
       x-mint:
         href: /nightly/api-reference/keys/create-a-key-gateway-add-key
         metadata:
-          title: Create a key.
           sidebarTitle: Create a key.
       parameters:
       - description: When set to true the key_hash returned will be similar to the
@@ -2747,7 +2746,6 @@ paths:
       x-mint:
         href: /nightly/api-reference/keys/create-a-key-gateway-create-key
         metadata:
-          title: Create a key.
           sidebarTitle: Create a key.
       requestBody:
         content:

--- a/swagger/nightly/gateway-swagger.yml
+++ b/swagger/nightly/gateway-swagger.yml
@@ -2223,6 +2223,9 @@ paths:
       operationId: addKey
       x-mint:
         href: /nightly/api-reference/keys/create-a-key-gateway-add-key
+        metadata:
+          title: Create a key.
+          sidebarTitle: Create a key.
       parameters:
       - description: When set to true the key_hash returned will be similar to the
           un-hashed key name.
@@ -2743,6 +2746,9 @@ paths:
       operationId: createKey
       x-mint:
         href: /nightly/api-reference/keys/create-a-key-gateway-create-key
+        metadata:
+          title: Create a key.
+          sidebarTitle: Create a key.
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
## Why

Follow-up to #2572 (merged) - that PR's second commit (the actual fix) didn't make it into the squash-merge, so this re-adds it against current production.

Live-testing #2572 showed the `x-mint.href` override correctly renders the right operation's content, and the page's own H1 already correctly shows "Create a key." with no override needed - but the **sidebar nav entry** fell back to a titleized version of the href's last path segment ("Create a key dashboard add key") instead of falling back to `summary`.

## Fix

Added `x-mint.metadata.sidebarTitle` (`Create a key.`) alongside the existing `href`, for all 3 overridden operations, across all 8 version copies:

```yaml
x-mint:
  href: /api-reference/keys/create-a-key-gateway-add-key
  metadata:
    sidebarTitle: Create a key.
```

Only `sidebarTitle` is included - an earlier draft of this PR also added `title`, but that was never actually confirmed broken (the page title already rendered correctly without it), so it's left out to keep the change to exactly what testing showed was needed.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on all 16 touched files - valid YAML
- [x] Confirmed exactly 48 lines added (3 operations x 8 versions x 2 lines each), nothing else touched
- [ ] Deploy/preview and confirm the sidebar now shows "Create a key." correctly for all 3 overridden operations
