### PR TITLE
[Draft/Experiment] Tyk Gateway 5.15.0 release notes

### DIFF
--- a/developer-support/release-notes/gateway.mdx
+++ b/developer-support/release-notes/gateway.mdx
@@ -15,6 +15,83 @@ Only the most recent Tyk Gateway release and the most recent on the [Long Term S
 
 ---
 
+## 5.15 Release Notes 
+
+### 5.15.0 Release Notes 
+
+#### Release Date 7 August 2026
+
+#### Release Highlights
+
+**Create an MCP Proxy from a REST API**
+
+Tyk Gateway now lets you create an MCP proxy directly from an existing Tyk-managed REST API, without writing a dedicated MCP server. The Gateway derives a tool catalogue automatically from the source API's OpenAPI definition: every valid, exposable operation is exposed as an MCP tool by default. You can optionally restrict the catalogue with an allow list, or override tool and parameter names and descriptions to make them clearer for AI agents. The full Tyk middleware and policy stack applies to these MCP proxies, including rate limits, quotas, and per-tool access control, and a new dry-run mode lets you preview the expanded tool catalogue before saving a configuration.
+
+**New Goja JavaScript Engine and Multi-Bundle Plugin Support**
+
+JavaScript plugins can now run on a new, opt-in **Goja** engine alongside the existing **Otto** engine, with no breaking changes - Otto remains the default. Plugins on the new engine also gain support for post-auth and response hooks, reaching parity with Go and gRPC plugins. An API can now also reference multiple plugin bundles at once using a comma-separated `custom_middleware_bundle` list, letting you compose a shared bundle, for example one maintained by a security team, with a team-specific bundle on the same API.
+
+**Other Changes**
+
+This release also delivers bundling support for custom analytics plugins, bringing them in line with other plugin types for containerized and Kubernetes deployments.
+
+Notable fixes include: excessive log noise for JWT scope-to-policy mapping mismatches; a redundant, malformed log line produced on Gateway shutdown; invalid JSON in Tyk OAS request validation error responses; and a race condition that could leave a deleted session usable under heavy load.
+
+For a comprehensive list of changes, please refer to the detailed [changelog](#Changelog-v5.15.0) below.
+
+#### Changelog
+<a id="Changelog-v5.15.0" data-scroll-offset></a>
+
+##### Added
+
+<AccordionGroup>
+
+<Accordion title='Create an MCP proxy directly from a REST API'>
+{/* TT-17319, TT-17320, TT-17321, TT-17322, TT-17588 */}
+You can now create an MCP proxy directly from an existing Tyk-managed REST API, without writing a dedicated MCP server. The Gateway derives a tool catalogue automatically from the source API's OpenAPI definition: every valid, exposable operation is exposed as an MCP tool by default. You can optionally restrict the catalogue with an allow list, or override tool and parameter names and descriptions to make them clearer for AI agents. The full Tyk middleware and policy stack applies to these MCP proxies, including rate limits, quotas, and per-tool access control, in the same way as for existing MCP proxies. A new dry-run mode lets you preview the expanded tool catalogue for a proposed configuration before saving it.
+</Accordion>
+
+<Accordion title='Bundling support for analytics plugins'>
+{/* TT-6176 */}
+Custom analytics plugins can now be packaged and distributed inside a plugin bundle, alongside other custom middleware, instead of only being loadable from a separate file path. This brings analytics plugins in line with other plugin types for containerized and Kubernetes deployments.
+</Accordion>
+
+<Accordion title='New Goja JavaScript engine and multi-bundle support for plugins'>
+{/* TT-16948 */}
+JavaScript plugins can now run on a new, opt-in **Goja** engine alongside the existing Otto engine, with no breaking changes - Otto remains the default. Plugins on the new engine also gain support for post-auth and response hooks, reaching parity with Go and gRPC plugins. An API can now also reference multiple plugin bundles at once using a comma-separated `custom_middleware_bundle` list, letting you compose a shared bundle, for example one maintained by a security team, with a team-specific bundle on the same API.
+</Accordion>
+
+</AccordionGroup>
+
+
+##### Fixed
+
+<AccordionGroup>
+
+<Accordion title='Fixed excessive log noise for JWT scope-to-policy mapping mismatches'>
+{/* TT-5893 */}
+When using JWT authentication with scope-to-policy mapping, the Gateway previously logged an error for every unmatched scope in a token, even when another scope successfully matched a policy and the request was authorized. Unmatched scopes are now logged at `DEBUG` level, and consolidated into a single log entry, whenever at least one scope matches a policy. An error is only logged when none of the token's scopes match any policy.
+</Accordion>
+
+<Accordion title='Fixed a redundant, malformed log line produced on Gateway shutdown'>
+{/* TT-17316 */}
+Sending `SIGINT`, `SIGTERM`, or `SIGQUIT` to the Gateway previously produced an extra, unstructured log line, for example `2026/05/27 07:55:32 interrupt`, alongside the Gateway's own structured shutdown log entry. This could break JSON log parsers that stopped processing after the malformed line. The redundant line has been removed; only the Gateway's correctly formatted shutdown log entry remains.
+</Accordion>
+
+<Accordion title='Fixed invalid JSON in Tyk OAS request validation error responses'>
+{/* TT-14798 */}
+Error responses from the Tyk OAS request validation middleware could contain incorrectly escaped single quotes, producing invalid JSON under RFC 8259 whenever a validation message included an apostrophe. This could prevent automated systems from parsing Gateway error responses correctly. Error message escaping has been corrected so all JSON error responses are valid.
+</Accordion>
+
+<Accordion title='Fixed a race condition that could leave a deleted session usable'>
+{/* TT-16259 */}
+Under heavy load, a race condition between session updates and session deletion could prevent a session from being deleted, or leave it appearing deleted on the control plane while remaining usable on the data plane with its original authorization token. This has been fixed using atomic, existence-checked writes when saving sessions, ensuring deletions are immediately and consistently invalidated across the control and data planes.
+</Accordion>
+
+</AccordionGroup>
+
+
+
 ## 5.14 Release Notes 
 
 ### 5.14.0 Release Notes 


### PR DESCRIPTION
## What this is

An experimental, AI-assisted pass at drafting the Tyk Gateway 5.15.0 release notes. **This is a draft PR and is not intended to be merged as-is** - it's here for the team to review, comment on, and collaborate on. We may end up abandoning this approach entirely depending on how the review goes, so please treat it as a proposal, not a finished artifact.

## Scope

11 Jira tickets (project TT, component "Tyk Gateway"), each cross-checked against real merged GitHub PRs and validated against the actual code diff (not just the ticket description) before being drafted:

- TT-17319, TT-17320, TT-17321, TT-17322, TT-17588 - API-to-MCP proxy (create an MCP proxy from a REST API)
- TT-6176 - analytics plugin bundling
- TT-16948 - Goja JS engine + multi-bundle plugin support
- TT-5893, TT-17316, TT-14798, TT-16259 - fixes

Five other tickets that were candidates for this release were excluded because no merged PR could be found for them as of this draft (TT-15516, TT-9550, TT-16039, TT-17611, TT-17641) - three of these (TT-15516, TT-16039, TT-17611) have active open PRs and could land before code freeze, so it's worth re-checking those specifically before any final version of these notes is prepared.

## What we'd like feedback on

- Accuracy of the technical descriptions
- Whether the tone/style matches how release notes should read (this was calibrated against the existing gateway.mdx history and the repo's CLAUDE.md style guide, but a human pass is still valuable)
- Whether TT-16259 belongs under "Fixed" rather than "Security Fixes" (no CVE was found for it in Jira, and "Security Fixes" appears to be reserved for third-party CVE bundles in past releases - flagging this judgment call explicitly)
- Whether this whole workflow is worth continuing to invest in

🤖 Drafted with Claude Code