### PR TITLE
Auto-resolve OpenAPI page-slug collisions via x-mint.href in CI (DX-2380)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -290,14 +290,22 @@ jobs:
           python3 scripts/add-canonical-urls/index.py || { echo "❌ Canonical script failed"; exit 1; }
           echo "✅ Canonical URL update completed."
 
+      - name: Auto-fix OpenAPI page-slug collisions (DX-2380)
+        run: |
+          echo "🔧 Resolving any Mintlify OpenAPI page-slug collision in the merged output..."
+          echo "Gives every colliding operation except one an explicit x-mint.href + sidebarTitle"
+          echo "override - no summary/tag/description changes, no directory restructuring, no"
+          echo "redirects (the one operation that keeps the default slug never moves)."
+          python3 scripts/fix_openapi_slug_collisions.py .
+
       - name: Verify no OpenAPI page-slug collisions (DX-2380)
         run: |
           echo "🧭 Verifying no Mintlify OpenAPI page-slug collisions in the merged output..."
           echo "Mintlify builds every API page URL as <directory>/<tag>/<summary>; identical"
           echo "tag+summary within the same directory collide and silently render the wrong endpoint."
-          echo "This is now caught at PR time on main (validate-docs.yml) instead of being"
-          echo "auto-rewritten here - this is a backstop for versions that don't yet have that gate."
-          python3 scripts/validate_openapi_slugs.py .
+          echo "The previous step should have resolved every one of these already via x-mint.href -"
+          echo "this is the hard-fail backstop in case something couldn't be auto-fixed."
+          python3 scripts/validate_openapi_slugs.py . --fail-on-within-spec
           echo "✅ OpenAPI page slugs are collision-free."
 
       - name: Verify output

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -303,9 +303,9 @@ jobs:
           echo "🧭 Verifying no Mintlify OpenAPI page-slug collisions in the merged output..."
           echo "Mintlify builds every API page URL as <directory>/<tag>/<summary>; identical"
           echo "tag+summary within the same directory collide and silently render the wrong endpoint."
-          echo "The previous step should have resolved every one of these already via x-mint.href -"
-          echo "this is the hard-fail backstop in case something couldn't be auto-fixed."
-          python3 scripts/validate_openapi_slugs.py . --fail-on-within-spec
+          echo "This is now caught at PR time on main (validate-docs.yml) instead of being"
+          echo "auto-rewritten here - this is a backstop for versions that don't yet have that gate."
+          python3 scripts/validate_openapi_slugs.py .
           echo "✅ OpenAPI page slugs are collision-free."
 
       - name: Verify output

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -30,6 +30,13 @@ jobs:
         echo "🔍 Running documentation validation..."
         python scripts/validate_mintlify_docs.py . --validate-redirects --verbose
 
+    - name: Check for auto-fixable OpenAPI page-slug collisions
+      run: |
+        echo "🧭 Checking whether any OpenAPI page-slug collision in this PR needs an x-mint.href fix (DX-2380)..."
+        echo "If this fails, run 'python3 scripts/fix_openapi_slug_collisions.py .' locally and commit the result -"
+        echo "it resolves every collision it finds with a per-operation x-mint.href override, no summary/tag changes."
+        python scripts/fix_openapi_slug_collisions.py . --check
+
     - name: Check for OpenAPI page-slug collisions
       run: |
         echo "🧭 Checking for Mintlify OpenAPI page-slug collisions across specs (DX-2380)..."

--- a/scripts/fix_openapi_slug_collisions.py
+++ b/scripts/fix_openapi_slug_collisions.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""
+Automatically resolve Mintlify OpenAPI page-slug collisions (DX-2380).
+
+validate_openapi_slugs.py *detects* two operations sharing the same generated page
+slug (<directory>/<slug(tag)>/<slug(summary)>). This script *fixes* every collision it
+finds by giving every operation in a colliding group except one an explicit
+`x-mint.href` override (a Mintlify OpenAPI extension - see
+https://www.mintlify.com/docs/api-playground/openapi-setup) pointing at a unique page
+URL, plus `x-mint.metadata.sidebarTitle` set to the operation's own unmodified summary
+(without it, Mintlify's sidebar falls back to a titleized version of the href instead
+of the summary - confirmed by live-testing tyk-docs#2572/#2573).
+
+Deliberately does NOT touch `summary`, `tags`, or `description` on any operation - the
+fix is pure URL plumbing, invisible to a reader browsing the page itself.
+
+Within one colliding group, exactly one operation keeps its default (no override) slug,
+so its URL never changes and nothing needs a redirect. "Which one" is decided
+deterministically (SPEC_PRIORITY, then path, then method) rather than by whatever
+Mintlify's build happens to render first today - a real production ambiguity that this
+script has no way to observe. Every other operation gets:
+
+    x-mint:
+      href: <directory>/<tag-slug>/<summary-slug>-<spec-dir-name>-<operationId-slug>
+      metadata:
+        sidebarTitle: <original summary, unchanged>
+
+`operationId` is required to be unique within one OpenAPI document, and combined with
+the spec's own directory name (globally unique by construction), the combination can
+never collide with anything else - regardless of whether the original collision was
+within one spec or across several.
+
+Insertion is done as a targeted text edit anchored on the operation's `operationId:`
+line (which must therefore be present and unique in its file), not a full YAML
+load/dump, so the rest of each file is untouched byte-for-byte.
+
+Usage:
+    python3 scripts/fix_openapi_slug_collisions.py [directory]              # apply fixes
+    python3 scripts/fix_openapi_slug_collisions.py [directory] --check      # report only, exit 1 if anything would change
+"""
+import argparse
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from validate_openapi_slugs import (  # noqa: E402
+    collect_slugs,
+    find_openapi_specs,
+    openapi_directory_name,
+    slugify,
+)
+
+# Mirrors OPENAPI_SPEC_DIRECTORY_NAMES's own ordering (validate_openapi_slugs.py /
+# merge_docs_configs.py) - Gateway is the most foundational/most-referenced product, so
+# it's first and therefore always the one that keeps its default slug when it's part of
+# a collision. Order after that follows the same "more specialized loses" convention
+# established across the DX-2380 fix PRs.
+SPEC_PRIORITY = [
+    "gateway-swagger.yml",
+    "dashboard-swagger.yml",
+    "dashboard-admin-swagger.yml",
+    "mdcb-swagger.yml",
+    "identity-broker-swagger.yml",
+    "enterprise-developer-portal-swagger.yaml",
+    "ai-studio-swagger.yml",
+]
+
+
+def spec_priority_key(spec_rel):
+    basename = spec_rel.rsplit("/", 1)[-1]
+    try:
+        return SPEC_PRIORITY.index(basename)
+    except ValueError:
+        return len(SPEC_PRIORITY)
+
+
+def slugify_operation_id(operation_id):
+    """Camel-case-aware slug so word boundaries survive (addKey -> add-key, not addkey)."""
+    spaced = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "-", operation_id)
+    return slugify(spaced)
+
+
+def disambiguator_slug(occ):
+    """A slug guaranteed unique within one spec: operationId when present (OpenAPI
+    requires this to be unique per document), otherwise method+path (also always
+    unique per document - you can't declare the same method twice under one path).
+    Never a constant placeholder - two operations in the same collision group both
+    lacking operationId must still get distinct suffixes from each other."""
+    if occ["operation_id"]:
+        return slugify_operation_id(occ["operation_id"])
+    return slugify(f"{occ['method']}-{occ['path']}")
+
+
+def plan_fixes(root, docs_json_path):
+    """Return list of (occurrence, href, sidebar_title) for every operation that needs
+    an x-mint override - i.e. every member of a colliding group except the first."""
+    specs = find_openapi_specs(docs_json_path)
+    slug_map = collect_slugs(root, specs)
+
+    fixes = []
+    for occurrences in slug_map.values():
+        if len(occurrences) < 2:
+            continue
+        ordered = sorted(
+            occurrences,
+            key=lambda o: (spec_priority_key(o["spec"]), o["path"], o["method"]),
+        )
+        for occ in ordered[1:]:
+            spec_basename = occ["spec"].rsplit("/", 1)[-1]
+            spec_dir_name = openapi_directory_name(spec_basename)
+            href = (
+                f"/{occ['directory']}/{slugify(occ['tag'])}/{slugify(occ['summary'])}"
+                f"-{spec_dir_name}-{disambiguator_slug(occ)}"
+            )
+            fixes.append((occ, href, occ["summary"]))
+    return fixes
+
+
+def find_operation_line(lines, path, method):
+    """Locate the line index of `<method>:` nested directly under the `<path>:` key.
+    Path keys may or may not be YAML-quoted (varies by generator - e.g. ai-studio's
+    swag-generated spec quotes every path, gateway/dashboard's hand-authored ones
+    don't), so match either form. Returns the index of the method line itself -
+    the x-mint block is inserted as its first child, which is always valid
+    regardless of whether the operation has an operationId."""
+    path_pattern = re.compile(r'^(\s*)"?' + re.escape(path) + r'"?:\s*$')
+    for i, line in enumerate(lines):
+        m = path_pattern.match(line)
+        if not m:
+            continue
+        path_indent = len(m.group(1))
+        method_pattern = re.compile(r"^(\s*)" + re.escape(method.lower()) + r":\s*$")
+        for j in range(i + 1, len(lines)):
+            stripped_indent = len(lines[j]) - len(lines[j].lstrip())
+            if lines[j].strip() and stripped_indent <= path_indent:
+                break  # left the path's block without finding the method
+            mm = method_pattern.match(lines[j])
+            if mm and stripped_indent == path_indent + 2:
+                return j
+    return None
+
+
+def apply_fix(root, occ, href, sidebar_title):
+    file_path = os.path.join(root, occ["spec"])
+    with open(file_path, encoding="utf-8") as f:
+        lines = f.readlines()
+
+    idx = find_operation_line(lines, occ["path"], occ["method"])
+    if idx is None:
+        raise RuntimeError(
+            f"{occ['spec']}: couldn't locate {occ['method']} {occ['path']} in the raw text - "
+            "can't safely auto-fix, needs manual attention"
+        )
+    method_indent = len(lines[idx]) - len(lines[idx].lstrip())
+    indent = " " * (method_indent + 2)
+
+    insertion = [
+        f"{indent}x-mint:\n",
+        f"{indent}  href: {href}\n",
+        f"{indent}  metadata:\n",
+        f"{indent}    sidebarTitle: {sidebar_title}\n",
+    ]
+    lines[idx + 1 : idx + 1] = insertion
+
+    with open(file_path, "w", encoding="utf-8") as f:
+        f.writelines(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("directory", nargs="?", default=".", help="Repo root containing docs.json (default: .)")
+    parser.add_argument("--check", action="store_true", help="Report what would change without writing; exit 1 if anything would change")
+    args = parser.parse_args()
+
+    docs_json_path = os.path.join(args.directory, "docs.json")
+    if not os.path.isfile(docs_json_path):
+        print(f"ERROR: docs.json not found in {args.directory}")
+        return 2
+
+    fixes = plan_fixes(args.directory, docs_json_path)
+
+    if args.check:
+        if not fixes:
+            print("✅ No OpenAPI page-slug collisions need fixing.")
+            return 0
+        print(f"❌ {len(fixes)} operation(s) need an x-mint.href fix - run without --check to apply, then commit the result:")
+        for occ, href, _ in fixes:
+            print(f"  [{occ['spec']}] {occ['method']} {occ['path']} (operationId: {occ['operation_id']}) -> {href}")
+        return 1
+
+    if not fixes:
+        print("✅ No OpenAPI page-slug collisions found - nothing to fix.")
+        return 0
+
+    for occ, href, sidebar_title in fixes:
+        apply_fix(args.directory, occ, href, sidebar_title)
+        print(f"Fixed: [{occ['spec']}] {occ['method']} {occ['path']} -> {href}")
+    print(f"\n{len(fixes)} operation(s) fixed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_openapi_slugs.py
+++ b/scripts/validate_openapi_slugs.py
@@ -112,7 +112,7 @@ def operation_slug(tag, operation):
 
 
 def collect_slugs(root, specs):
-    """Return full-page-slug (directory included) -> list of {spec, method, path, tag, summary} occurrences."""
+    """Return full-page-slug (directory included) -> list of {spec, method, path, tag, summary, operation_id} occurrences."""
     slug_map = defaultdict(list)
     for spec_info in specs:
         spec_rel = spec_info["source"]
@@ -132,13 +132,19 @@ def collect_slugs(root, specs):
                 # Mintlify groups an operation under its FIRST tag (that drives the URL).
                 tags = operation.get("tags") or ["untagged"]
                 tag = tags[0]
-                full_slug = f"{directory}/{operation_slug(tag, operation)}"
+                # An x-mint.href override (see fix_openapi_slug_collisions.py) replaces
+                # the default <directory>/<tag>/<summary> slug entirely - Mintlify
+                # renders the operation at that explicit path instead, so collision
+                # detection must key on it when present, not the slug it overrides.
+                href = ((operation.get("x-mint") or {}).get("href") or "").lstrip("/")
+                full_slug = href or f"{directory}/{operation_slug(tag, operation)}"
                 slug_map[full_slug].append({
                     "spec": spec_rel,
                     "directory": directory,
                     "method": method.upper(),
                     "path": path,
                     "tag": tag,
+                    "operation_id": operation.get("operationId"),
                     "summary": operation.get("summary") or operation.get("operationId") or "",
                 })
     return slug_map

--- a/swagger/ai-studio-swagger.yml
+++ b/swagger/ai-studio-swagger.yml
@@ -5473,6 +5473,10 @@ paths:
       security:
       - BearerAuth: []
     post:
+      x-mint:
+        href: /api-reference/ai-studio/catalogues/create-a-new-catalogue-ai-studio-post-catalogues
+        metadata:
+          sidebarTitle: Create a new catalogue
       tags:
       - catalogues
       summary: Create a new catalogue
@@ -5724,6 +5728,10 @@ paths:
       - BearerAuth: []
   "/catalogues/search":
     get:
+      x-mint:
+        href: /api-reference/ai-studio/catalogues/search-catalogues-by-name-ai-studio-get-catalogues-search
+        metadata:
+          sidebarTitle: Search catalogues by name
       tags:
       - catalogues
       summary: Search catalogues by name
@@ -7393,6 +7401,10 @@ paths:
       security:
       - BearerAuth: []
     post:
+      x-mint:
+        href: /api-reference/ai-studio/data-catalogues/create-a-new-data-catalogue-ai-studio-post-data-catalogues
+        metadata:
+          sidebarTitle: Create a new data catalogue
       tags:
       - data-catalogues
       summary: Create a new data catalogue
@@ -7685,6 +7697,10 @@ paths:
       - BearerAuth: []
   "/data-catalogues/by-datasource":
     get:
+      x-mint:
+        href: /api-reference/ai-studio/data-catalogues/get-data-catalogues-by-datasource-ai-studio-get-data-catalogues-by-datasource
+        metadata:
+          sidebarTitle: Get data catalogues by datasource
       tags:
       - data-catalogues
       summary: Get data catalogues by datasource
@@ -7721,6 +7737,10 @@ paths:
       - BearerAuth: []
   "/data-catalogues/by-tag":
     get:
+      x-mint:
+        href: /api-reference/ai-studio/data-catalogues/get-data-catalogues-by-tag-ai-studio-get-data-catalogues-by-tag
+        metadata:
+          sidebarTitle: Get data catalogues by tag
       tags:
       - data-catalogues
       summary: Get data catalogues by tag
@@ -7757,6 +7777,10 @@ paths:
       - BearerAuth: []
   "/data-catalogues/search":
     get:
+      x-mint:
+        href: /api-reference/ai-studio/data-catalogues/search-data-catalogues-ai-studio-get-data-catalogues-search
+        metadata:
+          sidebarTitle: Search data catalogues
       tags:
       - data-catalogues
       summary: Search data catalogues
@@ -8776,6 +8800,10 @@ paths:
       security:
       - BearerAuth: []
     post:
+      x-mint:
+        href: /api-reference/ai-studio/groups/create-a-new-group-ai-studio-post-groups
+        metadata:
+          sidebarTitle: Create a new group
       tags:
       - groups
       summary: Create a new group
@@ -8951,6 +8979,10 @@ paths:
       security:
       - BearerAuth: []
     put:
+      x-mint:
+        href: /api-reference/ai-studio/groups/update-group-catalogues-ai-studio-put-groups-id-catalogues
+        metadata:
+          sidebarTitle: Update group catalogues
       tags:
       - groups
       summary: Update group catalogues
@@ -9325,6 +9357,10 @@ paths:
       security:
       - BearerAuth: []
     put:
+      x-mint:
+        href: /api-reference/ai-studio/groups/update-group-users-ai-studio-put-groups-id-users
+        metadata:
+          sidebarTitle: Update group users
       tags:
       - groups
       summary: Update group users
@@ -10142,6 +10178,10 @@ paths:
       x-codegen-request-body-name: modelPrice
   "/model-prices/{id}/recalculate":
     patch:
+      x-mint:
+        href: /api-reference/ai-studio/model-prices/update-a-model-price-and-recalculate-historical-costs-ai-studio-patch-model-prices-id-recalculate
+        metadata:
+          sidebarTitle: Update a model price and recalculate historical costs
       tags:
       - model-prices
       - model-prices
@@ -11450,6 +11490,10 @@ paths:
               schema:
                 "$ref": "#/components/schemas/api.ErrorResponse"
     post:
+      x-mint:
+        href: /api-reference/ai-studio/tool-catalogues/create-a-new-tool-catalogue-ai-studio-post-tool-catalogues
+        metadata:
+          sidebarTitle: Create a new tool catalogue
       tags:
       - tool-catalogues
       summary: Create a new tool catalogue
@@ -11840,6 +11884,10 @@ paths:
                 "$ref": "#/components/schemas/api.ErrorResponse"
   "/tool-catalogues/search":
     get:
+      x-mint:
+        href: /api-reference/ai-studio/tool-catalogues/search-tool-catalogues-ai-studio-get-tool-catalogues-search
+        metadata:
+          sidebarTitle: Search tool catalogues
       tags:
       - tool-catalogues
       summary: Search tool catalogues

--- a/swagger/dashboard-swagger.yml
+++ b/swagger/dashboard-swagger.yml
@@ -8392,6 +8392,10 @@ paths:
       - Schemas
   /api/schemas/apidefs/oas:
     get:
+      x-mint:
+        href: /api-reference/dashboard/schemas/get-api-definition-oas-schema-dashboard-get-apidef-oasschema
+        metadata:
+          sidebarTitle: Get API definition OAS schema.
       description: Get API definition OAS schema.
       operationId: getApidefOASSchema
       parameters:

--- a/swagger/gateway-swagger.yml
+++ b/swagger/gateway-swagger.yml
@@ -2737,6 +2737,10 @@ paths:
       - Keys
   /tyk/keys/create:
     post:
+      x-mint:
+        href: /api-reference/gateway/keys/create-a-key-gateway-create-key
+        metadata:
+          sidebarTitle: Create a key.
       description: Create a key.
       operationId: createKey
       requestBody:


### PR DESCRIPTION
## Why

Every prior DX-2380 fix required a human to notice a collision and hand-write a source-repo rename PR (10 of those got closed - too visible/ugly, see the linked discussion). The directory-split structural fix was also rejected (too many redirects on already-published versions). This closes the loop: **automatically** resolve every collision via Mintlify's `x-mint.href` extension, verified end-to-end live on production first (tyk-docs#2572, #2573) before wiring it into CI so it never needs a human to hand-write the fix again.

## What changed

**New: `scripts/fix_openapi_slug_collisions.py`** - for every collision group `validate_openapi_slugs.py` detects, gives every operation in the group except one an explicit override:

```yaml
x-mint:
  href: <directory>/<tag>/<summary>-<spec-dir-name>-<disambiguator>
  metadata:
    sidebarTitle: <original summary, unchanged>
```

- One operation per group keeps no override - its URL never changes, so nothing needs a redirect. "Which one" is a deterministic priority order (`SPEC_PRIORITY`, then path, then method), not an attempt to match whatever Mintlify's build happens to currently render (not observable from a script).
- `<disambiguator>` is `operationId` when present (OpenAPI requires it unique per document) or `method+path` when absent (also always unique per document) - confirmed necessary: most of ai-studio's operations have no `operationId` at all, and a naive placeholder would have made two collision-group members collide with *each other*.
- Insertion is a targeted text edit anchored on the operation's exact method line under its exact path - handles both quoted and unquoted path keys (varies by generator: ai-studio's `swag`-generated spec quotes every path key, gateway/dashboard's hand-authored ones don't) - not a full YAML load/dump, so the rest of each file is untouched byte-for-byte.

**`scripts/validate_openapi_slugs.py`**: now reads `x-mint.href` when computing an operation's effective slug. Without this it would keep reporting a "collision" forever even after the fixer resolved it, since the override changes where Mintlify actually renders the page but the validator was only ever looking at `tag`+`summary`.

**CI wiring, both on `main`:**
- `validate-docs.yml` (PR-time): runs the fixer in `--check` mode. Fails the PR with instructions to run it locally and commit the result - deliberately does NOT auto-commit to someone else's PR branch.
- `deploy-docs.yml` (main's own copy): runs the fixer for real right before the existing verify step. That verify step is untouched otherwise - its strictness and continue-on-error semantics are exactly as they were before this PR, since the auto-fix step running first already resolves everything it would have caught.

## Verified

Tested against every real collision currently on `main` - 14 found (all within-spec; main's per-spec directory split already makes cross-spec collisions structurally impossible, unlike `production` where that split was reverted):

```
python3 scripts/fix_openapi_slug_collisions.py . --check   # 14 found
python3 scripts/fix_openapi_slug_collisions.py .           # 14 fixed
python3 scripts/validate_openapi_slugs.py .                 # ✅ exit 0
python3 scripts/fix_openapi_slug_collisions.py . --check   # ✅ 0 - idempotent
```

## Not included

`production`'s `deploy-docs.yml` is a separate file (production/main scripts don't auto-sync - a known drift point from earlier in this effort) and still has its `continue-on-error` step from #2567. Porting this same fix there is a natural follow-up, intentionally not bundled into this PR.

## Test plan

- [x] All modified YAML/workflow files pass `yaml.safe_load`
- [x] Fixer resolves all 14 real current collisions on `main`
- [x] Validator passes cleanly (exit 0) after the fix
- [x] Fixer is idempotent (0 changes on a second run)
- [ ] CI itself runs both new/changed steps successfully on this PR
