### PR TITLE
docs: add .mintignore to exclude internal, non-doc markdown files

### DIFF
--- a/.mintignore
+++ b/.mintignore
@@ -1,0 +1,6 @@
+# Repository/tooling files that are not published documentation content.
+# Excluding them keeps them out of the build, search index, and AI assistant.
+CLAUDE.md
+README.md
+scripts/README.md
+scripts/eod-report-generator/readme.md


### PR DESCRIPTION
### **User description**
## What
Adds a `.mintignore` file at repo root to exclude repository/tooling Markdown files that are not published documentation content:

- `CLAUDE.md`
- `README.md`
- `scripts/README.md`
- `scripts/eod-report-generator/readme.md`

## Why
Mintlify's AI assistant confirmed (screenshot in the linked task) that any Markdown file in the repo gets built, indexed for search, and made accessible to visitors unless it's excluded via `.mintignore` — regardless of whether it's referenced in `docs.json` navigation. These four files are internal (AI agent instructions, repo/script READMEs) and were previously unprotected, so they could surface in search results, the AI assistant, or as directly-accessible unlinked pages on the live docs site.

## Checked for other candidates
Searched the full repo tree for every plain `.md` file (docs content uses `.mdx`) — these four were the only matches outside the documented content directories, so no other files need excluding at this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Documentation


___

### **Description**
- Add root `.mintignore` file

- Exclude internal Markdown files

- Prevent docs build/search exposure


___

### Diagram Walkthrough


```mermaid
flowchart LR
  a["Internal markdown files"]
  b[".mintignore"]
  c["Excluded from docs pipeline"]
  a -- "listed in" --> b
  b -- "prevents inclusion in" --> c
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.mintignore</strong><dd><code>Exclude internal markdown from docs publishing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.mintignore

<ul><li>Add a root <code>.mintignore</code> file for Mintlify.<br> <li> Exclude repository and tooling Markdown files from publication.<br> <li> Keep internal files out of docs build, search, and AI assistant <br>indexing.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/2721/files#diff-672ade97e28c6e61c037ab0adad56c83cf6c4fa8f32213b1c95a51c0c9637dfe">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

