### PR TITLE
Consolidate all reference material into a Reference tab

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -450,7 +450,6 @@
                       "tyk-stack/tyk-operator/publish-an-api",
                       "product-stack/tyk-operator/tyk-ingress-controller",
                       "product-stack/tyk-operator/mcp-proxy",
-                      "product-stack/tyk-operator/crd-reference",
                       "product-stack/tyk-operator/advanced-configurations/graphql-federation",
                       "product-stack/tyk-operator/advanced-configurations/custom-plugins",
                       "product-stack/tyk-operator/advanced-configurations/internal-looping",
@@ -485,64 +484,8 @@
             ]
           },
           {
-            "group": "Reference",
-            "pages": [
-              {
-                "group": "Environment Variables and Configs",
-                "pages": [
-                  "tyk-oss-gateway/configuration",
-                  "tyk-pump/tyk-pump-configuration/tyk-pump-environment-variables",
-                  "tyk-multi-data-centre/mdcb-configuration-options",
-                  "tyk-configuration-reference/tyk-identity-broker-configuration"
-                ]
-              },
-              {
-                "group": "API Documentation",
-                "pages": [
-                  "tyk-apis",
-                  {
-                    "group": "Gateway API",
-                    "pages": [
-                      "tyk-gateway-api"
-                    ],
-                    "openapi": "swagger/gateway-swagger.yml"
-                  },
-                  {
-                    "group": "MDCB API",
-                    "pages": [
-                      "tyk-mdcb-api"
-                    ],
-                    "openapi": "swagger/mdcb-swagger.yml"
-                  },
-                  {
-                    "group": "Identity Broker API",
-                    "pages": [
-                      "tyk-identity-broker/tib-rest-api"
-                    ],
-                    "openapi": "swagger/identity-broker-swagger.yml"
-                  }
-                ]
-              }
-            ]
-          },
-          {
             "group": "Developer Support",
             "pages": [
-              {
-                "group": "Release Notes",
-                "pages": [
-                  "developer-support/release-notes/overview",
-                  "developer-support/release-notes/gateway",
-                  "developer-support/release-notes/dashboard",
-                  "developer-support/release-notes/pump",
-                  "developer-support/release-notes/sync",
-                  "developer-support/release-notes/mdcb",
-                  "developer-support/release-notes/operator",
-                  "developer-support/release-notes/helm-chart",
-                  "developer-support/release-notes/tib",
-                  "developer-support/release-notes/archived"
-                ]
-              },
               "developer-support/upgrading",
               "api-management/troubleshooting-debugging",
               "developer-support/faq"
@@ -626,31 +569,6 @@
               "api-management/enable-audit-logs-dashboard",
               "api-management/multiple-environments",
               "api-management/endpoint-designer"
-            ]
-          },
-          {
-            "group": "Reference",
-            "pages": [
-              "tyk-dashboard/configuration",
-              {
-                "group": "API Documentation",
-                "pages": [
-                  {
-                    "group": "Dashboard",
-                    "pages": [
-                      "tyk-dashboard-api"
-                    ],
-                    "openapi": "swagger/dashboard-swagger.yml"
-                  },
-                  {
-                    "group": "Dashboard Admin",
-                    "pages": [
-                      "dashboard-admin-api"
-                    ],
-                    "openapi": "swagger/dashboard-admin-swagger.yml"
-                  }
-                ]
-              }
             ]
           }
         ]
@@ -760,21 +678,6 @@
                   "tyk-developer-portal/enable-audit-logs-portal"
                 ]
               }
-            ]
-          },
-          {
-            "group": "Reference",
-            "pages": [
-              "product-stack/tyk-enterprise-developer-portal/deploy/configuration",
-              {
-                "group": "Developer Portal API",
-                "pages": [
-                  "product-stack/tyk-enterprise-developer-portal/api-documentation/tyk-edp-api"
-                ],
-                "openapi": "swagger/enterprise-developer-portal-swagger.yaml"
-              },
-              "product-stack/tyk-enterprise-developer-portal/api-documentation/list-of-endpoints/portal-api-list-of-endpoints",
-              "developer-support/release-notes/portal"
             ]
           },
           {
@@ -1051,26 +954,6 @@
                   },
                   "ai-management/ai-studio/manage-edge-gateway"
                 ]
-              },
-              {
-                "group": "Reference",
-                "pages": [
-                  {
-                    "group": "Environment Variables and Configs",
-                    "pages": [
-                      "ai-management/ai-studio/ai-studio-env",
-                      "ai-management/ai-studio/edge-gateway-env"
-                    ]
-                  },
-                  {
-                    "group": "AI Studio API",
-                    "pages": [
-                      "ai-management/ai-studio/ai-studio-swagger"
-                    ],
-                    "openapi": "swagger/ai-studio-swagger.yml"
-                  },
-                  "developer-support/release-notes/ai-studio"
-                ]
               }
             ]
           },
@@ -1091,7 +974,8 @@
           {
             "group": "Overview",
             "pages": [
-              "tyk-cloud"
+              "tyk-cloud",
+              "tyk-cloud/troubleshooting-support"
             ]
           },
           {
@@ -1125,12 +1009,98 @@
               "tyk-cloud/telemetry",
               "tyk-cloud/teams-users/single-sign-on"
             ]
+          }
+        ]
+      },
+      {
+        "tab": "Reference",
+        "groups": [
+          {
+            "group": "Release Notes",
+            "pages": [
+              "developer-support/release-notes/overview",
+              "developer-support/release-notes/gateway",
+              "developer-support/release-notes/dashboard",
+              "developer-support/release-notes/pump",
+              "developer-support/release-notes/mdcb",
+              "developer-support/release-notes/operator",
+              "developer-support/release-notes/sync",
+              "developer-support/release-notes/helm-chart",
+              "developer-support/release-notes/tib",
+              "developer-support/release-notes/portal",
+              "developer-support/release-notes/ai-studio",
+              "developer-support/release-notes/cloud",
+              "developer-support/release-notes/archived"
+            ]
           },
           {
-            "group": "Developer Support",
+            "group": "Configuration Reference",
             "pages": [
-              "developer-support/release-notes/cloud",
-              "tyk-cloud/troubleshooting-support"
+              "tyk-oss-gateway/configuration",
+              "tyk-dashboard/configuration",
+              "tyk-pump/tyk-pump-configuration/tyk-pump-environment-variables",
+              "tyk-multi-data-centre/mdcb-configuration-options",
+              "tyk-configuration-reference/tyk-identity-broker-configuration",
+              "product-stack/tyk-enterprise-developer-portal/deploy/configuration",
+              "ai-management/ai-studio/ai-studio-env",
+              "ai-management/ai-studio/edge-gateway-env",
+              "product-stack/tyk-operator/crd-reference"
+            ]
+          },
+          {
+            "group": "API Reference",
+            "pages": [
+              "tyk-apis",
+              {
+                "group": "Gateway API",
+                "pages": [
+                  "tyk-gateway-api"
+                ],
+                "openapi": "swagger/gateway-swagger.yml"
+              },
+              {
+                "group": "Dashboard API",
+                "pages": [
+                  "tyk-dashboard-api"
+                ],
+                "openapi": "swagger/dashboard-swagger.yml"
+              },
+              {
+                "group": "Dashboard Admin API",
+                "pages": [
+                  "dashboard-admin-api"
+                ],
+                "openapi": "swagger/dashboard-admin-swagger.yml"
+              },
+              {
+                "group": "MDCB API",
+                "pages": [
+                  "tyk-mdcb-api"
+                ],
+                "openapi": "swagger/mdcb-swagger.yml"
+              },
+              {
+                "group": "Identity Broker API",
+                "pages": [
+                  "tyk-identity-broker/tib-rest-api"
+                ],
+                "openapi": "swagger/identity-broker-swagger.yml"
+              },
+              {
+                "group": "Developer Portal API",
+                "pages": [
+                  "product-stack/tyk-enterprise-developer-portal/api-documentation/tyk-edp-api",
+                  "product-stack/tyk-enterprise-developer-portal/api-documentation/list-of-endpoints/portal-api-list-of-endpoints"
+                ],
+                "openapi": "swagger/enterprise-developer-portal-swagger.yaml"
+              },
+              {
+                "group": "AI Studio API",
+                "pages": [
+                  "ai-management/ai-studio/ai-studio-swagger"
+                ],
+                "openapi": "swagger/ai-studio-swagger.yml"
+              }
             ]
           }
         ]


### PR DESCRIPTION
### **User description**
## What

Consolidates all reference material into a single **Reference** tab, grouped by component.

This is step 8 of the wider IA proposal. It is shippable on its own and does not depend on any other phase.

## Why

Reference material sits on the **component** axis, not the task axis. Spreading it across task-based tabs means every change to a tab boundary reopens the question of where it belongs.

That is not hypothetical. It came up in `#team-ext-documentation` most recently as *"the Dashboard environment variables and API config moved to Platform Management, however the Release notes still remain in API Management, will the release notes be transferred as well?"* Answering that per page is endless. One home ends the whole class of question.

Today the same document types sit in **5 `Reference` groups across 4 tabs**:

| Document type | Current homes |
|---|---|
| Release notes | 4: API Management > Developer Support, API Publishing > Reference, AI Management > AI Studio > Reference, Cloud > Developer Support |
| Configuration reference | 4 |
| API reference | 5 |

Supporting evidence from 90 days of Mintlify analytics:

- `developer-support/release-notes/gateway` is the **3rd most-read page on the site** (9,588 views), and `release-notes/portal` takes another 4,145. Readers compare components side by side at upgrade time, so splitting release notes by tab works against the job they are doing.
- The OpenAPI-generated endpoint pages behind these specs take **383,455 views across all versions** from 5,432 generated pages. It is the largest content class in the docs and currently the most scattered.

## What changed

```
Reference (31 pages)
├── Release Notes (13)              all 4 previous homes merged
├── Configuration Reference (9)     every env-var/config page + Operator CRD reference
└── API Reference (9)               tyk-apis index + 7 OpenAPI-backed groups
    ├── Gateway API                 swagger/gateway-swagger.yml
    ├── Dashboard API               swagger/dashboard-swagger.yml
    ├── Dashboard Admin API         swagger/dashboard-admin-swagger.yml
    ├── MDCB API                    swagger/mdcb-swagger.yml
    ├── Identity Broker API         swagger/identity-broker-swagger.yml
    ├── Developer Portal API        swagger/enterprise-developer-portal-swagger.yaml
    └── AI Studio API               swagger/ai-studio-swagger.yml
```

**Navigation-only.** No files moved, no URLs changed. No redirects needed, no SEO impact, and reverting is a single commit.

### Side effects, both intentional

- `Cloud > Developer Support` would have been left with a single page, so `tyk-cloud/troubleshooting-support` moves to `Cloud > Overview`. That also clears a pre-existing single-child group.
- Emptied groups are removed: the `Reference` groups in API Management, Platform Management, API Publishing and AI Management > AI Studio, along with their `Environment Variables and Configs` and `API Documentation` subgroups.

## Verification

- **438 navigation pages before and after.** None lost, none duplicated (checked programmatically against `main`).
- **All 7 OpenAPI specs preserved**, byte-identical paths. The spec-backed groups were re-parented as whole objects rather than rebuilt.
- **No new single-child groups.** The count drops from 8 to 7.
- `scripts/validate_mintlify_docs.py` passes on `--links-only --check-anchors --check-multiple-h1 --validate-redirects --check-insecure-links`.

## Review notes

- Please sanity-check the **tab position** (currently last, after Cloud) and the **group order** inside Release Notes, which follows component maturity rather than alphabetical.
- `Dashboard` and `Dashboard Admin` groups are renamed to `Dashboard API` and `Dashboard Admin API` for consistency with the other five.
- This does **not** move `developer-support/upgrading`, `troubleshooting-debugging` or `faq`. They stay in `API Management > Developer Support`, which keeps 3 pages. They are not reference material.


___

### **PR Type**
Documentation, Enhancement


___

### **Description**
- Add unified `Reference` documentation tab

- Group release notes by component

- Centralize config and API references

- Move Cloud support page to `Overview`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  api["API Management references"]
  platform["Platform references"]
  publishing["API Publishing references"]
  ai["AI Studio references"]
  cloudrn["Cloud and product release notes"]
  ref["Unified Reference tab"]
  support["Cloud troubleshooting page"]
  overview["Cloud Overview group"]
  api -- "moved into" --> ref
  platform -- "moved into" --> ref
  publishing -- "moved into" --> ref
  ai -- "moved into" --> ref
  cloudrn -- "collected under" --> ref
  support -- "relocated to" --> overview
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docs.json</strong><dd><code>Reorganize docs navigation into a unified reference hub</code>&nbsp; &nbsp; </dd></summary>
<hr>

docs.json

<ul><li>Remove scattered <code>Reference</code> groups from product tabs<br> <li> Add top-level <code>Reference</code> tab sections<br> <li> Centralize release notes, configs, and API docs<br> <li> Move <code>tyk-cloud/troubleshooting-support</code> to <code>Overview</code></ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/2723/files#diff-b7b4169fa5b2e02aa17d40553a73c5d9520086753c501eeb926c63b162bb6d9e">+91/-121</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

