### PR TITLE
docs: clarify 5.8.15 FIPS crypto module update and 140-3 compliance boundary

### DIFF
--- a/developer-support/release-notes/dashboard.mdx
+++ b/developer-support/release-notes/dashboard.mdx
@@ -2202,7 +2202,7 @@ Tyk Dashboard embeds Tyk Identity Broker. This has been updated to [version 1.7.
 The `tyk-dashboard-fips` image now builds using Go 1.25's native FIPS 140-3 capable cryptographic module (`GOFIPS140=v1.0.0`), replacing the BoringCrypto module (`GOEXPERIMENT=boringcrypto`) used by earlier 5.8.x FIPS releases.
 
 <Note>
-This is a build-time dependency change only. It does not change Tyk's official compliance target for the 5.8.x release line, which remains FIPS 140-2. Official FIPS 140-3 compliance, which additionally requires Docker Hardened Images and enterprise supply chain assurances, is available exclusively from 5.13.x onward. See [FIPS 140-3 Compliance](/developer-support/release-types/fips-release#fips-standard-by-version) for details.
+This is a build-time dependency change only. It does not change Tyk's official FIPS readiness target for the 5.8.x release line, which remains FIPS 140-2. Official FIPS 140-3 compliance, which additionally requires Docker Hardened Images and enterprise supply chain assurances, is available exclusively from 5.13.x onward. See [FIPS 140-3 Compliance](/developer-support/release-types/fips-release#fips-standard-by-version) for details.
 </Note>
 </Accordion>
 

--- a/developer-support/release-notes/dashboard.mdx
+++ b/developer-support/release-notes/dashboard.mdx
@@ -2198,6 +2198,14 @@ If you are upgrading to 5.8.15, please follow the detailed [upgrade instructions
 Tyk Dashboard embeds Tyk Identity Broker. This has been updated to [version 1.7.3](/developer-support/release-notes/tib#1-7-3-release-notes).
 </Accordion>
 
+<Accordion title='Updated cryptographic module used by tyk-dashboard-fips'>
+The `tyk-dashboard-fips` image now builds using Go 1.25's native FIPS 140-3 capable cryptographic module (`GOFIPS140=v1.0.0`), replacing the BoringCrypto module (`GOEXPERIMENT=boringcrypto`) used by earlier 5.8.x FIPS releases.
+
+<Note>
+This is a build-time dependency change only. It does not change Tyk's official compliance target for the 5.8.x release line, which remains FIPS 140-2. Official FIPS 140-3 compliance, which additionally requires Docker Hardened Images and enterprise supply chain assurances, is available exclusively from 5.13.x onward. See [FIPS 140-3 Compliance](/developer-support/release-types/fips-release#fips-standard-by-version) for details.
+</Note>
+</Accordion>
+
 </AccordionGroup>
 
 ##### Fixed

--- a/developer-support/release-notes/dashboard.mdx
+++ b/developer-support/release-notes/dashboard.mdx
@@ -2202,7 +2202,9 @@ Tyk Dashboard embeds Tyk Identity Broker. This has been updated to [version 1.7.
 The `tyk-dashboard-fips` image now builds using Go 1.25's native FIPS 140-3 capable cryptographic module (`GOFIPS140=v1.0.0`), replacing the BoringCrypto module (`GOEXPERIMENT=boringcrypto`) used by earlier 5.8.x FIPS releases.
 
 <Note>
-This is a build-time dependency change only. It does not change Tyk's official FIPS readiness target for the 5.8.x release line, which remains FIPS 140-2. Official FIPS 140-3 compliance, which additionally requires Docker Hardened Images and enterprise supply chain assurances, is available exclusively from 5.13.x onward. See [FIPS 140-3](/developer-support/release-types/fips-release#fips-standard-by-version) for details.
+This is a build-time dependency change only. It does not change Tyk's official FIPS readiness target for the 5.8.x release line, which remains FIPS 140-2.
+
+Official FIPS 140-3 readiness, which additionally requires Docker Hardened Images and enterprise supply chain assurances, is available exclusively from 5.13.x onward. See [FIPS 140-3](/developer-support/release-types/fips-release#fips-standard-by-version) for details.
 </Note>
 </Accordion>
 

--- a/developer-support/release-notes/dashboard.mdx
+++ b/developer-support/release-notes/dashboard.mdx
@@ -2202,7 +2202,7 @@ Tyk Dashboard embeds Tyk Identity Broker. This has been updated to [version 1.7.
 The `tyk-dashboard-fips` image now builds using Go 1.25's native FIPS 140-3 capable cryptographic module (`GOFIPS140=v1.0.0`), replacing the BoringCrypto module (`GOEXPERIMENT=boringcrypto`) used by earlier 5.8.x FIPS releases.
 
 <Note>
-This is a build-time dependency change only. It does not change Tyk's official FIPS readiness target for the 5.8.x release line, which remains FIPS 140-2. Official FIPS 140-3 compliance, which additionally requires Docker Hardened Images and enterprise supply chain assurances, is available exclusively from 5.13.x onward. See [FIPS 140-3 Compliance](/developer-support/release-types/fips-release#fips-standard-by-version) for details.
+This is a build-time dependency change only. It does not change Tyk's official FIPS readiness target for the 5.8.x release line, which remains FIPS 140-2. Official FIPS 140-3 compliance, which additionally requires Docker Hardened Images and enterprise supply chain assurances, is available exclusively from 5.13.x onward. See [FIPS 140-3](/developer-support/release-types/fips-release#fips-standard-by-version) for details.
 </Note>
 </Accordion>
 

--- a/developer-support/release-notes/gateway.mdx
+++ b/developer-support/release-notes/gateway.mdx
@@ -2736,8 +2736,10 @@ If you are upgrading to 5.8.15, please follow the detailed [upgrade instructions
 The `tyk-gateway-fips` image now builds using Go 1.25's native FIPS 140-3 capable cryptographic module (`GOFIPS140=v1.0.0`), replacing the BoringCrypto module (`GOEXPERIMENT=boringcrypto`) used by earlier 5.8.x FIPS releases.
 
 <Note>
-For deployments that do not use custom Go plugins, this is a build-time dependency change only and does not change Tyk's official compliance target for the 5.8.x release line, which remains FIPS 140-2. If you build [custom Go plugins](/api-management/plugins/golang) for use with `tyk-gateway-fips`, you must rebuild them with a `tyk-plugin-compiler-fips` image for the matching Gateway version: plugins compiled against an older plugin compiler image are not binary-compatible with `tyk-gateway-fips:v5.8.15` and will fail to load. Official FIPS 140-3 compliance, which additionally requires Docker Hardened Images and enterprise supply chain assurances, is available exclusively from 5.13.x onward. See [FIPS 140-3 Compliance](/developer-support/release-types/fips-release#fips-standard-by-version) for details.
+This is a build-time dependency change only. It does not change Tyk's official compliance target for the 5.8.x release line, which remains FIPS 140-2. Official FIPS 140-3 compliance, which additionally requires Docker Hardened Images and enterprise supply chain assurances, is available exclusively from 5.13.x onward. See [FIPS 140-3 Compliance](/developer-support/release-types/fips-release#fips-standard-by-version) for details.
 </Note>
+
+If you build [custom Go plugins](/api-management/plugins/golang) for use with `tyk-gateway-fips`, they must be compiled with a `tyk-plugin-compiler-fips` image for the matching Gateway version. Plugins compiled against a plugin compiler image predating this change are not binary-compatible with `tyk-gateway-fips:v5.8.15` and will fail to load.
 </Accordion>
 
 </AccordionGroup>

--- a/developer-support/release-notes/gateway.mdx
+++ b/developer-support/release-notes/gateway.mdx
@@ -2728,6 +2728,22 @@ If you are upgrading to 5.8.15, please follow the detailed [upgrade instructions
 #### Changelog
 <a id="Changelog-v5.8.15" data-scroll-offset></a>
 
+##### Changed
+
+<AccordionGroup>
+
+<Accordion title='Updated cryptographic module used by tyk-gateway-fips'>
+The `tyk-gateway-fips` image now builds using Go 1.25's native FIPS 140-3 capable cryptographic module (`GOFIPS140=v1.0.0`), replacing the BoringCrypto module (`GOEXPERIMENT=boringcrypto`) used by earlier 5.8.x FIPS releases.
+
+<Note>
+This is a build-time dependency change only. It does not change Tyk's official compliance target for the 5.8.x release line, which remains FIPS 140-2. Official FIPS 140-3 compliance, which additionally requires Docker Hardened Images and enterprise supply chain assurances, is available exclusively from 5.13.x onward. See [FIPS 140-3 Compliance](/developer-support/release-types/fips-release#fips-standard-by-version) for details.
+</Note>
+
+If you build [custom Go plugins](/api-management/plugins/golang) for use with `tyk-gateway-fips`, they must be compiled with a `tyk-plugin-compiler-fips` image for the matching Gateway version. Plugins compiled against a plugin compiler image predating this change are not binary-compatible with `tyk-gateway-fips:v5.8.15` and will fail to load.
+</Accordion>
+
+</AccordionGroup>
+
 ##### Fixed
 
 <AccordionGroup>

--- a/developer-support/release-notes/gateway.mdx
+++ b/developer-support/release-notes/gateway.mdx
@@ -2740,7 +2740,7 @@ For deployments that do not use custom Go plugins, this is a build-time dependen
 
  If you build [custom Go plugins](/api-management/plugins/golang) for use with `tyk-gateway-fips`, you must rebuild them with a `tyk-plugin-compiler-fips` image for the matching Gateway version: plugins compiled against an older plugin compiler image are not binary-compatible with `tyk-gateway-fips:v5.8.15` and will fail to load. 
 
-Official FIPS 140-3 compliance, which additionally requires Docker Hardened Images and enterprise supply chain assurances, is available exclusively from 5.13.x onward. See [FIPS 140-3 Compliance](/developer-support/release-types/fips-release#fips-standard-by-version) for details.
+Official FIPS 140-3 compliance, which additionally requires Docker Hardened Images and enterprise supply chain assurances, is available exclusively from 5.13.x onward. See [FIPS 140-3](/developer-support/release-types/fips-release#fips-standard-by-version) for details.
 </Note>
 </Accordion>
 

--- a/developer-support/release-notes/gateway.mdx
+++ b/developer-support/release-notes/gateway.mdx
@@ -2736,7 +2736,7 @@ If you are upgrading to 5.8.15, please follow the detailed [upgrade instructions
 The `tyk-gateway-fips` image now builds using Go 1.25's native FIPS 140-3 capable cryptographic module (`GOFIPS140=v1.0.0`), replacing the BoringCrypto module (`GOEXPERIMENT=boringcrypto`) used by earlier 5.8.x FIPS releases.
 
 <Note>
-For deployments that do not use custom Go plugins, this is a build-time dependency change only and does not change Tyk's official compliance target for the 5.8.x release line, which remains FIPS 140-2.
+For deployments that do not use custom Go plugins, this is a build-time dependency change only and does not change Tyk's official FIPS readiness target for the 5.8.x release line, which remains FIPS 140-2.
 
  If you build [custom Go plugins](/api-management/plugins/golang) for use with `tyk-gateway-fips`, you must rebuild them with a `tyk-plugin-compiler-fips` image for the matching Gateway version: plugins compiled against an older plugin compiler image are not binary-compatible with `tyk-gateway-fips:v5.8.15` and will fail to load. 
 

--- a/developer-support/release-notes/gateway.mdx
+++ b/developer-support/release-notes/gateway.mdx
@@ -2736,10 +2736,8 @@ If you are upgrading to 5.8.15, please follow the detailed [upgrade instructions
 The `tyk-gateway-fips` image now builds using Go 1.25's native FIPS 140-3 capable cryptographic module (`GOFIPS140=v1.0.0`), replacing the BoringCrypto module (`GOEXPERIMENT=boringcrypto`) used by earlier 5.8.x FIPS releases.
 
 <Note>
-This is a build-time dependency change only. It does not change Tyk's official compliance target for the 5.8.x release line, which remains FIPS 140-2. Official FIPS 140-3 compliance, which additionally requires Docker Hardened Images and enterprise supply chain assurances, is available exclusively from 5.13.x onward. See [FIPS 140-3 Compliance](/developer-support/release-types/fips-release#fips-standard-by-version) for details.
+For deployments that do not use custom Go plugins, this is a build-time dependency change only and does not change Tyk's official compliance target for the 5.8.x release line, which remains FIPS 140-2. If you build [custom Go plugins](/api-management/plugins/golang) for use with `tyk-gateway-fips`, you must rebuild them with a `tyk-plugin-compiler-fips` image for the matching Gateway version: plugins compiled against an older plugin compiler image are not binary-compatible with `tyk-gateway-fips:v5.8.15` and will fail to load. Official FIPS 140-3 compliance, which additionally requires Docker Hardened Images and enterprise supply chain assurances, is available exclusively from 5.13.x onward. See [FIPS 140-3 Compliance](/developer-support/release-types/fips-release#fips-standard-by-version) for details.
 </Note>
-
-If you build [custom Go plugins](/api-management/plugins/golang) for use with `tyk-gateway-fips`, they must be compiled with a `tyk-plugin-compiler-fips` image for the matching Gateway version. Plugins compiled against a plugin compiler image predating this change are not binary-compatible with `tyk-gateway-fips:v5.8.15` and will fail to load.
 </Accordion>
 
 </AccordionGroup>

--- a/developer-support/release-notes/gateway.mdx
+++ b/developer-support/release-notes/gateway.mdx
@@ -2740,7 +2740,7 @@ For deployments that do not use custom Go plugins, this is a build-time dependen
 
  If you build [custom Go plugins](/api-management/plugins/golang) for use with `tyk-gateway-fips`, you must rebuild them with a `tyk-plugin-compiler-fips` image for the matching Gateway version: plugins compiled against an older plugin compiler image are not binary-compatible with `tyk-gateway-fips:v5.8.15` and will fail to load. 
 
-Official FIPS 140-3 compliance, which additionally requires Docker Hardened Images and enterprise supply chain assurances, is available exclusively from 5.13.x onward. See [FIPS 140-3](/developer-support/release-types/fips-release#fips-standard-by-version) for details.
+Official FIPS 140-3 readiness, which additionally requires Docker Hardened Images and enterprise supply chain assurances, is available exclusively from 5.13.x onward. See [FIPS 140-3](/developer-support/release-types/fips-release#fips-standard-by-version) for details.
 </Note>
 </Accordion>
 

--- a/developer-support/release-notes/gateway.mdx
+++ b/developer-support/release-notes/gateway.mdx
@@ -2736,7 +2736,11 @@ If you are upgrading to 5.8.15, please follow the detailed [upgrade instructions
 The `tyk-gateway-fips` image now builds using Go 1.25's native FIPS 140-3 capable cryptographic module (`GOFIPS140=v1.0.0`), replacing the BoringCrypto module (`GOEXPERIMENT=boringcrypto`) used by earlier 5.8.x FIPS releases.
 
 <Note>
-For deployments that do not use custom Go plugins, this is a build-time dependency change only and does not change Tyk's official compliance target for the 5.8.x release line, which remains FIPS 140-2. If you build [custom Go plugins](/api-management/plugins/golang) for use with `tyk-gateway-fips`, you must rebuild them with a `tyk-plugin-compiler-fips` image for the matching Gateway version: plugins compiled against an older plugin compiler image are not binary-compatible with `tyk-gateway-fips:v5.8.15` and will fail to load. Official FIPS 140-3 compliance, which additionally requires Docker Hardened Images and enterprise supply chain assurances, is available exclusively from 5.13.x onward. See [FIPS 140-3 Compliance](/developer-support/release-types/fips-release#fips-standard-by-version) for details.
+For deployments that do not use custom Go plugins, this is a build-time dependency change only and does not change Tyk's official compliance target for the 5.8.x release line, which remains FIPS 140-2.
+
+ If you build [custom Go plugins](/api-management/plugins/golang) for use with `tyk-gateway-fips`, you must rebuild them with a `tyk-plugin-compiler-fips` image for the matching Gateway version: plugins compiled against an older plugin compiler image are not binary-compatible with `tyk-gateway-fips:v5.8.15` and will fail to load. 
+
+Official FIPS 140-3 compliance, which additionally requires Docker Hardened Images and enterprise supply chain assurances, is available exclusively from 5.13.x onward. See [FIPS 140-3 Compliance](/developer-support/release-types/fips-release#fips-standard-by-version) for details.
 </Note>
 </Accordion>
 

--- a/developer-support/release-types/fips-release.mdx
+++ b/developer-support/release-types/fips-release.mdx
@@ -57,10 +57,13 @@ Compliance posture depends on the software version. See below for version-specif
 
 
 * Targets **FIPS 140-2** compliance
-* Available as **RPM/DEB packages only** using the BoringCrypto cryptographic module
+* Available as **RPM/DEB packages only**
+* From version 5.8.15, uses Go 1.25's native FIPS 140-3 capable cryptographic module (`GOFIPS140=v1.0.0`); earlier 5.8.x releases used the BoringCrypto module
 * Not built on a FIPS-certified base image
 * Compliance applies to the packaged binaries only; it does not extend to the container image, plug-ins, or surrounding environment
 * Does not include DHI supply chain attestations (SLSA/SBOMs)
+
+> **Using the newer Go FIPS 140-3 capable module does not make 5.8.x FIPS 140-3 compliant.** Official FIPS 140-3 compliance, as targeted in 5.13.x, additionally requires Docker Hardened Images and enterprise supply chain assurances (SLSA Level 3 build provenance, signed SBOMs, and STIG compliance). 5.8.x remains our FIPS 140-2 targeted release line for compliance purposes.
 
 > **If your organisation has regulatory obligations requiring FIPS 140-3, a certified base image, or supply chain attestations, you should be on version 5.13.x or later using Docker Hardened Images.** Contact your Tyk account team for upgrade planning support.
 
@@ -95,7 +98,7 @@ Use of Tyk's FIPS Products is conditional on:
 
 <AccordionGroup>
 <Accordion title="Are All Tyk FIPS Products Equivalent in Their Compliance Posture?">
-No. Version 5.8.x targets FIPS 140-2 using BoringCrypto and is not built on a certified base image. Version 5.13.x and later targets FIPS 140-3 using Go’s native cryptographic implementation, is delivered as Docker Hardened Images with a FIPS-validated base layer, and includes supply chain attestations. If your requirements specify FIPS 140-3, a certified base image, or SBOMs, you need 5.13.x or later.
+No. Version 5.8.x targets FIPS 140-2 compliance and is not built on a certified base image. From version 5.8.15, it uses the same Go native FIPS 140-3 capable cryptographic module as 5.13.x, but this does not change its FIPS 140-2 compliance target. Version 5.13.x and later targets FIPS 140-3 compliance, is delivered as Docker Hardened Images with a FIPS-validated base layer, and includes supply chain attestations. If your requirements specify FIPS 140-3, a certified base image, or SBOMs, you need 5.13.x or later.
 </Accordion>
 
 <Accordion title="Is Tyk FIPS-Certified?">

--- a/developer-support/release-types/fips-release.mdx
+++ b/developer-support/release-types/fips-release.mdx
@@ -57,13 +57,10 @@ Compliance posture depends on the software version. See below for version-specif
 
 
 * Targets **FIPS 140-2** compliance
-* Available as **RPM/DEB packages only**
-* From version 5.8.15, uses Go 1.25's native FIPS 140-3 capable cryptographic module (`GOFIPS140=v1.0.0`); earlier 5.8.x releases used the BoringCrypto module
+* Available as **RPM/DEB packages only** using the BoringCrypto cryptographic module
 * Not built on a FIPS-certified base image
 * Compliance applies to the packaged binaries only; it does not extend to the container image, plug-ins, or surrounding environment
 * Does not include DHI supply chain attestations (SLSA/SBOMs)
-
-> **Using the newer Go FIPS 140-3 capable module does not make 5.8.x FIPS 140-3 compliant.** Official FIPS 140-3 compliance, as targeted in 5.13.x, additionally requires Docker Hardened Images and enterprise supply chain assurances (SLSA Level 3 build provenance, signed SBOMs, and STIG compliance). 5.8.x remains our FIPS 140-2 targeted release line for compliance purposes.
 
 > **If your organisation has regulatory obligations requiring FIPS 140-3, a certified base image, or supply chain attestations, you should be on version 5.13.x or later using Docker Hardened Images.** Contact your Tyk account team for upgrade planning support.
 
@@ -98,7 +95,7 @@ Use of Tyk's FIPS Products is conditional on:
 
 <AccordionGroup>
 <Accordion title="Are All Tyk FIPS Products Equivalent in Their Compliance Posture?">
-No. Version 5.8.x targets FIPS 140-2 compliance and is not built on a certified base image. From version 5.8.15, it uses the same Go native FIPS 140-3 capable cryptographic module as 5.13.x, but this does not change its FIPS 140-2 compliance target. Version 5.13.x and later targets FIPS 140-3 compliance, is delivered as Docker Hardened Images with a FIPS-validated base layer, and includes supply chain attestations. If your requirements specify FIPS 140-3, a certified base image, or SBOMs, you need 5.13.x or later.
+No. Version 5.8.x targets FIPS 140-2 using BoringCrypto and is not built on a certified base image. Version 5.13.x and later targets FIPS 140-3 using Go’s native cryptographic implementation, is delivered as Docker Hardened Images with a FIPS-validated base layer, and includes supply chain attestations. If your requirements specify FIPS 140-3, a certified base image, or SBOMs, you need 5.13.x or later.
 </Accordion>
 
 <Accordion title="Is Tyk FIPS-Certified?">

--- a/developer-support/release-types/fips-release.mdx
+++ b/developer-support/release-types/fips-release.mdx
@@ -45,7 +45,7 @@ FIPS Products are available on the **current LTS**, **LTS-1**, and **latest feat
 
 Compliance posture depends on the software version. See below for version-specific details.
 
-**5.13.X will become our next LTS version in the summer of 2026. Please refer to this [page](/developer-support/release-types/long-term-support) for exact timelines**
+**5.13.x is our current LTS release. Please refer to this [page](/developer-support/release-types/long-term-support) for exact timelines**
 
 * Targets **FIPS 140-3** compliance
 * Available as **Docker Hardened Images (DHI)** or **native OS packages (RPM/DEB)**
@@ -53,7 +53,7 @@ Compliance posture depends on the software version. See below for version-specif
 * DHI builds additionally use a FIPS-validated base image, are STIG-compliant, and include enterprise supply chain security controls (SLSA Level 3 build provenance, signed SBOMs, and cryptographic image signatures)
 * Native packages deliver the core FIPS-compliant cryptographic binaries but do not include a certified base image or supply chain attestations
 
-**Version 5.8.x (LTS-1, in Maintenance Support from the point 5.13.X is anointed at LTS, summer of 2026)**
+**Version 5.8.x (LTS-1, now in Maintenance Support)**
 
 
 * Targets **FIPS 140-2** compliance


### PR DESCRIPTION
### **User description**
## Summary

- 5.8.15 switched `tyk-gateway-fips` and `tyk-dashboard-fips` from BoringCrypto to Go 1.25's native FIPS 140-3 capable cryptographic module (`GOFIPS140=v1.0.0`), which wasn't reflected in the release notes and left the change unexplained for customers who hit custom Go plugin compatibility issues on upgrade.
- Our FIPS policy page still described 5.8.x as using BoringCrypto only, which is now inaccurate as of 5.8.15.

Per Allan's clarification in the thread: this module change alone does **not** make 5.8.x officially FIPS 140-3 compliant. Official FIPS 140-3 compliance (as targeted in 5.13.x) also requires Docker Hardened Images and enterprise supply chain assurances (SLSA provenance, signed SBOMs, STIG compliance), which 5.8.x does not have. 5.8.x remains the FIPS 140-2 targeted release line.


___

### **PR Type**
Documentation


___

### **Description**
- Document 5.8.15 FIPS module switch

- Clarify 5.8.x remains FIPS 140-2

- Add plugin compatibility upgrade warning

- Update FIPS policy version guidance


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["tyk-gateway-fips and tyk-dashboard-fips"] -- "switch to" --> B["Go 1.25 native FIPS-capable module"]
  B -- "documented in" --> C["5.8.15 release notes"]
  B -- "clarified against" --> D["5.8.x compliance target remains FIPS 140-2"]
  D -- "contrast with" --> E["5.13.x official FIPS 140-3 posture"]
  C -- "adds" --> F["custom Go plugin compatibility warning"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashboard.mdx</strong><dd><code>Dashboard release notes FIPS module clarification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

developer-support/release-notes/dashboard.mdx

<ul><li>Add 5.8.15 note for <code>tyk-dashboard-fips</code><br> <li> Document switch from BoringCrypto to <code>GOFIPS140=v1.0.0</code><br> <li> Clarify change does not alter compliance target<br> <li> Link readers to FIPS version guidance</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/2585/files#diff-46eab3c33b18d7ca160d2569a5d0575603ce1af6ba1af53ae2a943aff9926bb4">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gateway.mdx</strong><dd><code>Gateway release notes add FIPS change</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

developer-support/release-notes/gateway.mdx

<ul><li>Add <code>Changed</code> section for 5.8.15<br> <li> Document <code>tyk-gateway-fips</code> cryptographic module update<br> <li> Clarify 5.8.x remains FIPS 140-2<br> <li> Warn about custom Go plugin incompatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/2585/files#diff-9095026f67d8773f400fd494ced0d00ea8034dc1ccd14aa0988038ca8f45d0be">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fips-release.mdx</strong><dd><code>FIPS policy page compliance boundary update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

developer-support/release-types/fips-release.mdx

<ul><li>Update 5.8.x version-specific FIPS details<br> <li> Note 5.8.15 uses Go native module<br> <li> Explain this does not imply 140-3 compliance<br> <li> Revise FAQ to reflect compliance boundary</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/2585/files#diff-c0336861e42dc15798b6b97689ec813a7a70e6d3f3b001a04a11a18c930d796b">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

