### PR TITLE
Fix outdated-version banner to stay pinned when a page loads at an anchor

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -107,9 +107,10 @@ jobs:
           # Define files to keep (whitelist)
           keep_files=(
             "branches-config.json"
-            ".gitignore" 
+            ".gitignore"
             "README.md"
             ".vale.ini"
+            "outdated-version-banner.js"
           )
           
           echo "📋 Folders to keep: ${keep_folders[*]}"

--- a/outdated-version-banner.js
+++ b/outdated-version-banner.js
@@ -25,10 +25,10 @@
   // branches-config.json marks isLatest, LTS_VERSIONS as a JSON array of every
   // target_folder marked isLts. Dismissal is keyed to LATEST_VERSION, so both
   // banners automatically reappear for everyone once a new version ships.
-  var LATEST_VERSION = '{{LATEST_VERSION}}';
+  var LATEST_VERSION = '5.14';
   var LTS_VERSIONS = (function () {
     try {
-      return JSON.parse('{{LTS_VERSIONS}}');
+      return JSON.parse('["5.13"]');
     } catch (e) {
       return [];
     }

--- a/outdated-version-banner.js
+++ b/outdated-version-banner.js
@@ -1,0 +1,245 @@
+(function () {
+  // Merged deploys copy this file into version folders too, and Mintlify
+  // includes every .js in the content directory globally - run only once.
+  if (window.__tykOutdatedBannerInit) return;
+  window.__tykOutdatedBannerInit = true;
+
+  // Matches a version segment such as /5.10/ or /5.10.2/ anywhere in the path.
+  // "nightly" is intentionally excluded - it isn't a numbered release users need
+  // redirecting away from.
+  var versionRegex = /\/(\d+\.\d+(?:\.\d+)?)(?=\/|$)/;
+
+  var BANNER_ID = 'tyk-outdated-banner';
+  var SPACER_ID = 'tyk-outdated-banner-spacer';
+  var DISMISS_KEY_PREFIX = 'tykBannerDismissed:';
+  var HEIGHT_VAR = '--tyk-outdated-banner-height';
+
+  // {{LATEST_VERSION}} and {{LTS_VERSIONS}} are substituted at deploy time by
+  // scripts/merge_docs_configs.py: LATEST_VERSION from whichever version
+  // branches-config.json marks isLatest, LTS_VERSIONS as a JSON array of every
+  // target_folder marked isLts. Dismissal is keyed to LATEST_VERSION, so both
+  // banners automatically reappear for everyone once a new version ships.
+  var LATEST_VERSION = '{{LATEST_VERSION}}';
+  var LTS_VERSIONS = (function () {
+    try {
+      return JSON.parse('{{LTS_VERSIONS}}');
+    } catch (e) {
+      return [];
+    }
+  })();
+
+  var BANNER_CONFIG = {
+    outdated: {
+      color: '#d97706',
+      icon: '⚠️ ',
+      title: 'Outdated Version',
+      body:
+        ' - This page refers to an older version of our documentation. ' +
+        'We recommend using the ',
+      linkText: 'latest release (v' + LATEST_VERSION + ')',
+      suffix: ' for the most up-to-date guidance.',
+    },
+    lts: {
+      color: '#2563eb',
+      icon: 'ℹ️ ',
+      title: 'Long Term Support (LTS) Version',
+      body: " - If you'd like to see what's new, the ",
+      linkText: 'latest release (v' + LATEST_VERSION + ')',
+      suffix: ' is available here.',
+    },
+  };
+
+  function dismissKey(kind) {
+    return DISMISS_KEY_PREFIX + kind;
+  }
+
+  function isDismissed(kind) {
+    try {
+      return localStorage.getItem(dismissKey(kind)) === LATEST_VERSION;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  function pathVersion() {
+    var match = versionRegex.exec(location.pathname);
+    return match ? match[1] : null;
+  }
+
+  function bannerKind() {
+    var version = pathVersion();
+    if (!version) return null;
+    return LTS_VERSIONS.indexOf(version) !== -1 ? 'lts' : 'outdated';
+  }
+
+  function findNavbar() {
+    return document.getElementById('navbar');
+  }
+
+  // The banner is fixed to the viewport top rather than inserted into the
+  // page content, so it stays visible on every scroll position - including
+  // landing on an anchor link straight into the middle of a page, which used
+  // to scroll straight past a banner embedded at the top of the content.
+  function buildBanner(kind) {
+    var config = BANNER_CONFIG[kind];
+
+    var el = document.createElement('div');
+    el.id = BANNER_ID;
+    el.setAttribute('data-kind', kind);
+    el.style.cssText =
+      'position:fixed;top:0;left:0;width:100%;z-index:45;background:' +
+      config.color +
+      ';color:#fff;text-align:center;' +
+      'font-size:14px;line-height:1.5;padding:10px 44px;box-sizing:border-box;';
+
+    var text = document.createElement('span');
+    text.appendChild(document.createTextNode(config.icon));
+
+    var strong = document.createElement('strong');
+    strong.textContent = config.title;
+    text.appendChild(strong);
+
+    text.appendChild(document.createTextNode(config.body));
+
+    var link = document.createElement('a');
+    link.setAttribute('data-role', 'latest-link');
+    link.style.cssText = 'color:#fff;font-weight:600;text-decoration:underline;';
+    link.textContent = config.linkText;
+    text.appendChild(link);
+
+    text.appendChild(document.createTextNode(config.suffix));
+
+    el.appendChild(text);
+
+    var close = document.createElement('button');
+    close.setAttribute('aria-label', 'Dismiss banner');
+    close.textContent = '✕';
+    close.style.cssText =
+      'position:absolute;right:12px;top:50%;transform:translateY(-50%);' +
+      'background:none;border:none;color:#fff;font-size:16px;cursor:pointer;padding:4px;';
+    close.onclick = function () {
+      try {
+        localStorage.setItem(dismissKey(kind), LATEST_VERSION);
+      } catch (e) {}
+      removeBanner();
+    };
+    el.appendChild(close);
+
+    return el;
+  }
+
+  // An invisible spacer, sized to match the fixed banner's own height, is
+  // inserted as the first child of the navbar. The banner is removed from
+  // normal flow (position:fixed), so without this the navbar and sidebar
+  // would render underneath it; the spacer pushes them down by exactly the
+  // banner's height instead, mirroring how Mintlify offsets its own layout
+  // for its native (docs.json-configured) banner feature.
+  function buildSpacer() {
+    var spacer = document.createElement('div');
+    spacer.id = SPACER_ID;
+    spacer.setAttribute('aria-hidden', 'true');
+    spacer.style.cssText = 'width:100%;height:var(' + HEIGHT_VAR + ',0px);';
+    return spacer;
+  }
+
+  function syncHeight(banner) {
+    var height = banner ? banner.offsetHeight : 0;
+    document.documentElement.style.setProperty(HEIGHT_VAR, height + 'px');
+  }
+
+  function removeBanner() {
+    var existing = document.getElementById(BANNER_ID);
+    var spacer = document.getElementById(SPACER_ID);
+    if (existing) existing.remove();
+    if (spacer) spacer.remove();
+    document.documentElement.style.removeProperty(HEIGHT_VAR);
+  }
+
+  function updateBanner() {
+    var existing = document.getElementById(BANNER_ID);
+    var kind = bannerKind();
+
+    if (!kind || isDismissed(kind)) {
+      if (existing) removeBanner();
+      return;
+    }
+
+    if (existing && existing.getAttribute('data-kind') !== kind) {
+      removeBanner();
+      existing = null;
+    }
+
+    var navbar = findNavbar();
+
+    if (!existing) {
+      existing = buildBanner(kind);
+      if (navbar && navbar.parentNode) {
+        navbar.parentNode.insertBefore(existing, navbar);
+      } else {
+        document.body.insertBefore(existing, document.body.firstChild);
+      }
+      syncHeight(existing);
+    }
+
+    // The spacer lives inside the navbar's own subtree, so it can be dropped
+    // by a navbar re-render independently of the banner itself surviving -
+    // re-check and reinsert it on every update, not just when first built.
+    if (navbar && !document.getElementById(SPACER_ID)) {
+      navbar.insertBefore(buildSpacer(), navbar.firstChild);
+    }
+
+    // Point the link at the same page in the latest version (strip the
+    // version segment), keeping any query string or anchor so the reader
+    // lands on the exact same section, not just the top of the page.
+    var link = existing.querySelector('a[data-role="latest-link"]');
+    if (link) {
+      link.href =
+        location.origin +
+        location.pathname.replace(versionRegex, '') +
+        location.search +
+        location.hash;
+    }
+  }
+
+  function debounce(fn, wait) {
+    var timer;
+    return function () {
+      clearTimeout(timer);
+      timer = setTimeout(fn, wait);
+    };
+  }
+
+  var scheduleUpdate = debounce(updateBanner, 100);
+
+  // The banner's height changes with viewport width (its text wraps onto
+  // more lines on narrow screens), so the spacer/layout offset needs to be
+  // recalculated whenever the window resizes, not just once on load.
+  var scheduleResync = debounce(function () {
+    syncHeight(document.getElementById(BANNER_ID));
+  }, 100);
+  window.addEventListener('resize', scheduleResync);
+
+  // Mintlify is a SPA: client-side navigation changes the path via the
+  // History API without a full page load. Hook both so we catch it, then
+  // fall back to a MutationObserver in case a route swaps content without
+  // going through history (e.g. an in-place re-render).
+  ['pushState', 'replaceState'].forEach(function (method) {
+    var original = history[method];
+    history[method] = function () {
+      var result = original.apply(this, arguments);
+      scheduleUpdate();
+      return result;
+    };
+  });
+  window.addEventListener('popstate', scheduleUpdate);
+
+  updateBanner();
+
+  // Observed at the body level (not just the navbar) because the spacer
+  // lives inside the navbar's own React-managed subtree - a re-render there
+  // could drop it even when the navbar element itself is untouched.
+  new MutationObserver(scheduleUpdate).observe(document.body, {
+    childList: true,
+    subtree: true,
+  });
+})();

--- a/outdated-version-banner.js
+++ b/outdated-version-banner.js
@@ -20,7 +20,7 @@
   var DISMISS_DAYS = 7;
   var DISMISS_MS = DISMISS_DAYS * 24 * 60 * 60 * 1000;
 
-  // {{LATEST_VERSION}} and {{LTS_VERSIONS}} are substituted at deploy time by
+  // The two string literals below are substituted at deploy time by
   // scripts/merge_docs_configs.py: LATEST_VERSION from whichever version
   // branches-config.json marks isLatest, LTS_VERSIONS as a JSON array of every
   // target_folder marked isLts. Dismissal is keyed to LATEST_VERSION, so both

--- a/outdated-version-banner.js
+++ b/outdated-version-banner.js
@@ -25,10 +25,10 @@
   // branches-config.json marks isLatest, LTS_VERSIONS as a JSON array of every
   // target_folder marked isLts. Dismissal is keyed to LATEST_VERSION, so both
   // banners automatically reappear for everyone once a new version ships.
-  var LATEST_VERSION = '5.14';
+  var LATEST_VERSION = '{{LATEST_VERSION}}';
   var LTS_VERSIONS = (function () {
     try {
-      return JSON.parse('["5.13"]');
+      return JSON.parse('{{LTS_VERSIONS}}');
     } catch (e) {
       return [];
     }

--- a/outdated-version-banner.js
+++ b/outdated-version-banner.js
@@ -13,6 +13,12 @@
   var SPACER_ID = 'tyk-outdated-banner-spacer';
   var DISMISS_KEY_PREFIX = 'tykBannerDismissed:';
   var HEIGHT_VAR = '--tyk-outdated-banner-height';
+  // A dismissal also expires after a fixed number of days, on top of being
+  // keyed to LATEST_VERSION below - otherwise someone who dismisses right
+  // after a release ships would not see the banner again until the *next*
+  // release, however long that takes.
+  var DISMISS_DAYS = 7;
+  var DISMISS_MS = DISMISS_DAYS * 24 * 60 * 60 * 1000;
 
   // {{LATEST_VERSION}} and {{LTS_VERSIONS}} are substituted at deploy time by
   // scripts/merge_docs_configs.py: LATEST_VERSION from whichever version
@@ -53,9 +59,23 @@
     return DISMISS_KEY_PREFIX + kind;
   }
 
+  function setDismissed(kind) {
+    try {
+      localStorage.setItem(
+        dismissKey(kind),
+        JSON.stringify({ version: LATEST_VERSION, dismissedAt: Date.now() })
+      );
+    } catch (e) {}
+  }
+
   function isDismissed(kind) {
     try {
-      return localStorage.getItem(dismissKey(kind)) === LATEST_VERSION;
+      var record = JSON.parse(localStorage.getItem(dismissKey(kind)));
+      return (
+        !!record &&
+        record.version === LATEST_VERSION &&
+        Date.now() - record.dismissedAt < DISMISS_MS
+      );
     } catch (e) {
       return false;
     }
@@ -118,9 +138,7 @@
       'position:absolute;right:12px;top:50%;transform:translateY(-50%);' +
       'background:none;border:none;color:#fff;font-size:16px;cursor:pointer;padding:4px;';
     close.onclick = function () {
-      try {
-        localStorage.setItem(dismissKey(kind), LATEST_VERSION);
-      } catch (e) {}
+      setDismissed(kind);
       removeBanner();
     };
     el.appendChild(close);

--- a/scripts/merge_docs_configs.py
+++ b/scripts/merge_docs_configs.py
@@ -30,6 +30,7 @@ class DocsMerger:
         self.target_folders = {}  # Maps source_folder -> target_folder
         self.latest_version = None
         self.main_version = None  # Track main branch with most current assets
+        self.lts_versions = []  # target_folders marked isLts in branches-config.json
 
     def load_version_config(self, config_path: str, version: str) -> Dict:
         """Load a single version configuration."""
@@ -57,6 +58,7 @@ class DocsMerger:
                 self.external_versions = {}  # Store external version info
                 self.source_folders = {}  # Maps target_folder -> source_folder
                 self.target_folders = {}  # Maps source_folder -> target_folder
+                self.lts_versions = []
 
                 for version_info in versions:
                     is_external = version_info.get('isExternal', False)
@@ -108,6 +110,8 @@ class DocsMerger:
                                 self.latest_version = target_folder
                             if is_main:
                                 self.main_version = target_folder
+                            if is_lts:
+                                self.lts_versions.append(target_folder)
 
                             if source_folder != target_folder:
                                 print(f"📁 Version {target_folder}: source='{source_folder}' → target='{target_folder}'")
@@ -119,6 +123,7 @@ class DocsMerger:
                 print(f"🔗 External versions: {len(self.external_versions)} found")
                 print(f"⭐ Latest version: {self.latest_version}")
                 print(f"🔧 Main version: {self.main_version}")
+                print(f"🛡️  LTS versions: {self.lts_versions}")
 
                 return config
         except Exception as e:
@@ -1380,6 +1385,48 @@ class DocsMerger:
                 unified[field] = value
 
         return unified
+
+    def substitute_latest_version_in_banner_scripts(self, base_dir: str = ".") -> None:
+        """Replace {{LATEST_VERSION}} and {{LTS_VERSIONS}} in every copy of
+        outdated-version-banner.js.
+
+        The outdated-version banner widget embeds the latest version number in
+        its message text, and its dismissal handling stores that exact text -
+        so substituting a fresh version number on each release automatically
+        makes a previously-dismissed banner reappear for everyone. It also
+        embeds the list of target_folders marked isLts in branches-config.json,
+        so the widget can show the informational LTS banner instead of the
+        outdated-version warning on those versions.
+
+        Every copy in the output tree is patched (not just the root one):
+        merged deploys duplicate root-level JS into version folders, Mintlify
+        includes all of them globally, and load order between copies is not
+        guaranteed.
+        """
+        if not self.latest_version:
+            return
+
+        lts_versions_json = json.dumps(self.lts_versions)
+
+        for script_path in Path(base_dir).rglob("outdated-version-banner.js"):
+            try:
+                content = script_path.read_text(encoding="utf-8")
+                changed = False
+                if "{{LATEST_VERSION}}" in content:
+                    content = content.replace("{{LATEST_VERSION}}", self.latest_version)
+                    changed = True
+                if "{{LTS_VERSIONS}}" in content:
+                    content = content.replace("{{LTS_VERSIONS}}", lts_versions_json)
+                    changed = True
+                if changed:
+                    script_path.write_text(content, encoding="utf-8")
+                    print(
+                        f"🏷️  Substituted latest version ({self.latest_version}) and "
+                        f"LTS versions ({lts_versions_json}) in {script_path}"
+                    )
+            except Exception as e:
+                print(f"⚠️ Could not substitute version in {script_path}: {e}")
+
     def merge(self, version_configs: Dict[str, str] = None,
               config_dir: str = None,
               base_dir: str = None,
@@ -1419,6 +1466,9 @@ class DocsMerger:
         # Copy latest version content to root if requested
         if copy_latest:
             self.organize_content_files(configs, base_dir or ".")
+
+        # Stamp the current latest version into the outdated-version banner widget
+        self.substitute_latest_version_in_banner_scripts(base_dir or ".")
 
         # Create unified configuration
         unified_config = self.create_unified_config(configs)


### PR DESCRIPTION
## Summary
Supersedes #2602. Same widget approach (self-injected script, bypassing Mintlify's native `docs.json` `banner` field since it can't be scoped per-version), reworked for positioning, and targeted directly at `production` instead of `main`:

- The old widget inserted the banner as the first child of the content container, in normal document flow. Landing on a page via an anchor link, or scrolling at all, would move the banner out of view - readers on old-version pages could easily never see it.
- The banner is now `position:fixed` to the viewport top, inserted as a sibling before `#navbar` rather than inside the content area, so it stays visible regardless of scroll position or where the page lands on load.
- A spacer is inserted as the first child of `#navbar`, sized to the banner's own measured height via a CSS variable, so the navbar and sidebar get pushed down instead of rendering underneath the fixed banner. This mirrors how Mintlify offsets its own layout for its native (docs.json-configured) banner - confirmed by inspecting that feature's rendered DOM/CSS directly, since it isn't documented.
- Height is re-measured on resize, since the banner's text wraps differently at different viewport widths.
- A dismissal now also expires after 7 days on top of being keyed to `LATEST_VERSION`, so someone who dismisses right after a release ships isn't stuck without the banner until the *next* release, however long that takes.
- Everything else is unchanged from #2602: outdated (amber) vs LTS (blue) banner kinds, link rewriting that preserves query string/hash, and `{{LATEST_VERSION}}`/`{{LTS_VERSIONS}}` substitution at build time via `scripts/merge_docs_configs.py`.

**Base branch changed to `production` directly** (was `main`): `main` and `production` keep independent copies of `scripts/merge_docs_configs.py`, and the real deploy pipeline (`deploy-docs.yml`) only ever runs production's own copy. #2602 only patched main's copy, which would have left the `{{LATEST_VERSION}}`/`{{LTS_VERSIONS}}` placeholders unsubstituted live. This PR instead adds the same `lts_versions` tracking and `substitute_latest_version_in_banner_scripts` call directly to production's copy of the merge script, adapted to its own (already-diverged) structure.

**Found and fixed a real deploy-pipeline bug while verifying this end to end:** `deploy-docs.yml`'s cleanup step wipes every file/folder not on a hardcoded whitelist before re-cloning from release branches. `outdated-version-banner.js` wasn't on that whitelist and doesn't live on any individual release branch (it only ever existed at production's own root) - so the very next real deploy after this merges would have silently deleted it with no way to regenerate it. Added it to `keep_files` in the workflow. Also fixed the placeholder-substitution comment, which literally contained the `{{LATEST_VERSION}}`/`{{LTS_VERSIONS}}` tokens it was describing, so the deploy-time string replace was mangling the comment text itself along with the real values.

## Test plan
- [x] Verified locally: merged a 4-version test build (5.10, 5.13 LTS, 5.14 latest, nightly) and ran it via `mint dev`
- [x] Confirmed the banner stays visible when loading a page directly at a heading anchor (the bug this fixes)
- [x] Confirmed navbar/sidebar are not covered by the fixed banner
- [x] Ran the actual deploy pipeline locally against this branch: shallow-cloned all 8 real release branches (`release-5.14` through `release-5.8`, plus `main`/nightly), ran `merge_docs_configs.py`, `add-canonical-urls`, `fix_openapi_slug_collisions.py`, and `validate_openapi_slugs.py` exactly as CI does
- [x] Confirmed `LATEST_VERSION`/`LTS_VERSIONS` correctly substitute to real values (`5.14` / `["5.13"]`) and the LTS banner correctly renders on `/5.13/*` pages, via a `mint dev` server against the fully regenerated output
- [ ] Review/merge, then decide whether to close #2602 in favor of this