### PR TITLE
🤖 Auto-merge documentation from branches

### DIFF
--- a/api-management/metrics/metrics-pumps.mdx
+++ b/api-management/metrics/metrics-pumps.mdx
@@ -113,8 +113,23 @@ Each entry accepts:
 | `name` | - | Metric name. |
 | `description` | - | Metric description. |
 | `metric_type` | - | `counter` or `histogram`. Histograms always observe the `request_time` field. |
-| `labels` | - | Traffic log fields to expose as metric labels. Available values: `host`, `method`, `path`, `response_code`, `api_key`, `time_stamp`, `api_version`, `api_name`, `api_id`, `org_id`, `oauth_id`, `request_time`, `ip_address`, `alias`. |
+| `labels` | - | Traffic log fields to expose as metric labels. Available values: `host`, `method`, `path`, `response_code`, `api_key`, `time_stamp`, `api_version`, `api_name`, `api_id`, `org_id`, `oauth_id`, `request_time`, `ip_address`, `alias`, `mcp_method`, `mcp_primitive_type`, `mcp_primitive_name`, `mcp_error_code`. |
 | `buckets` | `[1, 2, 5, 7, 10, 15, 20, 25, 30, 40, 50, 60, 70, 80, 90, 100, 200, 300, 400, 500, 1000, 2000, 5000, 10000, 30000, 60000]` | Histogram bucket boundaries, in milliseconds. Histograms only. |
+| `mcp_only` | `false` | Restrict this metric to [MCP Gateway](/ai-management/mcp-gateway/overview) traffic. When `false`, the metric processes all traffic, and the `mcp_*` labels resolve to an empty string for non-MCP requests. |
+
+<Note>
+`mcp_method`, `mcp_primitive_type`, `mcp_primitive_name`, and `mcp_error_code` are only populated for MCP Gateway traffic. Use `mcp_only` to keep a metric exclusively for MCP records, for example to count MCP tool and prompt invocations separately from your REST API traffic:
+
+```json
+{
+  "name": "tyk_mcp_requests_total",
+  "description": "Total MCP requests per method and primitive",
+  "metric_type": "counter",
+  "labels": ["api_id", "mcp_method", "mcp_primitive_type", "mcp_primitive_name"],
+  "mcp_only": true
+}
+```
+</Note>
 
 ### Docker
 

--- a/nightly/api-management/metrics/metrics-pumps.mdx
+++ b/nightly/api-management/metrics/metrics-pumps.mdx
@@ -113,8 +113,23 @@ Each entry accepts:
 | `name` | - | Metric name. |
 | `description` | - | Metric description. |
 | `metric_type` | - | `counter` or `histogram`. Histograms always observe the `request_time` field. |
-| `labels` | - | Traffic log fields to expose as metric labels. Available values: `host`, `method`, `path`, `response_code`, `api_key`, `time_stamp`, `api_version`, `api_name`, `api_id`, `org_id`, `oauth_id`, `request_time`, `ip_address`, `alias`. |
+| `labels` | - | Traffic log fields to expose as metric labels. Available values: `host`, `method`, `path`, `response_code`, `api_key`, `time_stamp`, `api_version`, `api_name`, `api_id`, `org_id`, `oauth_id`, `request_time`, `ip_address`, `alias`, `mcp_method`, `mcp_primitive_type`, `mcp_primitive_name`, `mcp_error_code`. |
 | `buckets` | `[1, 2, 5, 7, 10, 15, 20, 25, 30, 40, 50, 60, 70, 80, 90, 100, 200, 300, 400, 500, 1000, 2000, 5000, 10000, 30000, 60000]` | Histogram bucket boundaries, in milliseconds. Histograms only. |
+| `mcp_only` | `false` | Restrict this metric to [MCP Gateway](/nightly/ai-management/mcp-gateway/overview) traffic. When `false`, the metric processes all traffic, and the `mcp_*` labels resolve to an empty string for non-MCP requests. |
+
+<Note>
+`mcp_method`, `mcp_primitive_type`, `mcp_primitive_name`, and `mcp_error_code` are only populated for MCP Gateway traffic. Use `mcp_only` to keep a metric exclusively for MCP records, for example to count MCP tool and prompt invocations separately from your REST API traffic:
+
+```json
+{
+  "name": "tyk_mcp_requests_total",
+  "description": "Total MCP requests per method and primitive",
+  "metric_type": "counter",
+  "labels": ["api_id", "mcp_method", "mcp_primitive_type", "mcp_primitive_name"],
+  "mcp_only": true
+}
+```
+</Note>
 
 ### Docker
 


### PR DESCRIPTION
### **User description**
## 📚 Documentation Merge Summary

This PR contains automatically merged documentation from multiple branches.

**Triggered by:**
- **Branch:** release-5.14
- **Commit:** b5ca321362324dde450bdfd0b9a7809200bbb91f
- **PR:** #2699 - Merging to release-5.14: [TT-16809] docs: Add MCP Prometheus metrics and hybrid pump aggregation configuration (#1848) (cherry-pick of #1848)

**Deployment Details:**
- **Generated from:** `branches-config.json`  
- **Run ID:** 31096209265
- **Subfolder:** `(root deployment)`
- **Timestamp:** $(date)

### Changes Include:
- ✅ Merged documentation from multiple branches
- ✅ Generated unified `docs.json` configuration
- ✅ Updated assets and content structure
- ✅ Cleaned up outdated version folders

---

🚦 **This PR will be processed by merge queue to ensure proper validation and ordering.**

Previous deployment PRs have been automatically closed to prevent conflicts.

[TT-16809]: https://tyktech.atlassian.net/browse/TT-16809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Document MCP-specific Prometheus metric labels

- Explain `mcp_only` traffic filtering behavior

- Add MCP request counter configuration example

- Synchronize root and nightly documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  config["Custom Prometheus metric"] 
  labels["MCP-specific labels"] 
  filter["MCP-only traffic filter"] 
  counter["MCP request counter"] 
  config -- "supports" --> labels
  config -- "configures" --> filter
  filter -- "produces" --> counter
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>metrics-pumps.mdx</strong><dd><code>Document MCP Prometheus metric configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api-management/metrics/metrics-pumps.mdx

<ul><li>Add four MCP-specific metric labels<br> <li> Document <code>mcp_only</code> filtering and defaults<br> <li> Provide an MCP request counter example</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/2700/files#diff-516bc35e10251ed951efcca935b0f18ddf22c80185cfb6a0f7519dc8f0668b79">+16/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>metrics-pumps.mdx</strong><dd><code>Update nightly MCP metrics documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nightly/api-management/metrics/metrics-pumps.mdx

<ul><li>Add MCP labels to nightly metrics reference<br> <li> Explain non-MCP label fallback behavior<br> <li> Include an MCP-only counter example</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/2700/files#diff-1b86a95612447b5c0a0c48644653f559b3bedce51c8b5e6f7b13fa7f5563cf7c">+16/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

