### PR TITLE
Fix stale custom metrics link in MCP Gateway metrics page

### DIFF
--- a/ai-management/mcp-gateway/mcp-metrics.mdx
+++ b/ai-management/mcp-gateway/mcp-metrics.mdx
@@ -28,7 +28,7 @@ All four fields are populated only for MCP APIs. For non-MCP requests they are e
 
 ## Use cases
 
-The examples below use Tyk's [custom metrics](/api-management/logs) system. Each instrument is a JSON object in the `opentelemetry.metrics.api_metrics` array in `tyk.conf`.
+The examples below use Tyk's [custom metrics](/api-management/metrics/custom-metrics) system. Each instrument is a JSON object in the `opentelemetry.metrics.api_metrics` array in `tyk.conf`.
 
 ### MCP traffic volume by method
 


### PR DESCRIPTION
## Summary
- The `custom metrics` link on the MCP Gateway metrics page pointed at a placeholder target (`/api-management/logs`) left over from before the Custom Metrics page existed.
- Repoints it at `/api-management/metrics/custom-metrics`, the actual Custom Metrics page.

## Test plan
- [ ] Confirm the link resolves correctly on the built docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)