### PR TITLE
[TT-17631] Updated for leading slash requirement and self healing

### DIFF
--- a/api-management/gateway-config-tyk-classic.mdx
+++ b/api-management/gateway-config-tyk-classic.mdx
@@ -43,6 +43,10 @@ Key things to note when configuring versioning for a Tyk Classic API:
 - configuration for the different versions is contained within the [version_data](/api-management/gateway-config-tyk-classic#version-specific-configuration) object
   - this also contains some common configuration (`not_versioned` and `default_version`)
 
+<Note>
+Tyk Classic versioning expects every version to share the same `listen_path`, with the version identifier appended as a URL fragment, header, or query parameter (`definition.location`). If your versions instead live at genuinely different base paths (for example `/v1/function/` and `/v2/function/` as distinct listen paths), model them as separate, non-versioned API definitions rather than using `version_data`.
+</Note>
+
 When you first create an API, it will not be "versioned" (i.e. `not_versioned` will be set to `true`) and there will be a single version with the name `Default` created in the `version_data` section.
 
 ### Common versioning configuration
@@ -539,15 +543,17 @@ Set to `true` to preserve the host header. If `proxy.preserve_host_header` is se
 </ParamField>
 
 <ParamField path="proxy.listen_path">
-The path to listen on, e.g. `/api` or `/`. Any requests coming into the host, on the port that Tyk is configured to run on, that go to this path will have the rules defined in the API Definition applied. Versioning assumes that different versions of an API will live on the same URL structure. If you are using URL-based versioning (e.g. `/v1/function`, `/v2/function/`) then it is recommended to set up a separate non-versioned definition for each version as they are essentially separate APIs.
-    
-Proxied requests are literal, no re-writing takes place, for example, if a request is sent to the listen path of: `/listen-path/widgets/new` and the URL to proxy to is `http://your.api.com/api/` then the *actual* request that will land at your service will be: `http://your.api.com/api/listen-path/widgets/new`.
-    
-This behavior can be circumvented so that the `listen_path` is stripped from the outgoing request. See the section on `strip_listen_path` below.
+The path to listen on, e.g. `/api` or `/`. Any request to this path will have the rules defined in the API Definition applied.
+
+This must start with a leading slash `/`. See [Request Matching](/getting-started/key-concepts/url-matching#api-level-matching-the-listen-path) for detail.
+
+See [Tyk Classic API versioning](#tyk-classic-api-versioning) for guidance on structuring API definitions when versions live at different URL paths.
+
+By default, the listen path is kept in the forwarded request path. See [`strip_listen_path`](#param-proxy-strip-listen-path) to remove it, and [Request Forwarding](/planning-for-production/ensure-high-availability/load-balancing) for how the forwarded URL is constructed.
 </ParamField>
 
 <ParamField path="proxy.strip_listen_path">
-By setting this to `true`, Tyk will attempt to replace the `listen-path` in the outgoing request with an empty string. This means that in the above scenario where `/listen-path/widgets/new` and the URL to proxy to is `http://your.api.com/api/` becomes `http://your.api.com/api/listen-path/widgets/new`, actually changes the outgoing request to be: `http://your.api.com/api/widgets/new`.
+Set to `true` to remove the listen path from the forwarded request path instead of keeping it. See [Request Forwarding](/planning-for-production/ensure-high-availability/load-balancing) for an example.
 </ParamField>
 
 <ParamField path="proxy.target_url">

--- a/getting-started/key-concepts/url-matching.mdx
+++ b/getting-started/key-concepts/url-matching.mdx
@@ -27,13 +27,19 @@ With reference to [RFC 3986](https://www.ietf.org/rfc/rfc3986.txt), `protocol` i
 
 If no API listen path matches the request, Tyk Gateway returns `HTTP 404 Not Found`.
 
-<Note>
-Tyk Gateway acts as a reverse proxy. When forwarding a request upstream, it replaces its own hostname with the upstream [target URL](/api-management/gateway-config-tyk-oas#upstream) configured in the API definition. The [strip listen path](/api-management/gateway-config-tyk-oas#listenpath) option removes the listen path from the upstream request, allowing a cleaner public API facade over a legacy upstream service.
-</Note>
-
 ## API-Level Matching: The Listen Path
 
 Tyk Gateway treats the listen path configured in an API definition as a regular expression, enabling advanced users to perform complex listen path matching.
+
+<Warning>
+The listen path must start with a leading slash `/`, for example `/my-api`.
+
+Tyk Gateway's router requires this to register the API's routes. Without it, when Tyk Gateway loads or reloads the API definition it logs an error such as `Invalid listen path when creating router error="mux: path must start with a slash..."` and fails to load the API. Requests to it then return `HTTP 404 Not Found`.
+
+From Tyk Gateway 5.15.0 and 5.13.2 (LTS), the Gateway automatically adds a missing leading slash when the API definition loads. This exists as a safety net for APIs that already lack one, for example after an upgrade; it's not a reason to omit the leading slash when constructing a new or updated `listen_path`.
+
+Tyk Dashboard also validates this, from the same versions, and rejects the save if you create, edit, or import an API with a `listen_path` missing the leading slash. This protects deployments where Dashboard is paired with an older Gateway that doesn't yet self-heal, such as distributed setups upgraded on different schedules.
+</Warning>
 
 ### Path Ordering
 


### PR DESCRIPTION
### **User description**
Added documentation for listenPath leading slash and improvements in 5.13.2/5.15.0


___

### **PR Type**
Documentation


___

### **Description**
- Clarify `listen_path` leading slash requirement

- Document Gateway self-healing behavior

- Explain Dashboard validation compatibility

- Refine Classic versioning and forwarding guidance


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["API definition listen_path"] 
  B["Leading slash required"]
  C["Gateway loads routes"]
  D["Missing slash safety net in 5.15.0/5.13.2"]
  E["Dashboard rejects invalid saves"]
  F["Separate APIs for path-based versions"]
  A -- "must satisfy" --> B
  B -- "allows" --> C
  A -- "if missing" --> D
  A -- "validated by" --> E
  A -- "versioning guidance" --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gateway-config-tyk-classic.mdx</strong><dd><code>Clarify Classic listen path and versioning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api-management/gateway-config-tyk-classic.mdx

<ul><li>Add note on Classic versioning assumptions<br> <li> Advise separate APIs for path-based versions<br> <li> Require leading slash in <code>proxy.listen_path</code><br> <li> Simplify listen path forwarding explanations</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/2725/files#diff-093270ae26e4d6e343aeeffdacc6f853e1a445f12614fb4d8958beb9c5382919">+12/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>url-matching.mdx</strong><dd><code>Document listen path validation and self-healing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

getting-started/key-concepts/url-matching.mdx

<ul><li>Add warning for leading slash requirement<br> <li> Document router error and 404 outcome<br> <li> Describe Gateway auto-correction in supported versions<br> <li> Explain Dashboard validation across mixed upgrades</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk-docs/pull/2725/files#diff-1adafe1affd50f750d183e157591b3a84edbfa474b52b71ce55b5c1ec1fafbed">+10/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

