### PR TITLE
fix: anchor logs pattern in .gitignore to repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ __pycache__/
 
 ### Node template
 # Logs
-logs
+/logs
 *.log
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
## Summary
- \`production\`'s \`.gitignore\` has an unanchored \`logs\` entry (default Node template line), which git treats as matching a directory/file named \`logs\` at **any depth**, not just repo root.
- PR #2556 added a new \`api-management/logs/\` subdirectory (5 pages: access-logs, application-logs, audit-logs, external-data-sinks, traffic-logs) to \`main\`, cherry-picked to \`release-5.14\` via #2665.
- When the \`deploy-docs.yml\` auto-merge workflow (PR #2666 / \`docs-merge-1035\`) staged the generated output via \`create-pull-request\`, git silently ignored \`api-management/logs/*\` and \`nightly/api-management/logs/*\` because of this pattern — the files exist in both source branches but never made it into the merge commit.
- Result: \`api-management/logs.mdx\` (updated by the same PR to link to these new pages) ends up pointing at pages that don't exist in the merged output → 170 broken links, failing the Mintlify link-rot check on #2666.
- \`main\`'s \`.gitignore\` already anchors this correctly as \`/logs\`, which is why the original PR #2556 never hit this on \`main\`.

## Fix
Anchor the pattern to repo root (\`/logs\`), matching \`main\`'s \`.gitignore\`, so it only ignores a top-level \`logs/\` directory and no longer swallows nested docs paths.

## Test plan
- [ ] Verified locally with \`git check-ignore\` that \`api-management/logs/traffic-logs.mdx\` and \`nightly/api-management/logs/traffic-logs.mdx\` are no longer ignored after the fix
- [ ] Re-run/re-trigger the \`deploy-docs.yml\` auto-merge so the next \`docs-merge-*\` PR picks up the missing \`api-management/logs/*\` pages and the link-rot check passes