### PR TITLE
docs: restore full request-body example for PUT /users/:id

### DIFF
--- a/swagger/enterprise-developer-portal-swagger.yaml
+++ b/swagger/enterprise-developer-portal-swagger.yaml
@@ -3375,8 +3375,15 @@ paths:
             schema:
               $ref: "#/components/schemas/User-update"
             example:
+              Active: true
+              Email: admin@acme.com
+              First: John
+              Last: Doe
               OrganisationID: 1
+              Role: consumer-team-member
+              Provider: password
               Teams: ["team-id-1", "team-id-2"]
+              ResetPassword: false
       responses:
         "200":
           content:

--- a/swagger/enterprise-developer-portal-swagger.yaml
+++ b/swagger/enterprise-developer-portal-swagger.yaml
@@ -3374,16 +3374,6 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/User-update"
-            example:
-              Active: true
-              Email: admin@acme.com
-              First: John
-              Last: Doe
-              OrganisationID: 1
-              Role: consumer-team-member
-              Provider: password
-              Teams: ["team-id-1", "team-id-2"]
-              ResetPassword: false
       responses:
         "200":
           content:
@@ -7832,7 +7822,7 @@ components:
               description: Array of team IDs that this user belongs to
               items:
                 type: string
-                example: "team-id-1"
+              example: ["team-id-1", "team-id-2"]
             ResetPassword:
               type: boolean
               description: >-

--- a/swagger/enterprise-developer-portal-swagger.yaml
+++ b/swagger/enterprise-developer-portal-swagger.yaml
@@ -7794,10 +7794,9 @@ components:
               example: false
             Teams:
               items:
-                type: string
-                description: Name of this user's teams
-                example: Default Organisation All users
+                $ref: "#/components/schemas/Team-show"
               type: array
+              description: Teams that this user belongs to
             ID:
               type: integer
               description: UID of a user


### PR DESCRIPTION
## Problem / Task

Follow-up to #2527 (merged), which synced portal PR #1937 and added an explicit `example:` to the `PUT /portal-api/users/:id` request body to demonstrate the new `Teams` array-of-IDs support:

```yaml
example:
  OrganisationID: 1
  Teams: ["team-id-1", "team-id-2"]
```

An explicit media-type-level `example` completely replaces the example Mintlify would otherwise auto-generate from each schema property's individual `example:` value. Before #2527, there was no explicit example, so the rendered request body included all of `User-basis`'s fields (`Active`, `Email`, `First`, `Last`, `Role`, `Provider`) plus `Teams` and `ResetPassword`. After #2527, the rendered example dropped to just the two fields listed above, which is a regression in the docs' usefulness even though it correctly demonstrates `Teams`.

## Changes

- Restored `Active`, `Email`, `First`, `Last`, `Role`, `Provider` and `ResetPassword` in the request body `example`, using the same values each field's schema already documents, alongside the corrected `Teams: ["team-id-1", "team-id-2"]`.
- Mirrors source-of-truth portal PR TykTechnologies/portal#1949.

## Testing

- Validated the Swagger YAML syntax.